### PR TITLE
Adjust image diff fail percent for shading modes test

### DIFF
--- a/test/lib/mayaUsd/render/mayaToHydra/testMayaShadingModes.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/testMayaShadingModes.py
@@ -39,7 +39,7 @@ class TestMayaShadingModes(mtohUtils.MtohTestCase): #Subclassing mtohUtils.MtohT
         # for that platform specifically for now, so we can still catch issues on other platforms.
         if platform.system() == "Darwin":
             return 6.5
-        return 0.2
+        return 0.3
 
     def test_MayaShadingModes(self):
         


### PR DESCRIPTION
Seems like since MSAA was enabled this test can sometimes fail in preflights (Windows only it seems) due to a very minimal change along the wireframes. Possibly different Windows machines with different GPUs?