### PR TITLE
Fix coverage crashes in newly-added filtering scene indices.

### DIFF
--- a/lib/flowViewport/sceneIndex/fvpBBoxSceneIndex.cpp
+++ b/lib/flowViewport/sceneIndex/fvpBBoxSceneIndex.cpp
@@ -406,7 +406,7 @@ namespace
 
 HdSceneIndexPrim BboxSceneIndex::GetPrim(const SdfPath& primPath) const
 {
-    HdSceneIndexPrim prim = _GetInputSceneIndex()->GetPrim(primPath);
+    HdSceneIndexPrim prim = GetInputSceneIndex()->GetPrim(primPath);
     if (prim.dataSource && ((prim.primType == HdPrimTypeTokens->mesh) || (prim.primType == HdPrimTypeTokens->basisCurves)) ){
         prim.primType   = HdPrimTypeTokens->basisCurves;//Convert to basisCurve for displaying a bounding box
         prim.dataSource = _BoundsPrimDataSource::New(prim.dataSource);
@@ -420,7 +420,7 @@ void BboxSceneIndex::_PrimsAdded(const HdSceneIndexBase& sender, const HdSceneIn
     HdSceneIndexObserver::AddedPrimEntries newEntries;
     for (const HdSceneIndexObserver::AddedPrimEntry &entry : entries) {
         const SdfPath &path = entry.primPath;
-        HdSceneIndexPrim prim = _GetInputSceneIndex()->GetPrim(path);
+        HdSceneIndexPrim prim = GetInputSceneIndex()->GetPrim(path);
         if (prim.primType == HdPrimTypeTokens->mesh){
             newEntries.push_back({path, HdPrimTypeTokens->basisCurves});//Convert meshes to basisCurve to display a bounding box
         }else{

--- a/lib/flowViewport/sceneIndex/fvpBBoxSceneIndex.h
+++ b/lib/flowViewport/sceneIndex/fvpBBoxSceneIndex.h
@@ -18,6 +18,7 @@
 
 //Local headers
 #include "flowViewport/api.h"
+#include "flowViewport/sceneIndex/fvpSceneIndexUtils.h"
 
 //Hydra headers
 #include <pxr/base/tf/declarePtrs.h>
@@ -35,10 +36,10 @@ typedef PXR_NS::TfRefPtr<const BboxSceneIndex> BboxSceneIndexConstRefPtr;
 /// If the extent attribute is not present, it does not draw anything for that prim.
 ///
 class BboxSceneIndex : public PXR_NS::HdSingleInputFilteringSceneIndexBase
+    , public Fvp::InputSceneIndexUtils<BboxSceneIndex>
 {
 public:
     using ParentClass = PXR_NS::HdSingleInputFilteringSceneIndexBase;
-    using PXR_NS::HdSingleInputFilteringSceneIndexBase::_GetInputSceneIndex;
 
     FVP_API
     static BboxSceneIndexRefPtr New(const PXR_NS::HdSceneIndexBaseRefPtr& inputSceneIndex){
@@ -51,14 +52,14 @@ public:
     
     FVP_API
     PXR_NS::SdfPathVector GetChildPrimPaths(const PXR_NS::SdfPath& primPath) const override{
-        return _GetInputSceneIndex()->GetChildPrimPaths(primPath);
+        return GetInputSceneIndex()->GetChildPrimPaths(primPath);
     }
     
     FVP_API
     ~BboxSceneIndex() override = default;
 
 protected:
-    BboxSceneIndex(const PXR_NS::HdSceneIndexBaseRefPtr& inputSceneIndex) : ParentClass(inputSceneIndex) {};
+    BboxSceneIndex(const PXR_NS::HdSceneIndexBaseRefPtr& inputSceneIndex) : ParentClass(inputSceneIndex), InputSceneIndexUtils(inputSceneIndex) {};
 
     //From HdSingleInputFilteringSceneIndexBase
     void _PrimsAdded(const PXR_NS::HdSceneIndexBase& sender, const PXR_NS::HdSceneIndexObserver::AddedPrimEntries& entries) override;

--- a/lib/flowViewport/sceneIndex/fvpBBoxSceneIndex.h
+++ b/lib/flowViewport/sceneIndex/fvpBBoxSceneIndex.h
@@ -40,6 +40,7 @@ class BboxSceneIndex : public PXR_NS::HdSingleInputFilteringSceneIndexBase
 {
 public:
     using ParentClass = PXR_NS::HdSingleInputFilteringSceneIndexBase;
+    using PXR_NS::HdSingleInputFilteringSceneIndexBase::_GetInputSceneIndex;
 
     FVP_API
     static BboxSceneIndexRefPtr New(const PXR_NS::HdSceneIndexBaseRefPtr& inputSceneIndex){

--- a/lib/flowViewport/sceneIndex/fvpDisplayStyleOverrideSceneIndex.cpp
+++ b/lib/flowViewport/sceneIndex/fvpDisplayStyleOverrideSceneIndex.cpp
@@ -87,6 +87,7 @@ DisplayStyleOverrideSceneIndex::
 DisplayStyleOverrideSceneIndex(
     const HdSceneIndexBaseRefPtr &inputSceneIndex)
   : HdSingleInputFilteringSceneIndexBase(inputSceneIndex)
+  , InputSceneIndexUtils(inputSceneIndex)
   , _styleInfo(std::make_shared<_StyleInfo>())
   , _overlayDs(
       HdRetainedContainerDataSource::New(
@@ -99,7 +100,7 @@ HdSceneIndexPrim
 DisplayStyleOverrideSceneIndex::GetPrim(
     const SdfPath &primPath) const
 {
-    HdSceneIndexPrim prim = _GetInputSceneIndex()->GetPrim(primPath);
+    HdSceneIndexPrim prim = GetInputSceneIndex()->GetPrim(primPath);
     if (prim.dataSource) {
         if (!isExcluded(primPath) && prim.primType == HdPrimTypeTokens->mesh) {
             prim.dataSource =
@@ -114,7 +115,7 @@ SdfPathVector
 DisplayStyleOverrideSceneIndex::GetChildPrimPaths(
     const SdfPath &primPath) const
 {
-    return _GetInputSceneIndex()->GetChildPrimPaths(primPath);
+    return GetInputSceneIndex()->GetChildPrimPaths(primPath);
 }
 
 void
@@ -147,7 +148,7 @@ DisplayStyleOverrideSceneIndex::_DirtyAllPrims(
     }
 
     HdSceneIndexObserver::DirtiedPrimEntries entries;
-    for (const SdfPath &path : HdSceneIndexPrimView(_GetInputSceneIndex())) {
+    for (const SdfPath &path : HdSceneIndexPrimView(GetInputSceneIndex())) {
         entries.push_back({path, locators});
     }
 

--- a/lib/flowViewport/sceneIndex/fvpDisplayStyleOverrideSceneIndex.h
+++ b/lib/flowViewport/sceneIndex/fvpDisplayStyleOverrideSceneIndex.h
@@ -16,6 +16,7 @@
 #define FVP_DISPLAY_STYLE_OVERRIDE_SCENE_INDEX_H
 
 #include "flowViewport/api.h"
+#include "flowViewport/sceneIndex/fvpSceneIndexUtils.h"
 
 #include "pxr/imaging/hdsi/api.h"
 #include "pxr/imaging/hd/filteringSceneIndex.h"
@@ -41,6 +42,7 @@ typedef PXR_NS::TfRefPtr<const DisplayStyleOverrideSceneIndex> DisplayStyleOverr
 ///
 class DisplayStyleOverrideSceneIndex :
     public PXR_NS::HdSingleInputFilteringSceneIndexBase
+    , public Fvp::InputSceneIndexUtils<DisplayStyleOverrideSceneIndex>
 {
 public:
     FVP_API

--- a/lib/flowViewport/sceneIndex/fvpDisplayStyleOverrideSceneIndex.h
+++ b/lib/flowViewport/sceneIndex/fvpDisplayStyleOverrideSceneIndex.h
@@ -45,6 +45,8 @@ class DisplayStyleOverrideSceneIndex :
     , public Fvp::InputSceneIndexUtils<DisplayStyleOverrideSceneIndex>
 {
 public:
+    using PXR_NS::HdSingleInputFilteringSceneIndexBase::_GetInputSceneIndex;
+
     FVP_API
     static DisplayStyleOverrideSceneIndexRefPtr
     New(const PXR_NS::HdSceneIndexBaseRefPtr &inputSceneIndex);

--- a/test/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
+++ b/test/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
@@ -9,7 +9,6 @@ set(INTERACTIVE_TEST_SCRIPT_FILES
     testNamespaces.py
     testVisibility.py
     testRendererSwitching.py
-    testSceneBrowser.py
     testStageAddPrim.py
     testTransforms.py
     testRefinement.py
@@ -56,6 +55,11 @@ set(INTERACTIVE_TEST_SCRIPT_FILES
 if(MayaUsd_FOUND)
     list(APPEND INTERACTIVE_TEST_SCRIPT_FILES testMayaUsdAPIUsage.py)
 endif(MayaUsd_FOUND)
+
+# Code coverage is not computed for the Hydra scene browser.
+if (NOT CODE_COVERAGE)
+    list(APPEND INTERACTIVE_TEST_SCRIPT_FILES testSceneBrowser.py)
+endif()
 
 # Interactive Unit test scripts for mesh adapter (launched with maya.exe instead of mayapy.exe)
 # Test use of mesh adapter code for mesh support, using environment variable.


### PR DESCRIPTION
Coverage builds require a workaround for single input scene indices to access their input scene index.