### PR TITLE
Fix Broken Link

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Build:**
 * Report build and version information from the mayaHydra plugin [#10](https://github.com/Autodesk/maya-hydra/pull/10)
-* Hydra for Maya has now a new home under https://github.com/Autodesk.com/maya-hdyra
+* Hydra for Maya has now a new home under https://github.com/Autodesk/maya-hydra
 
 **Documentation:**
 * Rename docs mentioning Flow Viewport Library to Flow Viewport Toolkit [#11](https://github.com/Autodesk/maya-hydra/pull/11)


### PR DESCRIPTION
There is a broken link in the CHANGELOG.md. I have fixed it:

https://github.com/Autodesk.com/maya-hdyra --> https://github.com/Autodesk/maya-hydra

I found this links using a tool I created called [link-inspector](https://github.com/justindhillon/link-inspector). If you find this PR useful, give the repo a ⭐

I have also applied to the [Intern, Front End Developer](https://autodesk.wd1.myworkdayjobs.com/en-US/Ext/job/Intern--Front-End-Developer_24WD74757) position at your company. If you could put a word in for me, it would be greatly appreciated.