### PR TITLE
HYDRA-474 : Filtering scene index example can have prims get unfiltered at the wrong location

### DIFF
--- a/lib/flowViewport/API/samples/fvpFilteringSceneIndexExample.cpp
+++ b/lib/flowViewport/API/samples/fvpFilteringSceneIndexExample.cpp
@@ -21,13 +21,16 @@
 #include <pxr/imaging/hd/primvarsSchema.h>
 #include <pxr/imaging/hd/meshSchema.h>
 #include <pxr/imaging/hd/tokens.h>
+#include <pxr/imaging/hd/xformSchema.h>
+
+#include <iostream>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 namespace 
 {
     //As an example, we use a filtering scene index to filter mesh primitives which have more than 10 000 vertices.
-    bool IsFiltered(const HdSceneIndexPrim& sceneIndexPrim)
+    bool ShouldBeFiltered(const HdSceneIndexPrim& sceneIndexPrim)
     {
         static bool _hideCameras        = false;
         static bool _hideSimpleLights   = false;
@@ -64,20 +67,94 @@ namespace
 }
 
 namespace FVP_NS_DEF {
+bool FilteringSceneIndexExample::IsFiltered(const SdfPath& primPath) const
+{
+    return _filteredPrims.find(primPath) != _filteredPrims.end();
+}
+void FilteringSceneIndexExample::UpdateFilteringStatus(const SdfPath& primPath)
+{
+    if (_GetInputSceneIndex() && ShouldBeFiltered(_GetInputSceneIndex()->GetPrim(primPath))) {
+        _filteredPrims.insert(primPath);
+    } else {
+        _filteredPrims.erase(primPath);
+    }
+}
 
 //This is the function where we filter prims
 HdSceneIndexPrim FilteringSceneIndexExample::GetPrim(const SdfPath& primPath) const
 {
-    if (_GetInputSceneIndex()){
-        const HdSceneIndexPrim prim = _GetInputSceneIndex()->GetPrim(primPath);
-        
-        const bool isThisPrimFiltered = IsFiltered(prim);
-        if ( ! isThisPrimFiltered){
-            return prim;//return only non filtered prims
+    HdSceneIndexPrim result;
+
+    std::cout << "DBP : GetPrim " << primPath.GetAsString() << std::endl;
+    if (_GetInputSceneIndex()) {
+        HdSceneIndexPrim prim = _GetInputSceneIndex()->GetPrim(primPath);
+        if (!ShouldBeFiltered(prim)) {
+            result = prim; // return only non filtered prims
         }
     }
 
-    return HdSceneIndexPrim();
+    return result;
+}
+
+void FilteringSceneIndexExample::_PrimsAdded(
+    const HdSceneIndexBase&                         sender,
+    const HdSceneIndexObserver::AddedPrimEntries& entries)
+{
+    HdSceneIndexObserver::AddedPrimEntries filteredEntries;
+    for (const auto& entry : entries) {
+        std::cout << "DBP : _PrimsAdded " << entry.primPath.GetAsString() << std::endl;
+        UpdateFilteringStatus(entry.primPath);
+        if (!IsFiltered(entry.primPath)) {
+            filteredEntries.push_back(entry);
+        }
+    }
+    _SendPrimsAdded(filteredEntries);
+}
+
+void FilteringSceneIndexExample::_PrimsRemoved(
+    const HdSceneIndexBase&                       sender,
+    const HdSceneIndexObserver::RemovedPrimEntries& entries)
+{
+    for (const auto& entry : entries) {
+        std::cout << "DBP : _PrimsRemoved " << entry.primPath.GetAsString() << std::endl;
+        _filteredPrims.erase(entry.primPath);
+    }
+    _SendPrimsRemoved(entries);
+}
+
+void FilteringSceneIndexExample::_PrimsDirtied(
+    const HdSceneIndexBase&                         sender,
+    const HdSceneIndexObserver::DirtiedPrimEntries& entries)
+{
+    HdSceneIndexObserver::AddedPrimEntries   unfilteredPrims;
+    HdSceneIndexObserver::RemovedPrimEntries filteredPrims;
+    HdSceneIndexObserver::DirtiedPrimEntries dirtiedEntries;
+    for (const auto& entry : entries) {
+        std::cout << "DBP : _PrimsDirtied " << entry.primPath.GetAsString() << std::endl;
+        bool wasFiltered = IsFiltered(entry.primPath);
+        UpdateFilteringStatus(entry.primPath);
+        if (wasFiltered == IsFiltered(entry.primPath)) {
+            // Filtering status did not change, forward notification as-is
+            dirtiedEntries.push_back(entry);
+        }
+        else {
+            // Filtering status changed, dirty everything
+            std::cout << "DBP : Filtering status changed from " << wasFiltered << " to "
+                      << IsFiltered(entry.primPath) << " for " << entry.primPath.GetAsString() << std::endl;
+            //HdDataSourceLocatorSet newSet = entry.dirtyLocators;
+            //newSet.insert(HdXformSchema::GetDefaultLocator());
+            //filteredEntries.push_back({ entry.primPath, HdDataSourceLocatorSet::UniversalSet() });
+            if (wasFiltered) {
+                    unfilteredPrims.emplace_back(
+                        entry.primPath, _GetInputSceneIndex()->GetPrim(entry.primPath).primType);
+            } else {
+                    filteredPrims.emplace_back(entry.primPath);
+            }
+        }
+    }
+    _SendPrimsAdded(unfilteredPrims);
+    _SendPrimsRemoved(filteredPrims);
+    _SendPrimsDirtied(dirtiedEntries);
 }
 
 }//end of namespace FVP_NS_DEF

--- a/lib/flowViewport/API/samples/fvpFilteringSceneIndexExample.cpp
+++ b/lib/flowViewport/API/samples/fvpFilteringSceneIndexExample.cpp
@@ -73,7 +73,7 @@ bool FilteringSceneIndexExample::IsFiltered(const SdfPath& primPath) const
 
 void FilteringSceneIndexExample::UpdateFilteringStatus(const SdfPath& primPath)
 {
-    if (_GetInputSceneIndex() && ShouldBeFiltered(_GetInputSceneIndex()->GetPrim(primPath))) {
+    if (ShouldBeFiltered(_GetInputSceneIndex()->GetPrim(primPath))) {
         _filteredPrims.insert(primPath);
     } else {
         _filteredPrims.erase(primPath);
@@ -96,15 +96,11 @@ FilteringSceneIndexExample::FilteringSceneIndexExample(const HdSceneIndexBaseRef
 
 HdSceneIndexPrim FilteringSceneIndexExample::GetPrim(const SdfPath& primPath) const
 {
-    if (!_GetInputSceneIndex()) {
-        return HdSceneIndexPrim();
-    }
-
     return IsFiltered(primPath) ? HdSceneIndexPrim() : _GetInputSceneIndex()->GetPrim(primPath);
 }
 
 SdfPathVector FilteringSceneIndexExample::GetChildPrimPaths(const SdfPath& primPath) const {
-    if (!_GetInputSceneIndex()) {
+    if (IsFiltered(primPath)) {
         return SdfPathVector();
     }
 
@@ -115,7 +111,7 @@ SdfPathVector FilteringSceneIndexExample::GetChildPrimPaths(const SdfPath& primP
             childPaths.end(),
             [this](const SdfPath& childPath) -> bool { return IsFiltered(childPath); }),
         childPaths.end());
-    return IsFiltered(primPath) ? SdfPathVector() : childPaths;
+    return childPaths;
 }
 
 void FilteringSceneIndexExample::_PrimsAdded(

--- a/lib/flowViewport/API/samples/fvpFilteringSceneIndexExample.cpp
+++ b/lib/flowViewport/API/samples/fvpFilteringSceneIndexExample.cpp
@@ -108,7 +108,14 @@ SdfPathVector FilteringSceneIndexExample::GetChildPrimPaths(const SdfPath& primP
         return SdfPathVector();
     }
 
-    return IsFiltered(primPath) ? SdfPathVector() : _GetInputSceneIndex()->GetChildPrimPaths(primPath);
+    SdfPathVector childPaths = _GetInputSceneIndex()->GetChildPrimPaths(primPath);
+    childPaths.erase(
+        std::remove_if(
+            childPaths.begin(),
+            childPaths.end(),
+            [this](const SdfPath& childPath) -> bool { return IsFiltered(childPath); }),
+        childPaths.end());
+    return IsFiltered(primPath) ? SdfPathVector() : childPaths;
 }
 
 void FilteringSceneIndexExample::_PrimsAdded(

--- a/lib/flowViewport/API/samples/fvpFilteringSceneIndexExample.h
+++ b/lib/flowViewport/API/samples/fvpFilteringSceneIndexExample.h
@@ -46,15 +46,9 @@ public:
     }
 
     // From HdSceneIndexBase
-    HdSceneIndexPrim GetPrim(const SdfPath& primPath) const override;//Is the useful function where we do filtering
+    HdSceneIndexPrim GetPrim(const SdfPath& primPath) const override;
     
-    SdfPathVector GetChildPrimPaths(const SdfPath& primPath) const override{//We leave this function with no filtering for simplicity
-        if (_GetInputSceneIndex()){
-            return _GetInputSceneIndex()->GetChildPrimPaths(primPath);
-        }
-
-        return {};
-    }
+    SdfPathVector GetChildPrimPaths(const SdfPath& primPath) const override;
     
     ~FilteringSceneIndexExample() override = default;
 

--- a/lib/flowViewport/API/samples/fvpFilteringSceneIndexExample.h
+++ b/lib/flowViewport/API/samples/fvpFilteringSceneIndexExample.h
@@ -53,7 +53,7 @@ public:
     ~FilteringSceneIndexExample() override = default;
 
 protected:
-    FilteringSceneIndexExample(const HdSceneIndexBaseRefPtr& inputSceneIndex) : ParentClass(inputSceneIndex) {}
+    FilteringSceneIndexExample(const HdSceneIndexBaseRefPtr& inputSceneIndex);
 
     void _PrimsAdded(
         const HdSceneIndexBase&                       sender,
@@ -68,6 +68,7 @@ protected:
         const HdSceneIndexObserver::DirtiedPrimEntries& entries) override;
 
     bool IsFiltered(const SdfPath& primPath) const;
+
     void UpdateFilteringStatus(const SdfPath& primPath);
 
     SdfPathSet _filteredPrims;

--- a/lib/flowViewport/API/samples/fvpFilteringSceneIndexExample.h
+++ b/lib/flowViewport/API/samples/fvpFilteringSceneIndexExample.h
@@ -63,24 +63,20 @@ protected:
 
     void _PrimsAdded(
         const HdSceneIndexBase&                       sender,
-        const HdSceneIndexObserver::AddedPrimEntries& entries) override final
-    {
-        _SendPrimsAdded(entries);
-    }
+        const HdSceneIndexObserver::AddedPrimEntries& entries) override;
 
     void _PrimsRemoved(
         const HdSceneIndexBase&                         sender,
-        const HdSceneIndexObserver::RemovedPrimEntries& entries) override 
-    {
-        _SendPrimsRemoved(entries);
-    }
+        const HdSceneIndexObserver::RemovedPrimEntries& entries) override;
 
     void _PrimsDirtied(
         const HdSceneIndexBase&                         sender,
-        const HdSceneIndexObserver::DirtiedPrimEntries& entries) override 
-        {
-            _SendPrimsDirtied(entries);
-        }
+        const HdSceneIndexObserver::DirtiedPrimEntries& entries) override;
+
+    bool IsFiltered(const SdfPath& primPath) const;
+    void UpdateFilteringStatus(const SdfPath& primPath);
+
+    SdfPathSet _filteredPrims;
 };
 
 }//end of namespace FVP_NS_DEF


### PR DESCRIPTION
This PR fixes the issue where filtered prims who are no longer filtered could reappear in wrong locations.

The approach taken is to make it so that the filtering fully appears as prim additions and removals to downstream scene indices. The reason for this is that we do not know what downstream scene indices might do with the information they get from a filtering scene index and/or its parents. They could full well call GetPrim once and cache the result, and then only relying on notifications for their purpose, which means the filtering scene index has to stay coherent across its API, and send notifications which match its observable state. It also wouldn't make much sense for downstream scene indices to receive notifications about prims which are supposed to be filtered out.

This approach has the caveat of requiring either 1) to maintain state in order to remember which prims are filtered or not, in order to send the correct prim removal/addition notifications, or 2) wastefully re-syncing prims. For example, suppose we receive a prim dirty notification, and the prim does not need to be filtered : how do we know whether to simply forward the dirty notification (because it was already not filtered), or instead send a prim added notification (because it was previously filtered)? Either we keep track of whether the prim was previously filtered, or we always send prim added notifications, which acts as a full (potentially wasteful) re-sync (see this comment in USD).