### PR TITLE
Add mayaHydra plugin commands to query CPU/GPU memory usage

### DIFF
--- a/lib/mayaHydra/hydraExtensions/mixedUtils.h
+++ b/lib/mayaHydra/hydraExtensions/mixedUtils.h
@@ -30,7 +30,61 @@
 #include <maya/MMatrix.h>
 #include <maya/MObject.h>
 
+#if defined(_WIN32)
+#include <windows.h>
+#include "psapi.h"
+#elif defined(__linux__)
+#include <fstream>
+#include <sstream>
+#elif defined(__APPLE__)
+#include <mach/task.h>
+#include <mach/mach.h>
+#endif
+
 namespace MAYAHYDRA_NS_DEF {
+
+constexpr int MB = 1024 * 1024;
+
+// Function to get memory usage of the current process
+MAYAHYDRALIB_API
+inline int getProcessMemory()
+{
+#if defined(_WIN32)
+    // see https://learn.microsoft.com/en-us/windows/win32/api/psapi/nf-psapi-getprocessmemoryinfo
+    PROCESS_MEMORY_COUNTERS_EX pmc;
+    GetProcessMemoryInfo(GetCurrentProcess(), (PROCESS_MEMORY_COUNTERS*)&pmc, sizeof(pmc));
+    return static_cast<int>(pmc.WorkingSetSize / MB); // Working Set Size in MB
+
+#elif defined(__linux__)
+    // https://man7.org/linux/man-pages/man5/proc.5.html
+    // When a process accesses this magic symbolic link, it
+    // resolves to the process's own /proc/pid directory.
+    std::ifstream processFile("/proc/self/status");
+    std::string line;
+    unsigned long long memoryUsage = 0;
+
+    while (std::getline(processFile, line)) {
+        if (line.compare(0, 6, "VmRSS:") == 0) {
+            std::istringstream iss(line.substr(7));
+            iss >> memoryUsage;
+            break;
+        }
+    }
+    return  static_cast<int>(memoryUsage / MB);
+    
+#elif defined(__APPLE__)
+    // https://developer.apple.com/documentation/kernel/1537934-task_info
+    task_vm_info_data_t vmInfo;
+    mach_msg_type_number_t count = TASK_VM_INFO_COUNT;
+    kern_return_t kernResult = task_info(mach_task_self(), TASK_VM_INFO, (task_info_t)&vmInfo, &count);
+
+    if (kernResult == KERN_SUCCESS) {
+        return static_cast<int>(vmInfo.phys_footprint / MB); // Physical footprint in MB
+    } else {
+        return 0; // Unable to retrieve memory usage
+    }
+#endif
+}
 
 /**
  * @brief Converts a Maya matrix to a double precision GfMatrix.

--- a/lib/mayaHydra/hydraExtensions/mixedUtils.h
+++ b/lib/mayaHydra/hydraExtensions/mixedUtils.h
@@ -53,7 +53,7 @@ inline int getProcessMemory()
     // see https://learn.microsoft.com/en-us/windows/win32/api/psapi/nf-psapi-getprocessmemoryinfo
     PROCESS_MEMORY_COUNTERS_EX pmc;
     GetProcessMemoryInfo(GetCurrentProcess(), (PROCESS_MEMORY_COUNTERS*)&pmc, sizeof(pmc));
-    return static_cast<int>(pmc.WorkingSetSize / MB); // Working Set Size in MB
+    return static_cast<int>(pmc.PrivateUsage / MB); // Working Set Size in MB
 
 #elif defined(__linux__)
     // https://man7.org/linux/man-pages/man5/proc.5.html
@@ -64,7 +64,7 @@ inline int getProcessMemory()
     unsigned long long memoryUsage = 0;
 
     while (std::getline(processFile, line)) {
-        if (line.compare(0, 6, "VmRSS:") == 0) {
+        if (line.compare(0, 6, "VmSize:") == 0) {
             std::istringstream iss(line.substr(7));
             iss >> memoryUsage;
             break;
@@ -79,7 +79,7 @@ inline int getProcessMemory()
     kern_return_t kernResult = task_info(mach_task_self(), TASK_VM_INFO, (task_info_t)&vmInfo, &count);
 
     if (kernResult == KERN_SUCCESS) {
-        return static_cast<int>(vmInfo.phys_footprint / MB); // Physical footprint in MB
+        return static_cast<int>(vmInfo.virtual_size / MB); // Physical footprint in MB
     } else {
         return 0; // Unable to retrieve memory usage
     }

--- a/lib/mayaHydra/mayaPlugin/renderOverride.cpp
+++ b/lib/mayaHydra/mayaPlugin/renderOverride.cpp
@@ -340,7 +340,7 @@ void MtohRenderOverride::UpdateRenderGlobals(
     MGlobal::executeCommandOnIdle("refresh -f");
 }
 
-VtValue MtohRenderOverride::_GetHdStGPUMemory() const
+VtValue MtohRenderOverride::_GetUsedGPUMemory() const
 {
     if (_isUsingHdSt && _renderDelegate)
     {
@@ -350,14 +350,14 @@ VtValue MtohRenderOverride::_GetHdStGPUMemory() const
     return VtValue();
 }
 
-int MtohRenderOverride::GetHdStGPUMemory()
+int MtohRenderOverride::GetUsedGPUMemory()
 {   
     int totalGPUMemory = 0;
     std::lock_guard<std::mutex> lock(_allInstancesMutex);
     for (auto* instance : _allInstances) {
-        totalGPUMemory += instance->_GetHdStGPUMemory().UncheckedGet<int>();
+        totalGPUMemory += instance->_GetUsedGPUMemory().UncheckedGet<int>();
     }
-    return totalGPUMemory; 
+    return totalGPUMemory / (1024*1024); 
 }
 
 std::vector<MString> MtohRenderOverride::AllActiveRendererNames()

--- a/lib/mayaHydra/mayaPlugin/renderOverride.cpp
+++ b/lib/mayaHydra/mayaPlugin/renderOverride.cpp
@@ -340,6 +340,26 @@ void MtohRenderOverride::UpdateRenderGlobals(
     MGlobal::executeCommandOnIdle("refresh -f");
 }
 
+VtValue MtohRenderOverride::_GetHdStGPUMemory() const
+{
+    if (_isUsingHdSt && _renderDelegate)
+    {
+        VtDictionary hdStRenderStat = _renderDelegate->GetRenderStats();
+        return hdStRenderStat[HdPerfTokens->gpuMemoryUsed.GetString()];
+    }
+    return VtValue();
+}
+
+int MtohRenderOverride::GetHdStGPUMemory()
+{   
+    int totalGPUMemory = 0;
+    std::lock_guard<std::mutex> lock(_allInstancesMutex);
+    for (auto* instance : _allInstances) {
+        totalGPUMemory += instance->_GetHdStGPUMemory().UncheckedGet<int>();
+    }
+    return totalGPUMemory; 
+}
+
 std::vector<MString> MtohRenderOverride::AllActiveRendererNames()
 {
     std::vector<MString> renderers;
@@ -720,7 +740,7 @@ MStatus MtohRenderOverride::Render(
     if (_mayaHydraSceneIndex) {
         _mayaHydraSceneIndex->PostFrame();
     }
-
+    
     return MStatus::kSuccess;
 }
 

--- a/lib/mayaHydra/mayaPlugin/renderOverride.cpp
+++ b/lib/mayaHydra/mayaPlugin/renderOverride.cpp
@@ -342,6 +342,8 @@ void MtohRenderOverride::UpdateRenderGlobals(
 
 VtValue MtohRenderOverride::_GetUsedGPUMemory() const
 {
+    // Currently, only Storm is the known/tested renderer that provides GPU stats
+    // via the Render Delegate.
     if (_isUsingHdSt && _renderDelegate)
     {
         VtDictionary hdStRenderStat = _renderDelegate->GetRenderStats();

--- a/lib/mayaHydra/mayaPlugin/renderOverride.h
+++ b/lib/mayaHydra/mayaPlugin/renderOverride.h
@@ -125,6 +125,9 @@ public:
     MStatus setup(const MString& destination) override;
     MStatus cleanup() override;
 
+    // Utility function to get HdStorm GPU memory usage stats
+    static int GetHdStGPUMemory();
+
     bool                         startOperationIterator() override;
     MHWRender::MRenderOperation* renderOperation() override;
     bool                         nextRenderOperation() override;
@@ -149,6 +152,7 @@ private:
     void              _ClearMayaHydraSceneIndex();
     void              _SetRenderPurposeTags(const MayaHydraParams& delegateParams);
     void              _CreateSceneIndicesChainAfterMergingSceneIndex();
+    VtValue           _GetHdStGPUMemory() const;
 
     void _PickByRegion(
         HdxPickHitVector& outHits,

--- a/lib/mayaHydra/mayaPlugin/renderOverride.h
+++ b/lib/mayaHydra/mayaPlugin/renderOverride.h
@@ -126,7 +126,7 @@ public:
     MStatus cleanup() override;
 
     // Utility function to get HdStorm GPU memory usage stats
-    static int GetHdStGPUMemory();
+    static int GetUsedGPUMemory();
 
     bool                         startOperationIterator() override;
     MHWRender::MRenderOperation* renderOperation() override;
@@ -152,7 +152,7 @@ private:
     void              _ClearMayaHydraSceneIndex();
     void              _SetRenderPurposeTags(const MayaHydraParams& delegateParams);
     void              _CreateSceneIndicesChainAfterMergingSceneIndex();
-    VtValue           _GetHdStGPUMemory() const;
+    VtValue           _GetUsedGPUMemory() const;
 
     void _PickByRegion(
         HdxPickHitVector& outHits,

--- a/lib/mayaHydra/mayaPlugin/renderOverride.h
+++ b/lib/mayaHydra/mayaPlugin/renderOverride.h
@@ -125,7 +125,7 @@ public:
     MStatus setup(const MString& destination) override;
     MStatus cleanup() override;
 
-    // Utility function to get HdStorm GPU memory usage stats
+    // Utility function to get GPU memory usage stats
     static int GetUsedGPUMemory();
 
     bool                         startOperationIterator() override;

--- a/lib/mayaHydra/mayaPlugin/viewCommand.cpp
+++ b/lib/mayaHydra/mayaPlugin/viewCommand.cpp
@@ -45,8 +45,8 @@ constexpr auto _listActiveRenderersLong = "-listActiveRenderers";
 constexpr auto _currentProcessMemory = "-cpm";
 constexpr auto _currentProcessMemoryLong = "-currentProcessMemory";
 
-constexpr auto _hdStGPUMem = "-hdm";
-constexpr auto _hdStGPUMemLong = "-hdStGPUMem";
+constexpr auto _hdGPUMem = "-hdm";
+constexpr auto _hdGPUMemLong = "-hdGPUMem";
 
 constexpr auto _getRendererDisplayName = "-gn";
 constexpr auto _getRendererDisplayNameLong = "-getRendererDisplayName";
@@ -148,7 +148,7 @@ MSyntax MtohViewCmd::createSyntax()
 
     syntax.addFlag(_currentProcessMemory, _currentProcessMemoryLong);
 
-    syntax.addFlag(_hdStGPUMem, _hdStGPUMemLong);
+    syntax.addFlag(_hdGPUMem, _hdGPUMemLong);
 
     syntax.addFlag(_getRendererDisplayName, _getRendererDisplayNameLong);
 
@@ -204,8 +204,8 @@ MStatus MtohViewCmd::doIt(const MArgList& args)
         }
     }
 
-    if (db.isFlagSet(_hdStGPUMem)) {
-        appendToResult(MtohRenderOverride::GetHdStGPUMemory());
+    if (db.isFlagSet(_hdGPUMem)) {
+        appendToResult(MtohRenderOverride::GetUsedGPUMemory());
     } if (db.isFlagSet(_currentProcessMemory)) {
         appendToResult(getProcessMemory());
     } else if (db.isFlagSet(_listRenderers)) {

--- a/lib/mayaHydra/mayaPlugin/viewCommand.cpp
+++ b/lib/mayaHydra/mayaPlugin/viewCommand.cpp
@@ -22,6 +22,7 @@
 
 #include <mayaHydraLib/mhBuildInfo.h>
 #include <mayaHydraLib/mayaHydra.h>
+#include <mayaHydraLib/mixedUtils.h>
 
 #include <maya/MArgDatabase.h>
 #include <maya/MGlobal.h>
@@ -40,6 +41,12 @@ constexpr auto _listRenderersLong = "-listRenderers";
 
 constexpr auto _listActiveRenderers = "-lar";
 constexpr auto _listActiveRenderersLong = "-listActiveRenderers";
+
+constexpr auto _currentProcessMemory = "-cpm";
+constexpr auto _currentProcessMemoryLong = "-currentProcessMemory";
+
+constexpr auto _hdStGPUMem = "-hdm";
+constexpr auto _hdStGPUMemLong = "-hdStGPUMem";
 
 constexpr auto _getRendererDisplayName = "-gn";
 constexpr auto _getRendererDisplayNameLong = "-getRendererDisplayName";
@@ -139,6 +146,10 @@ MSyntax MtohViewCmd::createSyntax()
 
     syntax.addFlag(_rendererId, _rendererIdLong, MSyntax::kString);
 
+    syntax.addFlag(_currentProcessMemory, _currentProcessMemoryLong);
+
+    syntax.addFlag(_hdStGPUMem, _hdStGPUMemLong);
+
     syntax.addFlag(_getRendererDisplayName, _getRendererDisplayNameLong);
 
     syntax.addFlag(_createRenderGlobals, _createRenderGlobalsLong);
@@ -193,7 +204,11 @@ MStatus MtohViewCmd::doIt(const MArgList& args)
         }
     }
 
-    if (db.isFlagSet(_listRenderers)) {
+    if (db.isFlagSet(_hdStGPUMem)) {
+        appendToResult(MtohRenderOverride::GetHdStGPUMemory());
+    } if (db.isFlagSet(_currentProcessMemory)) {
+        appendToResult(getProcessMemory());
+    } else if (db.isFlagSet(_listRenderers)) {
         for (auto& plugin : MtohGetRendererDescriptions())
             appendToResult(plugin.rendererName.GetText());
 


### PR DESCRIPTION
CPU and GPU usage can now be queried with mayaHydra using python commands when the plugin is loaded.


Sample usage:

```
import maya.cmds as cmds

cpuMem = cmds.mayaHydra(currentProcessMemory=1)
gpuMem = cmds.mayaHydra(hdGPUMem=1)
print("\nCPU Memory(MB): ", cpuMem[0])
print("\nGPU Memory(MB): ", gpuMem[0])
```