### PR TITLE
HYDRA-682 : Fix mesh adapter transform not updating

### DIFF
--- a/lib/mayaHydra/hydraExtensions/adapters/dagAdapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/dagAdapter.cpp
@@ -82,8 +82,8 @@ void _TransformNodeDirty(MObject& node, MPlug& plug, void* clientData)
         // that dirty as well...
         if (adapter->IsVisible(false)) {
             // Transform can change while dag path is hidden.
-            adapter->MarkDirty(HdChangeTracker::DirtyVisibility | HdChangeTracker::DirtyTransform);
             adapter->InvalidateTransform();
+            adapter->MarkDirty(HdChangeTracker::DirtyVisibility | HdChangeTracker::DirtyTransform);
         } else {
             adapter->MarkDirty(HdChangeTracker::DirtyVisibility);
         }
@@ -91,8 +91,8 @@ void _TransformNodeDirty(MObject& node, MPlug& plug, void* clientData)
         // DON'T update visibility from within this callback, since the change
         // has't propagated yet
     } else if (adapter->IsVisible(false)) {
-        adapter->MarkDirty(HdChangeTracker::DirtyTransform);
         adapter->InvalidateTransform();
+        adapter->MarkDirty(HdChangeTracker::DirtyTransform);
     }
 }
 
@@ -210,9 +210,9 @@ void MayaHydraDagAdapter::CreateCallbacks()
 void MayaHydraDagAdapter::MarkDirty(HdDirtyBits dirtyBits)
 {
     if (dirtyBits != 0) {
-        GetSceneProducer()->GetRenderIndex().GetChangeTracker().MarkRprimDirty(GetID(), dirtyBits);
+        GetSceneProducer()->MarkRprimDirty(GetID(), dirtyBits);
         if (IsInstanced()) {
-            GetSceneProducer()->GetRenderIndex().GetChangeTracker().MarkInstancerDirty(GetInstancerID(), dirtyBits);
+            GetSceneProducer()->MarkInstancerDirty(GetInstancerID(), dirtyBits);
         }
         if (dirtyBits & HdChangeTracker::DirtyVisibility) {
             _visibilityDirty = true;

--- a/lib/mayaHydra/hydraExtensions/mayaHydraSceneProducer.cpp
+++ b/lib/mayaHydra/hydraExtensions/mayaHydraSceneProducer.cpp
@@ -315,11 +315,23 @@ void MayaHydraSceneProducer::MarkRprimDirty(const SdfPath& id, HdDirtyBits dirty
 {
     if (enableMayaNativeSceneIndex())
     {
-        _sceneIndex->MarkPrimDirty(id, dirtyBits);
+        _sceneIndex->MarkRprimDirty(id, dirtyBits);
     }
     else
     {
         _sceneDelegate->GetRenderIndex().GetChangeTracker().MarkRprimDirty(id, dirtyBits);
+    }
+}
+
+void MayaHydraSceneProducer::MarkInstancerDirty(const SdfPath& id, HdDirtyBits dirtyBits)
+{
+    if (enableMayaNativeSceneIndex())
+    {
+        _sceneIndex->MarkInstancerDirty(id, dirtyBits);
+    }
+    else
+    {
+        _sceneDelegate->GetRenderIndex().GetChangeTracker().MarkInstancerDirty(id, dirtyBits);
     }
 }
 
@@ -355,7 +367,7 @@ void MayaHydraSceneProducer::MarkSprimDirty(const SdfPath& id, HdDirtyBits dirty
 {
     if (enableMayaNativeSceneIndex())
     {
-        _sceneIndex->MarkPrimDirty(id, dirtyBits);
+        _sceneIndex->MarkSprimDirty(id, dirtyBits);
     }
     else
     {

--- a/lib/mayaHydra/hydraExtensions/mayaHydraSceneProducer.h
+++ b/lib/mayaHydra/hydraExtensions/mayaHydraSceneProducer.h
@@ -92,6 +92,8 @@ public:
     // Mark a Rprim in hydra scene as dirty
     void MarkRprimDirty(const SdfPath& id, HdDirtyBits dirtyBits);
 
+    void MarkInstancerDirty(const SdfPath& id, HdDirtyBits dirtyBits);
+
     // Insert a Sprim to hydra scene
     void InsertSprim(
         MayaHydraAdapter* adapter,

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.h
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.h
@@ -47,6 +47,7 @@
 #include <pxr/imaging/hd/rendererPlugin.h>
 #include <pxr/imaging/hdx/taskController.h>
 #include <pxr/imaging/hd/retainedSceneIndex.h>
+#include "pxr/imaging/hd/dirtyBitsTranslator.h"
 
 #include <unordered_map>
 
@@ -106,10 +107,10 @@ public:
     // Remove a primitive from hydra scene
     void RemovePrim(const SdfPath& id);
 
-    // Mark a primitive in hydra scene as dirty
-    void MarkPrimDirty(
-        const SdfPath& id,
-        HdDirtyBits dirtyBits);
+    void MarkRprimDirty(const SdfPath& id, HdDirtyBits dirtyBits);
+    void MarkSprimDirty(const SdfPath& id, HdDirtyBits dirtyBits);
+    void MarkBprimDirty(const SdfPath& id, HdDirtyBits dirtyBits);
+    void MarkInstancerDirty(const SdfPath& id, HdDirtyBits dirtyBits);
 
     // Operation that's performed on rendering a frame
     void PreFrame(const MHWRender::MDrawContext& drawContext);
@@ -202,6 +203,12 @@ private:
     using LightDagPathMap = std::unordered_map<std::string, MDagPath>;
     LightDagPathMap _GetActiveLightPaths() const;
     static VtValue CreateMayaDefaultMaterial();
+
+    using DirtyBitsToLocatorsFunc = std::function<void(TfToken const&, const HdDirtyBits, HdDataSourceLocatorSet*)>;
+    void _MarkPrimDirty(
+        const SdfPath&          id,
+        HdDirtyBits             dirtyBits,
+        DirtyBitsToLocatorsFunc dirtyBitsToLocatorsFunc);
 private:
     // ------------------------------------------------------------------------
     // HdSceneIndexBase implementations

--- a/lib/mayaHydra/mayaPlugin/renderOverride.cpp
+++ b/lib/mayaHydra/mayaPlugin/renderOverride.cpp
@@ -643,8 +643,7 @@ MStatus MtohRenderOverride::Render(
                 if (_mayaHydraSceneProducer) {
                     params.camera = _mayaHydraSceneProducer->SetCameraViewport(camPath, _viewport);
                     if (vpDirty)
-                        _mayaHydraSceneProducer->GetRenderIndex().GetChangeTracker().MarkSprimDirty(
-                            params.camera, HdCamera::DirtyParams);
+                        _mayaHydraSceneProducer->MarkSprimDirty(params.camera, HdCamera::DirtyParams);
                 }
             }
         } else {


### PR DESCRIPTION
This PR fixes an issue where the mesh prims created from mesh adapters would not have their transform updated in Hydra when using the SceneIndex for Maya-native data.