### PR TITLE
Fix testFlowViewportAPI image diff thresholds

### DIFF
--- a/test/lib/mayaUsd/render/mayaToHydra/testFlowViewportAPI.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/testFlowViewportAPI.py
@@ -35,6 +35,9 @@ class TestFlowViewportAPI(mtohUtils.MtohTestCase): #Subclassing mtohUtils.MtohTe
     # MayaHydraBaseTestCase.setUpClass requirement.
     _file = __file__
 
+    IMAGE_DIFF_FAIL_THRESHOLD = 0.1
+    IMAGE_DIFF_FAIL_PERCENT = 2
+
     def setupScene(self):
         self.setHdStormRenderer()
 
@@ -55,7 +58,7 @@ class TestFlowViewportAPI(mtohUtils.MtohTestCase): #Subclassing mtohUtils.MtohTe
             cmds.getAttr(flowViewportNodeName + '.dummyOutput')#getting this value will trigger a call to compute
             cmds.refresh()
             #Original images are located for example in maya-hydra\test\lib\mayaUsd\render\mayaToHydra\FlowViewportAPITest
-            self.assertSnapshotClose("add_NodeCreated.png", None, None)
+            self.assertSnapshotClose("add_NodeCreated.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
 
             #Move the transform node, the added prims (cube grid) should move as well
             # Get the transform node of the FlowViewportAPIMayaLocator
@@ -66,44 +69,44 @@ class TestFlowViewportAPI(mtohUtils.MtohTestCase): #Subclassing mtohUtils.MtohTe
             # Move the selected node
             cmds.move(10, 5, -5)
             cmds.refresh()
-            self.assertSnapshotClose("add_NodeMoved.png", None, None)
+            self.assertSnapshotClose("add_NodeMoved.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
         
             #Hide the transform node, this should hide the FlowViewportAPIMayaLocator node and the added prims as well.
             cmds.hide(transformNode)
-            self.assertSnapshotClose("add_NodeHidden.png", None, None)
+            self.assertSnapshotClose("add_NodeHidden.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
 
             #Unhide the transform node, this should unhide the FlowViewportAPIMayaLocator node and the added prims as well.
             cmds.showHidden(transformNode)
-            self.assertSnapshotClose("add_NodeUnhidden.png", None, None)
+            self.assertSnapshotClose("add_NodeUnhidden.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
 
             #Delete the shape node, this should hide the added prims as well
             cmds.delete(flowViewportNodeName)
-            self.assertSnapshotClose("add_NodeDeleted.png", None, None)
+            self.assertSnapshotClose("add_NodeDeleted.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
             
             #Undo the delete, the node should be visible again so do the added prims
             cmds.undo()
-            self.assertSnapshotClose("add_NodeDeletedUndo.png", None, None)
+            self.assertSnapshotClose("add_NodeDeletedUndo.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
 
             #Redo the delete, the added prims should be hidden
             cmds.redo()
-            self.assertSnapshotClose("add_NodeDeletedRedo.png", None, None)
+            self.assertSnapshotClose("add_NodeDeletedRedo.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
 
             #Undo the delete again, the added prims should be visible
             cmds.undo()
-            self.assertSnapshotClose("add_NodeDeletedUndoAgain.png", None, None)
+            self.assertSnapshotClose("add_NodeDeletedUndoAgain.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
 
             #Move transform node again to see if it still updates the added prims transform
             cmds.select(transformNode)
             # Move the selected node
             cmds.move(-20, -5, 0)
             cmds.refresh()
-            self.assertSnapshotClose("add_NodeMovedAfterDeletionAndUndo.png", None, None)
+            self.assertSnapshotClose("add_NodeMovedAfterDeletionAndUndo.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
 
             #Switch to VP2
             self.setViewport2Renderer()
             #Switch back to Storm
             self.setHdStormRenderer()
-            self.assertSnapshotClose("add_VP2AndThenBackToStorm.png", None, None)
+            self.assertSnapshotClose("add_VP2AndThenBackToStorm.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
 
             #Finish by a File New command
             cmds.file(new=True, force=True)
@@ -125,7 +128,7 @@ class TestFlowViewportAPI(mtohUtils.MtohTestCase): #Subclassing mtohUtils.MtohTe
             cmds.getAttr(flowViewportNodeName + '.dummyOutput')#getting this value will trigger a call to compute
             cmds.refresh()
             #Original images are located for example in maya-hydra\test\lib\mayaUsd\render\mayaToHydra\FlowViewportAPITest
-            self.assertSnapshotClose("filter_NodeCreated.png", None, None)
+            self.assertSnapshotClose("filter_NodeCreated.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
 
             #Move the transform node, the added prims (cube grid) should move as well
             # Get the transform node of the FlowViewportAPIMayaLocator
@@ -136,43 +139,43 @@ class TestFlowViewportAPI(mtohUtils.MtohTestCase): #Subclassing mtohUtils.MtohTe
             # Move the selected node
             cmds.move(15, 0, 0)
             cmds.refresh()
-            self.assertSnapshotClose("filter_NodeMoved.png", None, None)
+            self.assertSnapshotClose("filter_NodeMoved.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
 
             #Change sphere attributes to add more vertices/polygons, our filtering hides a prim when its number of vertices is greater than 10 000.
             cmds.setAttr(sphereShape + '.subdivisionsAxis', 200)
             cmds.setAttr(sphereShape + '.subdivisionsHeight', 200)
             cmds.refresh()
-            self.assertSnapshotClose("filter_SphereFiltered.png", None, None)
+            self.assertSnapshotClose("filter_SphereFiltered.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
 
             #Decreasing the number of vertices of this sphere under 10 000 should make it visible again (not filtered)
             cmds.setAttr(sphereShape + '.subdivisionsAxis', 30)
             cmds.refresh()
-            self.assertSnapshotClose("filter_SphereUnFiltered.png", None, None)
+            self.assertSnapshotClose("filter_SphereUnFiltered.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
 
             #Increasing again the number of vertices above 10 000 should make it filtered again (invisible)
             cmds.setAttr(sphereShape + '.subdivisionsAxis', 200)
             cmds.refresh()
-            self.assertSnapshotClose("filter_SphereFilteredAgain.png", None, None)
+            self.assertSnapshotClose("filter_SphereFilteredAgain.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
 
             #Hide the transform node, this should hide the FlowViewportAPIMayaLocator shape node and disable the filtering as well.
             cmds.hide(transformNode)
-            self.assertSnapshotClose("filter_NodeHidden.png", None, None)
+            self.assertSnapshotClose("filter_NodeHidden.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
 
             #Unhide the transform node, this should unhide the FlowViewportAPIMayaLocator node and enable the filtering as well.
             cmds.showHidden(transformNode)
-            self.assertSnapshotClose("filter_NodeUnhidden.png", None, None)
+            self.assertSnapshotClose("filter_NodeUnhidden.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
 
             #Delete the shape node, this should disable filtering
             cmds.delete(flowViewportNodeName)
-            self.assertSnapshotClose("filter_NodeDeleted.png", None, None)
+            self.assertSnapshotClose("filter_NodeDeleted.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
             
             #Undo the delete, the node should be visible again and filtering be enabled
             cmds.undo()
-            self.assertSnapshotClose("filter_NodeDeletedUndo.png", None, None)
+            self.assertSnapshotClose("filter_NodeDeletedUndo.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
 
             #Redo the delete, filtering should be disabled
             cmds.redo()
-            self.assertSnapshotClose("filter_NodeDeletedRedo.png", None, None)
+            self.assertSnapshotClose("filter_NodeDeletedRedo.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
             
             #Undo the delete so filtering is enabled again
             cmds.undo()
@@ -181,7 +184,7 @@ class TestFlowViewportAPI(mtohUtils.MtohTestCase): #Subclassing mtohUtils.MtohTe
             self.setViewport2Renderer()
             #Switch back to Storm
             self.setHdStormRenderer()
-            self.assertSnapshotClose("filter_VP2AndThenBackToStorm.png", None, None)
+            self.assertSnapshotClose("filter_VP2AndThenBackToStorm.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
 
             #Finish by a File New command
             cmds.file(new=True, force=True)
@@ -198,7 +201,7 @@ class TestFlowViewportAPI(mtohUtils.MtohTestCase): #Subclassing mtohUtils.MtohTe
             #When the node above is created, its compute method is not called automatically, so work around to trigger a call to compute
             cmds.setAttr(flowViewportNodeName + '.dummyInput', 2)#setting this will set dirty the dummyOutput attribute
             cmds.getAttr(flowViewportNodeName + '.dummyOutput')#getting this value will trigger a call to compute
-            self.assertSnapshotClose("cubeGrid_BeforeModifs.png", None, None)
+            self.assertSnapshotClose("cubeGrid_BeforeModifs.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
 
             #Get the matrix and set a rotation of 70 degress around Y axis.
             matrix = cmds.getAttr(flowViewportNodeName + '.cubeInitalTransform')
@@ -216,12 +219,12 @@ class TestFlowViewportAPI(mtohUtils.MtohTestCase): #Subclassing mtohUtils.MtohTe
             cmds.setAttr(flowViewportNodeName + '.cubesUseInstancing', False)
             cmds.setAttr(flowViewportNodeName + '.cubesDeltaTrans', 15, 15, 15, type="double3")
             cmds.refresh()
-            self.assertSnapshotClose("cubeGrid_AfterModifs.png", None, None)
+            self.assertSnapshotClose("cubeGrid_AfterModifs.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
 
             #Test instancing
             cmds.setAttr(flowViewportNodeName + '.cubesUseInstancing', True)
             cmds.refresh()
-            self.assertSnapshotClose("cubeGrid_WithInstancing.png", None, None)
+            self.assertSnapshotClose("cubeGrid_WithInstancing.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
 
             #Add more cubes
             cmds.setAttr(flowViewportNodeName + '.numCubesX', 30)
@@ -231,13 +234,13 @@ class TestFlowViewportAPI(mtohUtils.MtohTestCase): #Subclassing mtohUtils.MtohTe
             cmds.setAttr(flowViewportNodeName + '.cubeOpacity', 0.3)
             cmds.setAttr(flowViewportNodeName + '.cubesDeltaTrans', 5, 5, 5, type="double3")
             cmds.refresh()
-            self.assertSnapshotClose("cubeGrid_WithInstancingModifs.png", None, None)
+            self.assertSnapshotClose("cubeGrid_WithInstancingModifs.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
 
             #Switch to VP2
             self.setViewport2Renderer()
             #Switch back to Storm
             self.setHdStormRenderer()
-            self.assertSnapshotClose("cubeGrid_VP2AndThenBackToStorm.png", None, None)
+            self.assertSnapshotClose("cubeGrid_VP2AndThenBackToStorm.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
 
             #Finish by a File New command
             cmds.file(new=True, force=True)
@@ -317,7 +320,7 @@ class TestFlowViewportAPI(mtohUtils.MtohTestCase): #Subclassing mtohUtils.MtohTe
             cmds.move(-30, 0, -30)
             cmds.refresh()
             
-            self.assertSnapshotClose("multipleNodes_BeforeModifs.png", None, None)
+            self.assertSnapshotClose("multipleNodes_BeforeModifs.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
 
             #Modify the color of node #2, it shouldn't change node's #1 color
             cmds.setAttr(flowViewportNodeName2 + '.cubeColor', 1.0, 1.0, 1.0, type="double3")
@@ -329,25 +332,25 @@ class TestFlowViewportAPI(mtohUtils.MtohTestCase): #Subclassing mtohUtils.MtohTe
             cmds.rotate(-30, 45, 0)
             cmds.scale(2, 1, 1)
             cmds.refresh()
-            self.assertSnapshotClose("multipleNodes_AfterModifs.png", None, None)
+            self.assertSnapshotClose("multipleNodes_AfterModifs.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
 
             #Remove instancing, the cubes should stay at the same place
             cmds.setAttr(flowViewportNodeName2 + '.cubesUseInstancing', False)
-            self.assertSnapshotClose("multipleNodes_AfterModifsRemoveInstancing.png", None, None)
+            self.assertSnapshotClose("multipleNodes_AfterModifsRemoveInstancing.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
 
             #Hide node #1
             cmds.hide(transformNode1)
-            self.assertSnapshotClose("multipleNodes_Node1Hidden.png", None, None)
+            self.assertSnapshotClose("multipleNodes_Node1Hidden.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
 
             #Unhide node #1
             cmds.showHidden(transformNode1)
-            self.assertSnapshotClose("multipleNodes_Node1Unhidden.png", None, None)
+            self.assertSnapshotClose("multipleNodes_Node1Unhidden.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
 
             #Switch to VP2
             self.setViewport2Renderer()
             #Switch back to Storm
             self.setHdStormRenderer()
-            self.assertSnapshotClose("multipleNodes_VP2AndThenBackToStorm.png", None, None)
+            self.assertSnapshotClose("multipleNodes_VP2AndThenBackToStorm.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
 
             #Finish by a File New command
             cmds.file(new=True, force=True)
@@ -395,42 +398,42 @@ class TestFlowViewportAPI(mtohUtils.MtohTestCase): #Subclassing mtohUtils.MtohTe
             cmds.refresh()
             
             cmds.setFocus ('modelPanel4')
-            self.assertSnapshotClose("multipleViewports_viewPanel4.png", None, None)
+            self.assertSnapshotClose("multipleViewports_viewPanel4.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
             cmds.setFocus ('modelPanel2')
-            self.assertSnapshotClose("multipleViewports_viewPanel2.png", None, None)
+            self.assertSnapshotClose("multipleViewports_viewPanel2.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
 
             #Change sphere attributes to add more vertices/polygons, our filtering removes a prim when its number of vertices is greater than 10 000.
             cmds.setAttr(sphereShape + '.subdivisionsAxis', 200)
             cmds.setAttr(sphereShape + '.subdivisionsHeight', 200)
             cmds.refresh()
             cmds.setFocus ('modelPanel4')
-            self.assertSnapshotClose("multipleViewports_sphereFiltered_viewPanel4.png", None, None)
+            self.assertSnapshotClose("multipleViewports_sphereFiltered_viewPanel4.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
             cmds.setFocus ('modelPanel2')
-            self.assertSnapshotClose("multipleViewports_sphereFiltered_viewPanel2.png", None, None)
+            self.assertSnapshotClose("multipleViewports_sphereFiltered_viewPanel2.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
             
             #Remove filtering by decreasing the number of vertices
             cmds.setAttr(sphereShape + '.subdivisionsAxis', 30)
             cmds.refresh()
             cmds.setFocus ('modelPanel4')
-            self.assertSnapshotClose("multipleViewports_sphereUnfiltered_viewPanel4.png", None, None)
+            self.assertSnapshotClose("multipleViewports_sphereUnfiltered_viewPanel4.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
             cmds.setFocus ('modelPanel2')
-            self.assertSnapshotClose("multipleViewports_sphereUnfiltered_viewPanel2.png", None, None)
+            self.assertSnapshotClose("multipleViewports_sphereUnfiltered_viewPanel2.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
             
             #Switch to VP2
             cmds.setFocus ('modelPanel4')
             self.setViewport2Renderer()
-            self.assertSnapshotClose("multipleViewports_VP2_modPan4.png", None, None)
+            self.assertSnapshotClose("multipleViewports_VP2_modPan4.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
             cmds.setFocus ('modelPanel2')
             self.setViewport2Renderer()
-            self.assertSnapshotClose("multipleViewports_VP2_modPan2.png", None, None)
+            self.assertSnapshotClose("multipleViewports_VP2_modPan2.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
             
             #Switch back to Storm
             cmds.setFocus ('modelPanel4')
             self.setHdStormRenderer()
-            self.assertSnapshotClose("multipleViewports_VP2AndThenBackToStorm_modPan4.png", None, None)
+            self.assertSnapshotClose("multipleViewports_VP2AndThenBackToStorm_modPan4.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
             cmds.setFocus ('modelPanel2')
             self.setHdStormRenderer()
-            self.assertSnapshotClose("multipleViewports_VP2AndThenBackToStorm_modPan2.png", None, None)
+            self.assertSnapshotClose("multipleViewports_VP2AndThenBackToStorm_modPan2.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
 
             #Finish by a File New command
             cmds.file(new=True, force=True)


### PR DESCRIPTION
The tests in testFlowViewportAPI were expecting renders that matched exactly 1:1 the reference images, but renders can vary slightly between GPUs, so there was a slight difference between the reference images and OSX renders. This PR adds in some small thresholds to accept slight differences between a render and its reference image. 