### PR TITLE
HYDRA-1207 - fix and re-enable case testSceneBrowser

### DIFF
--- a/lib/adskHydraSceneBrowser/test/adskHydraSceneBrowserTestFixture.cpp
+++ b/lib/adskHydraSceneBrowser/test/adskHydraSceneBrowserTestFixture.cpp
@@ -257,7 +257,16 @@ void AdskHydraSceneBrowserTestFixture::CompareValueContent(const pxr::VtValue& v
     std::string actualValue = valueText.toStdString();
 
     std::ostringstream valueStream;
-    valueStream << value;
+    if (value.IsHolding<pxr::SdfPathVector>()) {
+        // Special case for SdfPathVector.
+        pxr::SdfPathVector paths = value.Get<pxr::SdfPathVector>();
+        for (pxr::SdfPath const& path : paths) {
+            valueStream << path << "\n";
+        }
+    }
+    else {
+        valueStream << value;
+    }
     std::string expectedValue = valueStream.str();
 
     if (!MatchesFallbackTextOutput(expectedValue)) {

--- a/lib/adskHydraSceneBrowser/test/adskHydraSceneBrowserTestFixture.cpp
+++ b/lib/adskHydraSceneBrowser/test/adskHydraSceneBrowserTestFixture.cpp
@@ -257,6 +257,9 @@ void AdskHydraSceneBrowserTestFixture::CompareValueContent(const pxr::VtValue& v
     std::string actualValue = valueText.toStdString();
 
     std::ostringstream valueStream;
+#if PXR_VERSION < 2408
+    valueStream << value;
+#else
     if (value.IsHolding<pxr::SdfPathVector>()) {
         // Special case for SdfPathVector.
         pxr::SdfPathVector paths = value.Get<pxr::SdfPathVector>();
@@ -267,6 +270,7 @@ void AdskHydraSceneBrowserTestFixture::CompareValueContent(const pxr::VtValue& v
     else {
         valueStream << value;
     }
+#endif
     std::string expectedValue = valueStream.str();
 
     if (!MatchesFallbackTextOutput(expectedValue)) {

--- a/lib/adskHydraSceneBrowser/test/adskHydraSceneBrowserTestFixture.cpp
+++ b/lib/adskHydraSceneBrowser/test/adskHydraSceneBrowserTestFixture.cpp
@@ -262,6 +262,7 @@ void AdskHydraSceneBrowserTestFixture::CompareValueContent(const pxr::VtValue& v
 #else
     if (value.IsHolding<pxr::SdfPathVector>()) {
         // Special case for SdfPathVector.
+        // See https://github.com/PixarAnimationStudios/OpenUSD/commit/1d19b1d
         pxr::SdfPathVector paths = value.Get<pxr::SdfPathVector>();
         for (pxr::SdfPath const& path : paths) {
             valueStream << path << "\n";

--- a/test/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
+++ b/test/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
@@ -94,8 +94,7 @@ endif(MayaUsd_FOUND)
 
 # Code coverage is not computed for the Hydra scene browser.
 if (NOT CODE_COVERAGE)
-    # To be reenabled after investigation: HYDRA-1207
-    #list(APPEND INTERACTIVE_TEST_SCRIPT_FILES testSceneBrowser.py)
+    list(APPEND INTERACTIVE_TEST_SCRIPT_FILES testSceneBrowser.py)
 endif()
 
 # Interactive Unit test scripts for mesh adapter (launched with maya.exe instead of mayapy.exe)


### PR DESCRIPTION
Adjust test code in sceneBrowser to make the case happy on SdfPathVector value to compensate the change in USD: https://github.com/PixarAnimationStudios/OpenUSD/commit/1d19b1dbdd0daf12247f5a1cb4b858c444e3e4fa#diff-8c7415891d45a3810ea025ac58c7e025043412150b628560c12a1b8fdbe1f830R57