### PR TITLE
HYDRA-1131 : Fix selection being wiped when removing and re-adding prim

### DIFF
--- a/lib/flowViewport/sceneIndex/fvpSelectionSceneIndex.cpp
+++ b/lib/flowViewport/sceneIndex/fvpSelectionSceneIndex.cpp
@@ -324,12 +324,6 @@ SelectionSceneIndex::_PrimsRemoved(
     TF_DEBUG(FVP_SELECTION_SCENE_INDEX)
         .Msg("SelectionSceneIndex::_PrimsRemoved() called.\n");
 
-    if (!_selection->IsEmpty()) {
-        for (const auto &entry : entries) {
-            _selection->RemoveHierarchy(entry.primPath);
-        }
-    }
-
     _SendPrimsRemoved(entries);
 }
 

--- a/lib/flowViewport/selection/fvpSelection.cpp
+++ b/lib/flowViewport/selection/fvpSelection.cpp
@@ -87,14 +87,6 @@ void Selection::Replace(const PrimSelections& primSelections)
     }
 }
 
-void Selection::RemoveHierarchy(const PXR_NS::SdfPath& primPath)
-{
-    auto it = _pathToState.lower_bound(primPath);
-    while (it != _pathToState.end() && it->first.HasPrefix(primPath)) {
-        it = _pathToState.erase(it);
-    }
-}
-
 bool Selection::IsEmpty() const
 {
     return _pathToState.empty();

--- a/lib/flowViewport/selection/fvpSelection.h
+++ b/lib/flowViewport/selection/fvpSelection.h
@@ -60,10 +60,6 @@ public:
     FVP_API
     void Clear();
 
-    // Remove the argument and all descendants from the selection.
-    FVP_API
-    void RemoveHierarchy(const PXR_NS::SdfPath& primPath);
-
     FVP_API
     bool IsEmpty() const;
 

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testSelectionSceneIndex.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testSelectionSceneIndex.py
@@ -20,6 +20,7 @@ from testUtils import PluginLoaded
 class TestSelectionSceneIndex(mtohUtils.MayaHydraBaseTestCase):
     # MayaHydraBaseTestCase.setUpClass requirement.
     _file = __file__
+    _requiredPlugins = ['mayaHydraFlowViewportAPILocator']
 
     def setupScene(self):
         self.setHdStormRenderer()
@@ -31,6 +32,11 @@ class TestSelectionSceneIndex(mtohUtils.MayaHydraBaseTestCase):
         with PluginLoaded('mayaHydraCppTests'):
             cmds.mayaHydraCppTest(f="FlowViewport.selectionSceneIndex")
             cmds.mayaHydraCppTest(f="FlowViewport.selectionSceneIndexDirty")
+
+    def test_removeAndAddPrim(self):
+        cmds.createNode("MhFlowViewportAPILocator")
+        cmds.refresh()
+        self.runCppTest("FlowViewport.removeAndAddPrim")
 
 if __name__ == '__main__':
     fixturesUtils.runTests(globals())


### PR DESCRIPTION
The selection scene index stopped tracking a prim as selected when it was removed from the hierarchy. However, this means a removed and re-added prim was no longer marked as selected, and thus also had no highlight.