### PR TITLE
Add convenience mayaHydra.h include to api.h

### DIFF
--- a/lib/mayaHydra/hydraExtensions/api.h
+++ b/lib/mayaHydra/hydraExtensions/api.h
@@ -37,4 +37,8 @@
 #endif
 #endif
 
+// Convenience symbol versioning include: because api.h is widely
+// included, this reduces the need to explicitly include mayaHydra.h.
+#include <mayaHydraLib/mayaHydra.h>
+
 #endif // MAYAHYDRALIB_API_H

--- a/lib/mayaHydra/hydraExtensions/hydraUtils.h
+++ b/lib/mayaHydra/hydraExtensions/hydraUtils.h
@@ -19,7 +19,6 @@
 #define MAYAHYDRALIB_HYDRA_UTILS_H
 
 #include <mayaHydraLib/api.h>
-#include <mayaHydraLib/mayaHydra.h>
 
 #include <pxr/base/gf/matrix4d.h>
 #include <pxr/base/gf/vec3f.h>

--- a/lib/mayaHydra/hydraExtensions/mayaUtils.h
+++ b/lib/mayaHydra/hydraExtensions/mayaUtils.h
@@ -18,7 +18,6 @@
 #define MAYAHYDRALIB_MAYA_UTILS_H
 
 #include <mayaHydraLib/api.h>
-#include <mayaHydraLib/mayaHydra.h>
 
 #include <maya/MApiNamespace.h>
 #include <maya/MFnDependencyNode.h>

--- a/lib/mayaHydra/hydraExtensions/mhLeadObjectPathTracker.h
+++ b/lib/mayaHydra/hydraExtensions/mhLeadObjectPathTracker.h
@@ -18,7 +18,6 @@
 
 //Local headers
 #include "mayaHydraLib/api.h"
-#include "mayaHydraLib/mayaHydra.h"
 #include "mayaHydraLib/sceneIndex/mhDirtyLeadObjectSceneIndex.h"
 
 //Flow viewport headers

--- a/lib/mayaHydra/hydraExtensions/mhWireframeColorInterfaceImp.h
+++ b/lib/mayaHydra/hydraExtensions/mhWireframeColorInterfaceImp.h
@@ -18,7 +18,6 @@
 
 //Local headers
 #include <mayaHydraLib/api.h>
-#include <mayaHydraLib/mayaHydra.h>
 #include <mayaHydraLib/mhLeadObjectPathTracker.h>
 
 //Flow viewport headers

--- a/lib/mayaHydra/hydraExtensions/mixedUtils.h
+++ b/lib/mayaHydra/hydraExtensions/mixedUtils.h
@@ -19,7 +19,6 @@
 #define MAYAHYDRALIB_MIXED_UTILS_H
 
 #include <mayaHydraLib/api.h>
-#include <mayaHydraLib/mayaHydra.h>
 
 #include <pxr/base/gf/matrix4d.h>
 #include <pxr/base/tf/token.h>

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraMayaDataProducerSceneIndexDataConcreteFactory.h
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraMayaDataProducerSceneIndexDataConcreteFactory.h
@@ -18,7 +18,6 @@
 
 //MayaHydra headers
 #include "mayaHydraLib/api.h"
-#include "mayaHydraLib/mayaHydra.h"
 
 //Flow Viewport headers
 #include <flowViewport/API/perViewportSceneIndicesData/fvpDataProducerSceneIndexDataAbstractFactory.h>

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraMayaFilteringSceneIndexDataConcreteFactory.h
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraMayaFilteringSceneIndexDataConcreteFactory.h
@@ -18,7 +18,6 @@
 
 //MayaHydra headers
 #include "mayaHydraLib/api.h"
-#include "mayaHydraLib/mayaHydra.h"
 
 //Flow Viewport headers
 #include "flowViewport/API/perViewportSceneIndicesData/fvpFilteringSceneIndexDataAbstractFactory.h"

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndexDataFactoriesSetup.h
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndexDataFactoriesSetup.h
@@ -18,7 +18,6 @@
 
 //Local headers
 #include "mayaHydraLib/api.h"
-#include "mayaHydraLib/mayaHydra.h"
 
 namespace MAYAHYDRA_NS_DEF{
 

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mhDirtyLeadObjectSceneIndex.h
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mhDirtyLeadObjectSceneIndex.h
@@ -18,7 +18,6 @@
 
 //MayaHydra headers
 #include "mayaHydraLib/api.h"
-#include "mayaHydraLib/mayaHydra.h"
 
 // Flow Viewport Toolkit headers.
 #include "flowViewport/sceneIndex/fvpSceneIndexUtils.h"

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mhMayaUsdProxyShapeSceneIndex.h
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mhMayaUsdProxyShapeSceneIndex.h
@@ -19,7 +19,6 @@
 #if defined(MAYAHYDRALIB_MAYAUSDAPI_ENABLED)
 //MayaHydra headers
 #include "mayaHydraLib/api.h"
-#include "mayaHydraLib/mayaHydra.h"
 
 //MayaUsdAPI headers
 #include <mayaUsdAPI/proxyStage.h>


### PR DESCRIPTION
Although conceptually unrelated, including mayaHydra.h in api.h cuts down on the number of boilterplate includes.  We already do this in the Flow Viewport Toolkit library.
