### PR TITLE
HYDRA-456 : Add test for USD stage layer muting

### DIFF
--- a/test/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
+++ b/test/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
@@ -21,6 +21,7 @@ set(TEST_SCRIPT_FILES
     cpp/testSelectionSceneIndex.py
     cpp/testWireframeSelectionHighlightSceneIndex.py
     cpp/testFlowViewportAPIViewportInformation.py
+    cpp/testUsdStageLayerMuting.py
 )
 
 # Test use of mesh adapter code for mesh support, using environment variable.

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/CMakeLists.txt
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(${TARGET_NAME}
         testWireframeSelectionHighlightSceneIndex.cpp
         testFvpViewportInformationMultipleViewports.cpp
         testFvpViewportInformationRendererSwitching.cpp
+        testUsdStageLayerMuting.cpp
 )
 
 # -----------------------------------------------------------------------------

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testUsdStageLayerMuting.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testUsdStageLayerMuting.cpp
@@ -1,0 +1,78 @@
+// Copyright 2023 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "testUtils.h"
+
+#include <pxr/base/gf/vec3d.h>
+
+#include <gtest/gtest.h>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+namespace {
+
+constexpr float kUnmutedExtent = 4.0f;
+
+FindPrimPredicate findCubePredicate = PrimNamePredicate("USDCube");
+
+HdDataSourceLocator extentMinLocator = HdDataSourceLocator(TfToken("extent"), TfToken("min"));
+HdDataSourceLocator extentMaxLocator = HdDataSourceLocator(TfToken("extent"), TfToken("max"));
+
+} // namespace
+
+TEST(UsdStageLayerMuting, testSubLayerUnmuted)
+{
+    // Get the terminal scene index
+    const auto& sceneIndices = GetTerminalSceneIndices();
+    ASSERT_GT(sceneIndices.size(), 0u);
+    SceneIndexInspector inspector(sceneIndices.front());
+
+    // Find the cube prim
+    PrimEntriesVector cubePrims = inspector.FindPrims(findCubePredicate);
+    ASSERT_EQ(cubePrims.size(), 1u);
+    HdSceneIndexPrim cubePrim = cubePrims.front().prim;
+
+    // Retrieve the extent/min and extent/max data sources
+    auto extentMinDataSource = HdTypedSampledDataSource<GfVec3d>::Cast(
+        HdContainerDataSource::Get(cubePrim.dataSource, extentMinLocator));
+    ASSERT_TRUE(extentMinDataSource);
+    auto extentMaxDataSource = HdTypedSampledDataSource<GfVec3d>::Cast(
+        HdContainerDataSource::Get(cubePrim.dataSource, extentMaxLocator));
+    ASSERT_TRUE(extentMaxDataSource);
+
+    // Ensure the extents have the correct values
+    EXPECT_TRUE(GfIsClose(
+        extentMinDataSource->GetTypedValue(0), -GfVec3d(kUnmutedExtent), DEFAULT_TOLERANCE));
+    EXPECT_TRUE(GfIsClose(
+        extentMaxDataSource->GetTypedValue(0), GfVec3d(kUnmutedExtent), DEFAULT_TOLERANCE));
+}
+
+TEST(UsdStageLayerMuting, testSubLayerMuted)
+{
+    // Get the terminal scene index
+    const auto& sceneIndices = GetTerminalSceneIndices();
+    ASSERT_GT(sceneIndices.size(), 0u);
+    SceneIndexInspector inspector(sceneIndices.front());
+
+    // Find the cube prim
+    PrimEntriesVector cubePrims = inspector.FindPrims(findCubePredicate);
+    ASSERT_EQ(cubePrims.size(), 1u);
+    HdSceneIndexPrim cubePrim = cubePrims.front().prim;
+
+    // Ensure there is no "extent" data source with the sublayer muted,
+    // since the root layer did not define any special extents.
+    auto extentDataSource = cubePrim.dataSource->Get(TfToken("extent"));
+    EXPECT_FALSE(extentDataSource);
+}

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testUsdStageLayerMuting.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testUsdStageLayerMuting.py
@@ -1,0 +1,73 @@
+# Copyright 2023 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import maya.cmds as cmds
+
+import fixturesUtils
+import mtohUtils
+import unittest
+
+from testUtils import PluginLoaded
+
+class TestUsdStageLayerMuting(mtohUtils.MayaHydraBaseTestCase):
+    # MayaHydraBaseTestCase.setUpClass requirement.
+    _file = __file__
+
+    CUBE_PRIM_PATH = "/USDCube"
+    SUB_LAYER_CUBE_SIZE = 8.0
+
+    def setSubLayerMuted(self, isMuted: bool):
+        import maya.cmds as cmds
+        cmds.mayaUsdLayerEditor(self.subLayer.identifier, edit=True, muteLayer=(isMuted, self.usdProxyShapeUfePathString))
+
+    def setupUsdStage(self):
+        import maya.cmds as cmds
+        import mayaUsd
+        import mayaUsd_createStageWithNewLayer
+        from pxr import UsdGeom, Sdf
+
+        self.setHdStormRenderer()
+        cmds.refresh()
+
+        # Create a USD stage
+        self.usdProxyShapeUfePathString = mayaUsd_createStageWithNewLayer.createStageWithNewLayer()
+        stage = mayaUsd.lib.GetPrim(self.usdProxyShapeUfePathString).GetStage()
+
+        # Define a cube prim in the stage (implicit surface)
+        UsdGeom.Cube.Define(stage, self.CUBE_PRIM_PATH)
+
+        # Add a sublayer to the stage
+        rootLayer = stage.GetRootLayer()
+        subLayerId = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="testSubLayer")[0]
+        self.subLayer = Sdf.Layer.Find(subLayerId)
+
+        # Author an opinion on the sublayer
+        stage.SetEditTarget(self.subLayer)
+        cubePrim = stage.GetPrimAtPath(self.CUBE_PRIM_PATH)
+        cubePrim.GetAttribute('size').Set(self.SUB_LAYER_CUBE_SIZE)
+
+        cmds.refresh()
+
+    @unittest.skipUnless(mtohUtils.checkForMayaUsdPlugin(), "Requires Maya USD Plugin.")
+    def test_UsdStageLayerMuting(self):
+        self.setupUsdStage()
+        with PluginLoaded('mayaHydraCppTests'):
+            cmds.mayaHydraCppTest(f="UsdStageLayerMuting.testSubLayerUnmuted")
+            self.setSubLayerMuted(True)
+            cmds.mayaHydraCppTest(f="UsdStageLayerMuting.testSubLayerMuted")
+            self.setSubLayerMuted(False)
+            cmds.mayaHydraCppTest(f="UsdStageLayerMuting.testSubLayerUnmuted")
+
+if __name__ == '__main__':
+    fixturesUtils.runTests(globals())

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testUsdStageLayerMuting.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testUsdStageLayerMuting.py
@@ -28,11 +28,9 @@ class TestUsdStageLayerMuting(mtohUtils.MayaHydraBaseTestCase):
     SUB_LAYER_CUBE_SIZE = 8.0
 
     def setSubLayerMuted(self, isMuted: bool):
-        import maya.cmds as cmds
         cmds.mayaUsdLayerEditor(self.subLayer.identifier, edit=True, muteLayer=(isMuted, self.usdProxyShapeUfePathString))
 
     def setupUsdStage(self):
-        import maya.cmds as cmds
         import mayaUsd
         import mayaUsd_createStageWithNewLayer
         from pxr import UsdGeom, Sdf

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testUtils.h
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testUtils.h
@@ -150,14 +150,15 @@ public:
     PrimNamePredicate(const std::string& primName) : _primName(primName) {}
 
     /**
-     * @brief Predicate to match a prim name.
+     * @brief Predicate to match a prim name. This class is to be used as a FindPrimPredicate.
      *
-     * @param[in] sceneIndex The scene index in which the prim path to test is contained.
+     * @param[in] _ Unused scene index parameter. Is only present to conform to the 
+     * FindPrimPredicate signature.
      * @param[in] primPath The prim path to test.
      *
      * @return True if the argument prim path's name matches the predicate's prim name, false otherwise.
      */
-    bool operator()(const HdSceneIndexBasePtr& sceneIndex, const SdfPath& primPath) {
+    bool operator()(const HdSceneIndexBasePtr& _, const SdfPath& primPath) {
         return primPath.GetName() == _primName;
     }
 

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testUtils.h
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testUtils.h
@@ -144,6 +144,27 @@ private:
     HdSceneIndexBasePtr _sceneIndex;
 };
 
+class PrimNamePredicate
+{
+public:
+    PrimNamePredicate(const std::string& primName) : _primName(primName) {}
+
+    /**
+     * @brief Predicate to match a prim name.
+     *
+     * @param[in] sceneIndex The scene index in which the prim path to test is contained.
+     * @param[in] primPath The prim path to test.
+     *
+     * @return True if the argument prim path's name matches the predicate's prim name, false otherwise.
+     */
+    bool operator()(const HdSceneIndexBasePtr& sceneIndex, const SdfPath& primPath) {
+        return primPath.GetName() == _primName;
+    }
+
+private:
+    const std::string _primName;
+};
+
 class SceneIndexDisplayNamePred {
     const std::string _name;
 public:


### PR DESCRIPTION
This PR adds a test for HYDRA-456/HYDRA-436 where muting a USD stage layer would not be reflected in the scene index hierarchy.