### PR TITLE
HYDRA-786 - make sure skydome light is not turned off unexpectedly

### DIFF
--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
@@ -886,7 +886,7 @@ void MayaHydraSceneIndex::PreFrame(const MHWRender::MDrawContext& context)
         }
     }
 
-    // Turn on active lights, turn off non-active lights, and add non-created active lights.
+    // Turn on active lights, turn off non-active lights
     _MapAdapter<MayaHydraLightAdapter>(
         [&](MayaHydraLightAdapter* a) {
             auto lgtAdapter = activeLightPaths.find(a->GetDagPath().fullPathName().asChar());
@@ -894,7 +894,10 @@ void MayaHydraSceneIndex::PreFrame(const MHWRender::MDrawContext& context)
                 a->SetLightingOn(true);
                 activeLightPaths.erase(lgtAdapter);
             } else {
-                a->SetLightingOn(false);
+                // Skip dome light as maya numberOfActiveLights API doesn't count active dome light
+                if (a->LightType() != HdPrimTypeTokens->domeLight) {
+                    a->SetLightingOn(false);
+                }
             }
         },
         _lightAdapters);


### PR DESCRIPTION
Fix the dome light was turned off unexpectedly by https://github.com/Autodesk/maya-hydra/commit/96a722305c116ed1beb2060614777291aa89a770.

Note: there's another dome light issue logged as https://jira.autodesk.com/browse/HYDRA-794