### PR TITLE
HYDRA-703 :  Fix mesh adapter transform update

### DIFF
--- a/lib/mayaHydra/hydraExtensions/adapters/cameraAdapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/cameraAdapter.cpp
@@ -102,8 +102,8 @@ void MayaHydraCameraAdapter::CreateCallbacks()
         dag,
         +[](MObject& transformNode, MDagMessage::MatrixModifiedFlags& modified, void* clientData) {
             auto* adapter = reinterpret_cast<MayaHydraCameraAdapter*>(clientData);
-            adapter->MarkDirty(HdCamera::DirtyTransform);
             adapter->InvalidateTransform();
+            adapter->MarkDirty(HdCamera::DirtyTransform);
         },
         reinterpret_cast<void*>(this),
         &status);

--- a/lib/mayaHydra/hydraExtensions/adapters/dagAdapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/dagAdapter.cpp
@@ -82,8 +82,8 @@ void _TransformNodeDirty(MObject& node, MPlug& plug, void* clientData)
         // that dirty as well...
         if (adapter->IsVisible(false)) {
             // Transform can change while dag path is hidden.
-            adapter->MarkDirty(HdChangeTracker::DirtyVisibility | HdChangeTracker::DirtyTransform);
             adapter->InvalidateTransform();
+            adapter->MarkDirty(HdChangeTracker::DirtyVisibility | HdChangeTracker::DirtyTransform);
         } else {
             adapter->MarkDirty(HdChangeTracker::DirtyVisibility);
         }
@@ -91,8 +91,8 @@ void _TransformNodeDirty(MObject& node, MPlug& plug, void* clientData)
         // DON'T update visibility from within this callback, since the change
         // has't propagated yet
     } else if (adapter->IsVisible(false)) {
-        adapter->MarkDirty(HdChangeTracker::DirtyTransform);
         adapter->InvalidateTransform();
+        adapter->MarkDirty(HdChangeTracker::DirtyTransform);
     }
 }
 
@@ -210,9 +210,9 @@ void MayaHydraDagAdapter::CreateCallbacks()
 void MayaHydraDagAdapter::MarkDirty(HdDirtyBits dirtyBits)
 {
     if (dirtyBits != 0) {
-        GetSceneProducer()->GetRenderIndex().GetChangeTracker().MarkRprimDirty(GetID(), dirtyBits);
+        GetSceneProducer()->MarkRprimDirty(GetID(), dirtyBits);
         if (IsInstanced()) {
-            GetSceneProducer()->GetRenderIndex().GetChangeTracker().MarkInstancerDirty(GetInstancerID(), dirtyBits);
+            GetSceneProducer()->MarkInstancerDirty(GetInstancerID(), dirtyBits);
         }
         if (dirtyBits & HdChangeTracker::DirtyVisibility) {
             _visibilityDirty = true;

--- a/lib/mayaHydra/hydraExtensions/adapters/lightAdapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/lightAdapter.cpp
@@ -72,9 +72,9 @@ void _dirtyTransform(MObject& node, void* clientData)
     TF_UNUSED(node);
     auto* adapter = reinterpret_cast<MayaHydraDagAdapter*>(clientData);
     if (adapter->IsVisible()) {
+        adapter->InvalidateTransform();
         adapter->MarkDirty(
             HdLight::DirtyTransform | HdLight::DirtyParams | HdLight::DirtyShadowParams);
-        adapter->InvalidateTransform();
     }
 }
 
@@ -83,8 +83,8 @@ void _dirtyParams(MObject& node, void* clientData)
     TF_UNUSED(node);
     auto* adapter = reinterpret_cast<MayaHydraDagAdapter*>(clientData);
     if (adapter->IsVisible()) {
-        adapter->MarkDirty(HdLight::DirtyParams | HdLight::DirtyShadowParams);
         adapter->InvalidateTransform();
+        adapter->MarkDirty(HdLight::DirtyParams | HdLight::DirtyShadowParams);
     }
 }
 

--- a/lib/mayaHydra/hydraExtensions/mayaHydraLibInterface.h
+++ b/lib/mayaHydra/hydraExtensions/mayaHydraLibInterface.h
@@ -26,7 +26,7 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-using SceneIndicesVector                                        = std::vector<HdSceneIndexBasePtr>;//Be careful, these are not not Ref counted. Elements could become dangling
+using SceneIndicesVector = std::vector<HdSceneIndexBaseRefPtr>;
 
 /// In order to access this interface, call the function GetMayaHydraLibInterface()
 class MayaHydraLibInterface

--- a/lib/mayaHydra/hydraExtensions/mayaHydraSceneProducer.cpp
+++ b/lib/mayaHydra/hydraExtensions/mayaHydraSceneProducer.cpp
@@ -315,11 +315,23 @@ void MayaHydraSceneProducer::MarkRprimDirty(const SdfPath& id, HdDirtyBits dirty
 {
     if (enableMayaNativeSceneIndex())
     {
-        _sceneIndex->MarkPrimDirty(id, dirtyBits);
+        _sceneIndex->MarkRprimDirty(id, dirtyBits);
     }
     else
     {
         _sceneDelegate->GetRenderIndex().GetChangeTracker().MarkRprimDirty(id, dirtyBits);
+    }
+}
+
+void MayaHydraSceneProducer::MarkInstancerDirty(const SdfPath& id, HdDirtyBits dirtyBits)
+{
+    if (enableMayaNativeSceneIndex())
+    {
+        _sceneIndex->MarkInstancerDirty(id, dirtyBits);
+    }
+    else
+    {
+        _sceneDelegate->GetRenderIndex().GetChangeTracker().MarkInstancerDirty(id, dirtyBits);
     }
 }
 
@@ -355,7 +367,7 @@ void MayaHydraSceneProducer::MarkSprimDirty(const SdfPath& id, HdDirtyBits dirty
 {
     if (enableMayaNativeSceneIndex())
     {
-        _sceneIndex->MarkPrimDirty(id, dirtyBits);
+        _sceneIndex->MarkSprimDirty(id, dirtyBits);
     }
     else
     {

--- a/lib/mayaHydra/hydraExtensions/mayaHydraSceneProducer.h
+++ b/lib/mayaHydra/hydraExtensions/mayaHydraSceneProducer.h
@@ -92,6 +92,8 @@ public:
     // Mark a Rprim in hydra scene as dirty
     void MarkRprimDirty(const SdfPath& id, HdDirtyBits dirtyBits);
 
+    void MarkInstancerDirty(const SdfPath& id, HdDirtyBits dirtyBits);
+
     // Insert a Sprim to hydra scene
     void InsertSprim(
         MayaHydraAdapter* adapter,

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.h
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.h
@@ -47,6 +47,7 @@
 #include <pxr/imaging/hd/rendererPlugin.h>
 #include <pxr/imaging/hdx/taskController.h>
 #include <pxr/imaging/hd/retainedSceneIndex.h>
+#include "pxr/imaging/hd/dirtyBitsTranslator.h"
 
 #include <unordered_map>
 
@@ -106,10 +107,10 @@ public:
     // Remove a primitive from hydra scene
     void RemovePrim(const SdfPath& id);
 
-    // Mark a primitive in hydra scene as dirty
-    void MarkPrimDirty(
-        const SdfPath& id,
-        HdDirtyBits dirtyBits);
+    void MarkRprimDirty(const SdfPath& id, HdDirtyBits dirtyBits);
+    void MarkSprimDirty(const SdfPath& id, HdDirtyBits dirtyBits);
+    void MarkBprimDirty(const SdfPath& id, HdDirtyBits dirtyBits);
+    void MarkInstancerDirty(const SdfPath& id, HdDirtyBits dirtyBits);
 
     // Operation that's performed on rendering a frame
     void PreFrame(const MHWRender::MDrawContext& drawContext);
@@ -202,6 +203,12 @@ private:
     using LightDagPathMap = std::unordered_map<std::string, MDagPath>;
     LightDagPathMap _GetActiveLightPaths() const;
     static VtValue CreateMayaDefaultMaterial();
+
+    using DirtyBitsToLocatorsFunc = std::function<void(TfToken const&, const HdDirtyBits, HdDataSourceLocatorSet*)>;
+    void _MarkPrimDirty(
+        const SdfPath&          id,
+        HdDirtyBits             dirtyBits,
+        DirtyBitsToLocatorsFunc dirtyBitsToLocatorsFunc);
 private:
     // ------------------------------------------------------------------------
     // HdSceneIndexBase implementations

--- a/lib/mayaHydra/mayaPlugin/renderOverride.cpp
+++ b/lib/mayaHydra/mayaPlugin/renderOverride.cpp
@@ -643,8 +643,7 @@ MStatus MtohRenderOverride::Render(
                 if (_mayaHydraSceneProducer) {
                     params.camera = _mayaHydraSceneProducer->SetCameraViewport(camPath, _viewport);
                     if (vpDirty)
-                        _mayaHydraSceneProducer->GetRenderIndex().GetChangeTracker().MarkSprimDirty(
-                            params.camera, HdCamera::DirtyParams);
+                        _mayaHydraSceneProducer->MarkSprimDirty(params.camera, HdCamera::DirtyParams);
                 }
             }
         } else {

--- a/test/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
+++ b/test/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
@@ -29,6 +29,7 @@ set(TEST_SCRIPT_FILES
 # both versions of the test in parallel will conflict.
 set(TEST_SCRIPT_FILES_MESH_ADAPTER
     testMeshes.py
+    cpp/testMeshAdapterTransform.py
 )
 
 foreach(script ${TEST_SCRIPT_FILES})

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/CMakeLists.txt
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(${TARGET_NAME}
         testWireframeSelectionHighlightSceneIndex.cpp
         testFvpViewportInformationMultipleViewports.cpp
         testFvpViewportInformationRendererSwitching.cpp
+        testMeshAdapterTransform.cpp
 )
 
 # -----------------------------------------------------------------------------

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testMeshAdapterTransform.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testMeshAdapterTransform.cpp
@@ -1,0 +1,56 @@
+// Copyright 2023 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "testUtils.h"
+
+#include <pxr/imaging/hd/tokens.h>
+#include <pxr/imaging/hd/xformSchema.h>
+
+#include <maya/MGlobal.h>
+
+#include <gtest/gtest.h>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+namespace {
+const std::string kCubeName = "testCube";
+} // namespace
+
+TEST(MeshAdapterTransform, testDirtying)
+{
+    // Setup notifications accumulator for the first terminal scene index
+    const SceneIndicesVector& sceneIndices = GetTerminalSceneIndices();
+    ASSERT_GT(sceneIndices.size(), static_cast<size_t>(0));
+    SceneIndexNotificationsAccumulator notifsAccumulator(sceneIndices.front());
+
+    // The test cube should still be selected from the Python driver
+    MGlobal::executeCommand("move 3 5 8");
+
+    // Check if the cube mesh prim had its xform dirtied
+    bool cubeXformWasDirtied = false;
+    for (const auto& dirtiedPrimEntry : notifsAccumulator.GetDirtiedPrimEntries()) {
+        HdSceneIndexPrim prim
+            = notifsAccumulator.GetObservedSceneIndex()->GetPrim(dirtiedPrimEntry.primPath);
+
+        cubeXformWasDirtied = dirtiedPrimEntry.primPath.GetName() == kCubeName + "Shape"
+            && prim.primType == HdPrimTypeTokens->mesh
+            && dirtiedPrimEntry.dirtyLocators.Contains(HdXformSchema::GetDefaultLocator());
+
+        if (cubeXformWasDirtied) {
+            break;
+        }
+    }
+    EXPECT_TRUE(cubeXformWasDirtied);
+}

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testMeshAdapterTransform.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testMeshAdapterTransform.py
@@ -1,0 +1,35 @@
+# Copyright 2023 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import maya.cmds as cmds
+import fixturesUtils
+import mtohUtils
+from testUtils import PluginLoaded
+
+class TestMeshAdapterTransform(mtohUtils.MayaHydraBaseTestCase):
+    # MayaHydraBaseTestCase.setUpClass requirement.
+    _file = __file__
+
+    def setupScene(self):
+        self.setHdStormRenderer()
+        cmds.polyCube(name="testCube")
+        cmds.refresh() # Refresh to create the MeshAdapter and its mesh prim at the origin
+
+    def test_Dirtying(self):
+        self.setupScene()
+        with PluginLoaded('mayaHydraCppTests'):
+            cmds.mayaHydraCppTest(f="MeshAdapterTransform.testDirtying")
+
+if __name__ == '__main__':
+    fixturesUtils.runTests(globals())

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testUtils.h
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testUtils.h
@@ -31,7 +31,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 constexpr double DEFAULT_TOLERANCE = std::numeric_limits<double>::epsilon();
 
-using SceneIndicesVector = std::vector<HdSceneIndexBasePtr>;
+using SceneIndicesVector = std::vector<HdSceneIndexBaseRefPtr>;
 
 /**
  * @brief Retrieve the list of registered terminal scene indices from the Hydra plugin
@@ -173,6 +173,58 @@ HdSceneIndexBaseRefPtr findSceneIndexInTree(
     const HdSceneIndexBaseRefPtr&                             sceneIndex,
     const std::function<bool(const HdSceneIndexBaseRefPtr&)>& predicate
 );
+
+/**
+* @class A utility class to accumulate and read SceneIndex notifications sent by a SceneIndex.
+*/
+class SceneIndexNotificationsAccumulator : public HdSceneIndexObserver
+{
+public:
+    SceneIndexNotificationsAccumulator(HdSceneIndexBaseRefPtr observedSceneIndex)
+        : _observedSceneIndex(observedSceneIndex)
+    {
+        _observedSceneIndex->AddObserver(HdSceneIndexObserverPtr(this));
+    }
+    ~SceneIndexNotificationsAccumulator() override
+    {
+        _observedSceneIndex->RemoveObserver(HdSceneIndexObserverPtr(this));
+    }
+
+    HdSceneIndexBaseRefPtr GetObservedSceneIndex() { return _observedSceneIndex; }
+
+    const AddedPrimEntries&   GetAddedPrimEntries() { return _addedPrimEntries; }
+    const RemovedPrimEntries& GetRemovedPrimEntries() { return _removedPrimEntries; }
+    const DirtiedPrimEntries& GetDirtiedPrimEntries() { return _dirtiedPrimEntries; }
+    const RenamedPrimEntries& GetRenamedPrimEntries() { return _renamedPrimEntries; }
+
+    void PrimsAdded(const HdSceneIndexBase& sender, const AddedPrimEntries& entries) override
+    {
+        _addedPrimEntries.insert(_addedPrimEntries.end(), entries.begin(), entries.end());
+    }
+
+    void PrimsRemoved(const HdSceneIndexBase& sender, const RemovedPrimEntries& entries) override
+    {
+        _removedPrimEntries.insert(_removedPrimEntries.end(), entries.begin(), entries.end());
+    }
+
+    void PrimsDirtied(const HdSceneIndexBase& sender, const DirtiedPrimEntries& entries) override
+    {
+        _dirtiedPrimEntries.insert(_dirtiedPrimEntries.end(), entries.begin(), entries.end());
+    }
+
+    void PrimsRenamed(const HdSceneIndexBase& sender, const RenamedPrimEntries& entries) override
+    {
+        _renamedPrimEntries.insert(_renamedPrimEntries.end(), entries.begin(), entries.end());
+    }
+
+private:
+    HdSceneIndexBaseRefPtr _observedSceneIndex;
+
+    AddedPrimEntries   _addedPrimEntries;
+    DirtiedPrimEntries _dirtiedPrimEntries;
+    RemovedPrimEntries _removedPrimEntries;
+    RenamedPrimEntries _renamedPrimEntries;
+};
 
 PXR_NAMESPACE_CLOSE_SCOPE
 


### PR DESCRIPTION
This PR fixes an issue with MeshAdapters where their transform was not being dirtied properly, and thus not updated correctly in the viewport. Since this issue was not MeshAdapter-specific and only highlighted a larger-scale problem, I've fixed the problem in the other places where it appeared.