### PR TITLE
HYDRA-973 - fix putenv not working on linux/mac

### DIFF
--- a/lib/mayaHydra/mayaPlugin/plugin.cpp
+++ b/lib/mayaHydra/mayaPlugin/plugin.cpp
@@ -70,14 +70,13 @@ namespace {
 
     std::vector<MCallbackId> _pluginLoadingCallbackIds;
 
-    void setEnvVar(const char* envVarSet)
+    void setEnv(const std::string& name, const std::string& value)
     {
-        // putenv requires char* and I'm not willing to use const cast!
-        const auto        envVarSize = strlen(envVarSet) + 1;
-        std::vector<char> envVarData;
-        envVarData.resize(envVarSize);
-        snprintf(envVarData.data(), envVarSize, "%s", envVarSet);
-        putenv(envVarData.data());
+    #if defined(_WIN32)
+    _putenv_s(name.c_str(), value.c_str());
+    #else
+    setenv(name.c_str(), value.c_str(), 1);
+    #endif
     }
 }
 
@@ -144,10 +143,10 @@ PLUGIN_EXPORT MStatus initializePlugin(MObject obj)
     }
 
     // For now this is required for the HdSt backend to use lights.
-    setEnvVar("USDIMAGING_ENABLE_SCENE_LIGHTS=1");
+    setEnv("USDIMAGING_ENABLE_SCENE_LIGHTS", "1");
 
     // Performance optimization: disable RENDER_SELECTED_EDGE_FROM_FACE feature that could trigger unnecessary running of gometry shader.
-    setEnvVar("HDST_RENDER_SELECTED_EDGE_FROM_FACE=0");
+    setEnv("HDST_RENDER_SELECTED_EDGE_FROM_FACE", "0");
 
     MFnPlugin plugin(obj, "Autodesk", PLUGIN_VERSION, "Any");
 


### PR DESCRIPTION
There's a legayc issue that leads the env var failed to be set, seems putenv is not working well on Linux/Mac, switch to user setenv().