### PR TITLE
Revert cmake_minimum_required change change

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-cmake_minimum_required(VERSION 3.13...3.30)
+cmake_minimum_required(VERSION 3.13...3.17)
 
 project(maya-usd)
 

--- a/cmake/googletest.cmake
+++ b/cmake/googletest.cmake
@@ -26,7 +26,13 @@ macro(fetch_googletest)
         file(TO_CMAKE_PATH ${CMAKE_MAKE_PROGRAM} CMAKE_MAKE_PROGRAM)
 
         # Set some options used when compiling googletest.
-        set(CMAKE_CXX_STANDARD 11)
+
+        # USD updated to c++17 for USD v23.11
+        if(USD_VERSION VERSION_GREATER_EQUAL "0.23.11")
+            set(CMAKE_CXX_STANDARD 17)
+        else()
+            set(CMAKE_CXX_STANDARD 11)
+        endif()
         set(CMAKE_CXX_EXTENSIONS OFF)
         set(CMAKE_CXX_STANDARD_REQUIRED ON)
         if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")

--- a/doc/build.md
+++ b/doc/build.md
@@ -12,7 +12,7 @@ Before building the project, consult the following table to ensure you use the r
 |:---------------------:|:-------------------------:|:------------------------------------------------------------:|:---------------------------:|
 |    Operating System   |         Windows 10 <br> Windows 11 | High Sierra (10.13)<br>Mojave (10.14)<br>Catalina (10.15)<br>Big Sur (11.2.x)    |      Rocky Linux 8.6 / Linux® Red Hat® Enterprise 8.6 WS             |
 |   Compiler Requirement| Maya 2024 (VS 2022)<br>Maya 2025 (VS 2022) | Maya 2024 (Xcode 13.4 or higher)<br>Maya 2025 (Xcode 13.4 or higher) | Maya 2024 (gcc 11.2.1)<br>Maya 2025 (gcc 11.2.1) |
-| CMake Version (min/max) |        3.27.7...3.30      |                              3.27.7...3.30                     |           3.27.7...3.30       |
+| CMake Version (min/max) |        3.13...3.30      |                              3.13...3.30                     |           3.13...3.30       |
 |         Python        | 3.10.8, 3.11.4  |                       3.10.8, 3.11.4               |  3.10.8, 3.11.4   |
 |    Python Packages    | PyYAML, PySide, PyOpenGL        | PyYAML, PySide2, PyOpenGL              | PyYAML, PySide, PyOpenGL |
 |    Build generator    | Visual Studio, Ninja (Recommended)    |  XCode, Ninja (Recommended)                      |    Ninja (Recommended)      |


### PR DESCRIPTION
Per doc https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#policy-settings, the max version in call to cmake_minimum_required(VERSION <min>[...<policy_max>] [FATAL_ERROR]) is only for the polices. Change the policy will introduce other potential issues, so, revert the max version change and find an another way to solve the original issue.