### PR TITLE
HYDRA-1070 - add missing space in resource path for Mac/Linux

### DIFF
--- a/modules/mayaHydra.mod.template
+++ b/modules/mayaHydra.mod.template
@@ -14,5 +14,5 @@ icons:
 plug-ins: lib/maya
 presets: 
 scripts: 
-resources:
+resources: 
 ${PXR_OVERRIDE_PLUGINPATH_NAME}+:=lib/usd


### PR DESCRIPTION
Add missing space in "resource" path for mayaHydra.mod on Mac/Linux, otherwise, the path of PXR_PLUGINPATH_NAME section won't be recognized correctly by Maya. 

This bug leads a problematic case below when deploying mayaHydra cut seperately from mayaUSD, 

1.When Maya is loading mayaHydra plugin, the mayaHydraLib from mayaHydra cut folder is loaded and some variables are initializaed and registered to usd (e.g., MAYAHYDRALIB_SCENE_INDEX) as it's a dependency of mayaHydra plugin.

2.When Maya is parsing the mayaHydra.mod and mayaUSD.mod, due to the bug, the path of mayaHydra registered usd plugins (MayaHydra_cut_folder/MayaHydra/lib/usd) inside mayaHydraLib couldn't be added to PXR_PLUGINPATH_NAME correctly, but the plugins path (MayaUSD_folder/MayaUSD/lib/usd) from mayaUSD.mod is added to PXR_PLUGINPATH_NAME correctly, which leads unexpected mayaHydraLib from mayaUSD folder is loaded again during the first calling of MayaHydraAdapterRegistry::LoadAllPlugin() after switch to Hydra Viewport, and introduced double initialization issue for some variables. Note this seems to be a legacy issue, but exposed recently by new USD version.

This also solved a legacy mysterious bug that can cause some error output msg like: // Error: Could not find plugin for 'MayaHydraLightAdapter', when mayaUSD cut (deployed without mayaHydra stuff) and mayaHydra cut seperately.
