### PR TITLE
HYDRA-553 : Fix for aiSkyDomeLight bugs

### DIFF
--- a/lib/mayaHydra/hydraExtensions/adapters/aiSkydomeLightAdapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/aiSkydomeLightAdapter.cpp
@@ -104,7 +104,8 @@ public:
 
         // We are not using precomputed attributes here, because we don't have
         // a guarantee that mtoa will be loaded before mayaHydra.
-        if (paramName == HdLightTokens->color) {
+        if (paramName == HdLightTokens->color ||
+            paramName == UsdLuxTokens->inputsColor) {
             const auto plug = light.findPlug("color", true);
             MPlugArray conns;
             plug.connectedTo(conns, true, false);
@@ -150,23 +151,29 @@ public:
                 }
             }
             return VtValue(GfVec3f(r,g,b));
-        } else if (paramName == HdLightTokens->intensity) {
+        } else if (paramName == HdLightTokens->intensity ||
+                   paramName == UsdLuxTokens->inputsIntensity) {
             return VtValue(light.findPlug("intensity", true).asFloat());
-        } else if (paramName == HdLightTokens->diffuse) {
+        } else if (paramName == HdLightTokens->diffuse ||
+                   paramName == UsdLuxTokens->inputsDiffuse) {
             MPlug aiDiffuse = light.findPlug("aiDiffuse", true, &status);
             if (status == MS::kSuccess) {
                 return VtValue(aiDiffuse.asFloat());
             }
-        } else if (paramName == HdLightTokens->specular) {
+        } else if (paramName == HdLightTokens->specular || 
+                   paramName == UsdLuxTokens->inputsSpecular) {
             MPlug aiSpecular = light.findPlug("aiSpecular", true, &status);
             if (status == MS::kSuccess) {
                 return VtValue(aiSpecular.asFloat());
             }
-        } else if (paramName == HdLightTokens->exposure) {
+        } else if (paramName == HdLightTokens->exposure ||
+                   paramName == UsdLuxTokens->inputsExposure) {
             return VtValue(light.findPlug("aiExposure", true).asFloat());
-        } else if (paramName == HdLightTokens->normalize) {
+        } else if (paramName == HdLightTokens->normalize ||
+                   paramName == UsdLuxTokens->inputsNormalize) {
             return VtValue(light.findPlug("aiNormalize", true).asBool());
-        } else if (paramName == HdLightTokens->textureFormat) {
+        } else if (paramName == HdLightTokens->textureFormat ||
+                   paramName == UsdLuxTokens->inputsTextureFormat) {
             const auto format = light.findPlug("format", true).asShort();
             // mirrored_ball : 0
             // angular : 1
@@ -178,7 +185,8 @@ public:
             } else {
                 return VtValue(UsdLuxTokens->automatic);
             }
-        } else if (paramName == HdLightTokens->textureFile) {
+        } else if (paramName == HdLightTokens->textureFile ||
+                   paramName == UsdLuxTokens->inputsTextureFile) {
             // Be aware that dome lights in HdStorm always need a texture to work correctly,
             // the color is not used if no texture is present. 
 
@@ -220,7 +228,8 @@ public:
             // SdfAssetPath requires both "path" "resolvedPath"
             return VtValue(SdfAssetPath(fileTextureName, fileTextureName));
 
-        } else if (paramName == HdLightTokens->enableColorTemperature) {
+        } else if (paramName == HdLightTokens->enableColorTemperature ||
+                   paramName == UsdLuxTokens->inputsEnableColorTemperature) {
             return VtValue(false);
         }
         return {};

--- a/lib/mayaHydra/hydraExtensions/adapters/renderItemAdapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/renderItemAdapter.cpp
@@ -154,19 +154,12 @@ void MayaHydraRenderItemAdapter::UpdateFromDelta(const UpdateFromDeltaData& data
         dirtyBits |= HdChangeTracker::DirtyPrimvar; // displayColor primVar
     }
 
-    const bool displayStatusChanged = (_displayStatus != data._displayStatus);
-    _displayStatus = data._displayStatus;
     const bool hideOnPlayback = data._ri.isHideOnPlayback();
     if (hideOnPlayback != _isHideOnPlayback) {
         _isHideOnPlayback = hideOnPlayback;
         dirtyBits |= HdChangeTracker::DirtyVisibility;
     }
 
-    //Special case for aiSkydomeLight which is visible only when it is selected
-    if (_isArnoldSkyDomeLightTriangleShape && displayStatusChanged){ 
-        SetVisible(IsRenderItemSelected());
-        dirtyBits |= HdChangeTracker::DirtyVisibility;
-    } else
     if (visibChanged) {
         SetVisible(visible);
         dirtyBits |= HdChangeTracker::DirtyVisibility;
@@ -521,12 +514,6 @@ void MayaHydraRenderItemAdapter::SetPlaybackChanged()
     if (_isHideOnPlayback) {
         MarkDirty(HdChangeTracker::DirtyVisibility);
     }
-}
-
-bool MayaHydraRenderItemAdapter::IsRenderItemSelected() const
-{ 
-    return  (MHWRender::DisplayStatus::kActive  == _displayStatus) || 
-            (MHWRender::DisplayStatus::kLead    == _displayStatus);
 }
 
 HdCullStyle MayaHydraRenderItemAdapter::GetCullStyle() const

--- a/lib/mayaHydra/hydraExtensions/adapters/renderItemAdapter.h
+++ b/lib/mayaHydra/hydraExtensions/adapters/renderItemAdapter.h
@@ -114,9 +114,6 @@ public:
     const MColor& GetWireframeColor() const { return _wireframeColor; }
 
     MAYAHYDRALIB_API
-    MHWRender::DisplayStatus GetDisplayStatus() const { return _displayStatus; }
-
-    MAYAHYDRALIB_API
     GfMatrix4d GetTransform() override { return _transform[0]; }
 
     MAYAHYDRALIB_API
@@ -139,19 +136,16 @@ public:
         UpdateFromDeltaData(
             MRenderItem&             ri,
             unsigned int             flags,
-            const MColor&            wireframeColor,
-            MHWRender::DisplayStatus displayStatus)
+            const MColor&            wireframeColor)
             : _ri(ri)
             , _flags(flags)
             , _wireframeColor(wireframeColor)
-            , _displayStatus(displayStatus)
         {
         }
 
         MRenderItem&             _ri;
         unsigned int             _flags;
         const MColor&            _wireframeColor;
-        MHWRender::DisplayStatus _displayStatus;
     };
 
     /// We receive in that function the changes made in the Maya viewport between the last frame
@@ -192,9 +186,6 @@ public:
     MAYAHYDRALIB_API
     bool GetIsRenderITemAnaiSkydomeLightTriangleShape() const {return _isArnoldSkyDomeLightTriangleShape;}
 
-    MAYAHYDRALIB_API
-    bool IsRenderItemSelected() const;
-
 private:
     MAYAHYDRALIB_API
     void _RemoveRprim();
@@ -216,7 +207,6 @@ private:
     bool                        _visible = false;
     MColor                      _wireframeColor = { 1.f, 1.f, 1.f, 1.f };
     bool                        _isHideOnPlayback = false;
-    MHWRender::DisplayStatus    _displayStatus = MHWRender::DisplayStatus::kNoStatus;
     bool                        _isArnoldSkyDomeLightTriangleShape = false;
     GfBBox3d                    _bounds;//Bounding box
 };


### PR DESCRIPTION
 This PR contain fixes for bugs with aiSkyDomeLight when using Arnold Render Delegate.

1. Fixes black renders when the dome light is selected: This was caused by a textureSkyDome mesh which is produced for VP2. It should not be translated to Hydra as it has it own mechanims to display dome light in the viewport.
2. Fixes light param updates not working: incorrect token were being compared.