### PR TITLE
HYDRA-744 - Rename the env var to avoid duplication

### DIFF
--- a/lib/mayaHydra/hydraExtensions/delegates/sceneDelegate.cpp
+++ b/lib/mayaHydra/hydraExtensions/delegates/sceneDelegate.cpp
@@ -79,11 +79,11 @@ namespace {
 // Pixar macros require Pixar namespace.
 PXR_NAMESPACE_USING_DIRECTIVE
 
-TF_DEFINE_ENV_SETTING(MAYA_HYDRA_USE_MESH_ADAPTER, false,
+TF_DEFINE_ENV_SETTING(MAYA_HYDRA_USE_MESH_ADAPTER_WITH_SCENE_DELEGATE, false,
                       "Use mesh adapter instead of MRenderItem for Maya meshes.");
 
 bool useMeshAdapter() {
-    static bool uma = TfGetEnvSetting(MAYA_HYDRA_USE_MESH_ADAPTER);
+    static bool uma = TfGetEnvSetting(MAYA_HYDRA_USE_MESH_ADAPTER_WITH_SCENE_DELEGATE);
     return uma;
 }
 


### PR DESCRIPTION
Rename the env variable MAYA_HYDRA_USE_MESH_ADAPTER used in sceneDelegate.cpp to avoid duplicated definition, which was also used in mayaHydraSceneIndex.cpp.

Note the sceneDelegate related implementations would be deprecated in the future.