### PR TITLE
HYDRA-1133 : Cmake changes pertaining to OneTBB update

### DIFF
--- a/cmake/modules/FindUSD.cmake
+++ b/cmake/modules/FindUSD.cmake
@@ -164,7 +164,7 @@ find_package_handle_standard_args(USD
         USD_VERSION
         PXR_VERSION
     VERSION_VAR
-        USD_VERSION 
+        USD_VERSION
 )
 
 find_program(OIIO_idiff_BINARY

--- a/cmake/modules/FindUSD.cmake
+++ b/cmake/modules/FindUSD.cmake
@@ -54,7 +54,7 @@ if(DEFINED PXR_VERSION)
     # there is no need to extract them from the pxr/pxr.h header file anymore.
     # The only thing we need to do is assemble the USD_VERSION version string.
     set(USD_VERSION ${PXR_MAJOR_VERSION}.${PXR_MINOR_VERSION}.${PXR_PATCH_VERSION})
-elseif(USD_INCLUDE_DIR AND EXISTS "${PXR_INCLUDE_DIR}/pxr/pxr.h")
+elseif(USD_INCLUDE_DIR AND EXISTS "${USD_INCLUDE_DIR}/pxr/pxr.h")
     foreach(_usd_comp MAJOR MINOR PATCH)
         file(STRINGS
             "${USD_INCLUDE_DIR}/pxr/pxr.h"
@@ -146,7 +146,8 @@ if (USD_LIBRARY_DIR AND EXISTS "${USD_LIBRARY_DIR}/${USD_LIB_PREFIX}usdMtlx${CMA
     endif()
 endif()
 
-message(STATUS "USD include dir: ${PXR_INCLUDE_DIR}")
+message(STATUS "USD include dir: ${USD_INCLUDE_DIR}")
+message(STATUS "USD library dir: ${USD_LIBRARY_DIR}")
 message(STATUS "USD version: ${USD_VERSION}")
 if(DEFINED USD_BOOST_VERSION)
     message(STATUS "USD Boost::boost version: ${USD_BOOST_VERSION}")
@@ -157,14 +158,13 @@ include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(USD
     REQUIRED_VARS
         PXR_USD_LOCATION
-        PXR_INCLUDE_DIR
-        USD_LIBRARY_DIR
+        USD_INCLUDE_DIR
         USD_GENSCHEMA
         USD_CONFIG_FILE
         USD_VERSION
         PXR_VERSION
     VERSION_VAR
-        USD_VERSION
+        USD_VERSION 
 )
 
 find_program(OIIO_idiff_BINARY

--- a/cmake/modules/FindUSD.cmake
+++ b/cmake/modules/FindUSD.cmake
@@ -54,7 +54,7 @@ if(DEFINED PXR_VERSION)
     # there is no need to extract them from the pxr/pxr.h header file anymore.
     # The only thing we need to do is assemble the USD_VERSION version string.
     set(USD_VERSION ${PXR_MAJOR_VERSION}.${PXR_MINOR_VERSION}.${PXR_PATCH_VERSION})
-elseif(USD_INCLUDE_DIR AND EXISTS "${USD_INCLUDE_DIR}/pxr/pxr.h")
+elseif(USD_INCLUDE_DIR AND EXISTS "${PXR_INCLUDE_DIR}/pxr/pxr.h")
     foreach(_usd_comp MAJOR MINOR PATCH)
         file(STRINGS
             "${USD_INCLUDE_DIR}/pxr/pxr.h"
@@ -146,8 +146,7 @@ if (USD_LIBRARY_DIR AND EXISTS "${USD_LIBRARY_DIR}/${USD_LIB_PREFIX}usdMtlx${CMA
     endif()
 endif()
 
-message(STATUS "USD include dir: ${USD_INCLUDE_DIR}")
-message(STATUS "USD library dir: ${USD_LIBRARY_DIR}")
+message(STATUS "USD include dir: ${PXR_INCLUDE_DIR}")
 message(STATUS "USD version: ${USD_VERSION}")
 if(DEFINED USD_BOOST_VERSION)
     message(STATUS "USD Boost::boost version: ${USD_BOOST_VERSION}")
@@ -158,7 +157,7 @@ include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(USD
     REQUIRED_VARS
         PXR_USD_LOCATION
-        USD_INCLUDE_DIR
+        PXR_INCLUDE_DIR
         USD_LIBRARY_DIR
         USD_GENSCHEMA
         USD_CONFIG_FILE

--- a/lib/mayaHydra/hydraExtensions/CMakeLists.txt
+++ b/lib/mayaHydra/hydraExtensions/CMakeLists.txt
@@ -56,8 +56,8 @@ target_include_directories(${TARGET_NAME}
 target_include_directories(${TARGET_NAME}
             PUBLIC
                 ${PYTHON_INCLUDE_DIR}
-                ${BOOST_INCLUDE_DIR}
-                ${PYTHON_INCLUDE_DIR}
+                ${BOOST_INCLUDE_DIR}               
+                ${CMAKE_BINARY_DIR}/include
             PRIVATE
                 $<$<BOOL:${UFE_FOUND}>:${UFE_INCLUDE_DIR}>
                 $<$<BOOL:${MayaUsd_FOUND}>:${MAYAUSD_INCLUDE_DIR}>

--- a/lib/mayaHydra/hydraExtensions/CMakeLists.txt
+++ b/lib/mayaHydra/hydraExtensions/CMakeLists.txt
@@ -51,10 +51,13 @@ mayaHydra_compile_config(${TARGET_NAME})
 target_include_directories(${TARGET_NAME} 
             SYSTEM PUBLIC
                 ${PXR_INCLUDE_DIRS}
-                ${PYTHON_INCLUDE_DIR}
                 ${MAYA_INCLUDE_DIRS}
+)
+target_include_directories(${TARGET_NAME}
+            PUBLIC
+                ${PYTHON_INCLUDE_DIR}
                 ${BOOST_INCLUDE_DIR}
-                ${CMAKE_BINARY_DIR}/include
+                ${PYTHON_INCLUDE_DIR}
             PRIVATE
                 $<$<BOOL:${UFE_FOUND}>:${UFE_INCLUDE_DIR}>
                 $<$<BOOL:${MayaUsd_FOUND}>:${MAYAUSD_INCLUDE_DIR}>

--- a/lib/mayaHydra/hydraExtensions/CMakeLists.txt
+++ b/lib/mayaHydra/hydraExtensions/CMakeLists.txt
@@ -49,10 +49,10 @@ mayaHydra_compile_config(${TARGET_NAME})
 # include directories
 # -----------------------------------------------------------------------------
 target_include_directories(${TARGET_NAME} 
-            PUBLIC
-                ${MAYA_INCLUDE_DIRS}
-                ${PYTHON_INCLUDE_DIR}
+            SYSTEM PUBLIC
                 ${PXR_INCLUDE_DIRS}
+                ${PYTHON_INCLUDE_DIR}
+                ${MAYA_INCLUDE_DIRS}
                 ${BOOST_INCLUDE_DIR}
                 ${CMAKE_BINARY_DIR}/include
             PRIVATE

--- a/lib/mayaHydra/ufeExtensions/CMakeLists.txt
+++ b/lib/mayaHydra/ufeExtensions/CMakeLists.txt
@@ -34,6 +34,11 @@ mayaHydra_compile_config(${TARGET_NAME})
 # -----------------------------------------------------------------------------
 target_include_directories(${TARGET_NAME} 
         PUBLIC
+            ${PXR_INCLUDE_DIRS}
+)
+
+target_include_directories(${TARGET_NAME} 
+        SYSTEM PUBLIC
             ${MAYA_INCLUDE_DIRS}
             ${CMAKE_BINARY_DIR}/include
             $<$<BOOL:${UFE_FOUND}>:${UFE_INCLUDE_DIR}>

--- a/lib/mayaHydra/ufeExtensions/CMakeLists.txt
+++ b/lib/mayaHydra/ufeExtensions/CMakeLists.txt
@@ -70,6 +70,7 @@ target_link_libraries(${TARGET_NAME}
         sdf
         tf
         usd
+        ${MAYA_LIBRARIES}
     PRIVATE
         $<$<BOOL:${UFE_FOUND}>:${UFE_LIBRARY}>
         $<$<BOOL:${USD_001905_BUILD}>:hio>

--- a/lib/mayaHydra/ufeExtensions/CMakeLists.txt
+++ b/lib/mayaHydra/ufeExtensions/CMakeLists.txt
@@ -70,7 +70,6 @@ target_link_libraries(${TARGET_NAME}
         sdf
         tf
         usd
-        ${MAYA_LIBRARIES}
     PRIVATE
         $<$<BOOL:${UFE_FOUND}>:${UFE_LIBRARY}>
         $<$<BOOL:${USD_001905_BUILD}>:hio>

--- a/plugin/mayaHydraSceneBrowser/CMakeLists.txt
+++ b/plugin/mayaHydraSceneBrowser/CMakeLists.txt
@@ -40,6 +40,7 @@ target_compile_definitions(${TARGET_NAME}
 # -----------------------------------------------------------------------------
 target_include_directories(${TARGET_NAME} 
     PUBLIC
+        ${PXR_INCLUDE_DIRS}
         ${MAYA_INCLUDE_DIRS}
 )
 

--- a/plugin/mayaHydraSceneBrowserTest/CMakeLists.txt
+++ b/plugin/mayaHydraSceneBrowserTest/CMakeLists.txt
@@ -25,8 +25,9 @@ mayaHydra_compile_config(${TARGET_NAME})
 # include directories
 # -----------------------------------------------------------------------------
 target_include_directories(${TARGET_NAME} 
-    PUBLIC
-        ${MAYA_INCLUDE_DIRS}
+            SYSTEM PUBLIC                
+                ${PXR_INCLUDE_DIRS}
+                ${MAYA_INCLUDE_DIRS}
 )
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
The following changes ensure maya-hydra picks up TBB from USD first instead of that from Maya. 