### PR TITLE
HYDRA-688 : Fix scene browser test

### DIFF
--- a/lib/adskHydraSceneBrowser/test/adskHydraSceneBrowserTestFixture.cpp
+++ b/lib/adskHydraSceneBrowser/test/adskHydraSceneBrowserTestFixture.cpp
@@ -131,7 +131,7 @@ void AdskHydraSceneBrowserTestFixture::ComparePrimHierarchy(
         if (compareDataSourceHierarchy) {
             _primHierarchyWidget->setCurrentItem(primQtItem);
             CompareDataSourceHierarchy(
-                { primPath.GetElementToken(), prim.dataSource }, compareDataSourceValues);
+                { primPath.GetNameToken(), prim.dataSource }, compareDataSourceValues);
         }
 
         // Prepare next step (need to pop the stack before pushing the next elements)


### PR DESCRIPTION
Fixed a discrepancy where the name in the Qt scene browser would show up as "/" due to using `GetNameToken()`, but the test was using `GetElementToken()`, which returned "".