### PR TITLE
Tremblp/hydra 1235/isolate select point instancing

### DIFF
--- a/lib/flowViewport/CMakeLists.txt
+++ b/lib/flowViewport/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(${TARGET_NAME}
     PRIVATE
         debugCodes.cpp
         fvpInstruments.cpp
+        fvpPrimUtils.cpp
         fvpUtils.cpp
         global.cpp
         tokens.cpp
@@ -18,6 +19,7 @@ set(HEADERS
     api.h
     debugCodes.h
     fvpInstruments.h
+    fvpPrimUtils.h
     fvpUtils.h
     global.h
     tokens.h

--- a/lib/flowViewport/fvpPrimUtils.cpp
+++ b/lib/flowViewport/fvpPrimUtils.cpp
@@ -1,0 +1,57 @@
+// Copyright 2024 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "fvpPrimUtils.h"
+
+#include <pxr/usd/sdf/path.h>
+#include <pxr/imaging/hd/tokens.h>
+#include <pxr/imaging/hd/instancerTopologySchema.h>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+namespace FVP_NS_DEF {
+
+bool isPointInstancer(
+    const HdSceneIndexBaseRefPtr& si,
+    const SdfPath&                primPath
+)
+{
+    return isPointInstancer(si->GetPrim(primPath));
+}
+
+bool isPointInstancer(const PXR_NS::HdSceneIndexPrim& prim)
+{
+    // If prim isn't an instancer, it can't be a point instancer.
+    if (prim.primType != HdPrimTypeTokens->instancer) {
+        return false;
+    }
+
+    HdInstancerTopologySchema instancerTopologySchema = HdInstancerTopologySchema::GetFromParent(prim.dataSource);
+
+    // Documentation
+    // https://github.com/PixarAnimationStudios/OpenUSD/blob/59992d2178afcebd89273759f2bddfe730e59aa8/pxr/imaging/hd/instancerTopologySchema.h#L86
+    // says that instanceLocations is only meaningful for native
+    // instancing, empty for point instancing.
+    auto instanceLocationsDs = instancerTopologySchema.GetInstanceLocations();
+    if (!instanceLocationsDs) {
+        return true;
+    }
+
+    auto instanceLocations = instanceLocationsDs->GetTypedValue(0.0f);
+
+    return (instanceLocations.size() > 0);
+}
+
+} // namespace FVP_NS_DEF

--- a/lib/flowViewport/fvpPrimUtils.h
+++ b/lib/flowViewport/fvpPrimUtils.h
@@ -1,0 +1,40 @@
+// Copyright 2024 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef FVP_PRIM_UTILS
+#define FVP_PRIM_UTILS
+
+#include <flowViewport/api.h>
+
+#include <pxr/pxr.h>
+#include <pxr/imaging/hd/sceneIndex.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+class SdfPath;
+PXR_NAMESPACE_CLOSE_SCOPE
+
+namespace FVP_NS_DEF {
+
+FVP_API
+bool isPointInstancer(
+    const PXR_NS::HdSceneIndexBaseRefPtr& si,
+    const PXR_NS::SdfPath&                primPath
+);
+
+FVP_API
+bool isPointInstancer(const PXR_NS::HdSceneIndexPrim& prim);
+
+} // namespace FVP_NS_DEF
+
+#endif // FVP_PRIM_UTILS

--- a/lib/flowViewport/sceneIndex/CMakeLists.txt
+++ b/lib/flowViewport/sceneIndex/CMakeLists.txt
@@ -3,6 +3,7 @@
 # -----------------------------------------------------------------------------
 target_sources(${TARGET_NAME}
     PRIVATE
+    fvpIsolateSelectSceneIndex.cpp
     fvpMergingSceneIndex.cpp
     fvpPathInterface.cpp
     fvpPathInterfaceSceneIndex.cpp
@@ -19,14 +20,8 @@ target_sources(${TARGET_NAME}
     fvpLightsManagementSceneIndex.cpp
 )
 
-if (MAYA_HAS_VIEW_SELECTED_OBJECT_API)
-    target_sources(${TARGET_NAME}
-        PRIVATE
-        fvpIsolateSelectSceneIndex.cpp
-    )
-endif()
-
 set(HEADERS
+    fvpIsolateSelectSceneIndex.h
     fvpMergingSceneIndex.h
     fvpPathInterface.h
     fvpPathInterfaceSceneIndex.h
@@ -43,12 +38,6 @@ set(HEADERS
     fvpDefaultMaterialSceneIndex.h
     fvpLightsManagementSceneIndex.h
 )
-
-if (MAYA_HAS_VIEW_SELECTED_OBJECT_API)
-    list(APPEND HEADERS
-        fvpIsolateSelectSceneIndex.h
-    )
-endif()
 
 # -----------------------------------------------------------------------------
 # promoted headers

--- a/lib/flowViewport/sceneIndex/CMakeLists.txt
+++ b/lib/flowViewport/sceneIndex/CMakeLists.txt
@@ -3,7 +3,6 @@
 # -----------------------------------------------------------------------------
 target_sources(${TARGET_NAME}
     PRIVATE
-    fvpIsolateSelectSceneIndex.cpp
     fvpMergingSceneIndex.cpp
     fvpPathInterface.cpp
     fvpPathInterfaceSceneIndex.cpp
@@ -16,12 +15,18 @@ target_sources(${TARGET_NAME}
     fvpBBoxSceneIndex.cpp
     fvpReprSelectorSceneIndex.cpp
     fvpBlockPrimRemovalPropagationSceneIndex.cpp
-	fvpDefaultMaterialSceneIndex.cpp
+    fvpDefaultMaterialSceneIndex.cpp
     fvpLightsManagementSceneIndex.cpp
 )
 
+if (MAYA_HAS_VIEW_SELECTED_OBJECT_API)
+    target_sources(${TARGET_NAME}
+        PRIVATE
+        fvpIsolateSelectSceneIndex.cpp
+    )
+endif()
+
 set(HEADERS
-    fvpIsolateSelectSceneIndex.h
     fvpMergingSceneIndex.h
     fvpPathInterface.h
     fvpPathInterfaceSceneIndex.h
@@ -35,9 +40,15 @@ set(HEADERS
     fvpBBoxSceneIndex.h
     fvpReprSelectorSceneIndex.h
     fvpBlockPrimRemovalPropagationSceneIndex.h
-	fvpDefaultMaterialSceneIndex.h
+    fvpDefaultMaterialSceneIndex.h
     fvpLightsManagementSceneIndex.h
 )
+
+if (MAYA_HAS_VIEW_SELECTED_OBJECT_API)
+    list(APPEND HEADERS
+        fvpIsolateSelectSceneIndex.h
+    )
+endif()
 
 # -----------------------------------------------------------------------------
 # promoted headers

--- a/lib/flowViewport/sceneIndex/fvpIsolateSelectSceneIndex.cpp
+++ b/lib/flowViewport/sceneIndex/fvpIsolateSelectSceneIndex.cpp
@@ -57,7 +57,15 @@ void append(Fvp::Selection& a, const Fvp::Selection& b)
     }
 }
 
-std::size_t getNbInstances(const HdInstancerTopologySchema& instancerTopologySchema)
+// Schema accessors were made const in USD 24.05 (specifically Hydra API
+// version 66).
+#if HD_API_VERSION >= 66
+#define CONST_SCHEMA const
+#else
+#define CONST_SCHEMA
+#endif
+
+std::size_t getNbInstances(CONST_SCHEMA HdInstancerTopologySchema& instancerTopologySchema)
 {
     // No easy way to get the number of instances created by a point instancer.
     // Count the total number of instances for all prototypes.  As per documentation

--- a/lib/flowViewport/sceneIndex/fvpIsolateSelectSceneIndex.h
+++ b/lib/flowViewport/sceneIndex/fvpIsolateSelectSceneIndex.h
@@ -205,6 +205,8 @@ private:
         PXR_NS::HdSceneIndexObserver::DirtiedPrimEntries* dirtiedEntries
     ) const;    
 
+    bool _IsPointInstancer(const PXR_NS::SdfPath& primPath) const;
+
     std::string  _viewportId;
 
     SelectionPtr _isolateSelection{};

--- a/lib/flowViewport/sceneIndex/fvpIsolateSelectSceneIndex.h
+++ b/lib/flowViewport/sceneIndex/fvpIsolateSelectSceneIndex.h
@@ -205,8 +205,6 @@ private:
         PXR_NS::HdSceneIndexObserver::DirtiedPrimEntries* dirtiedEntries
     ) const;    
 
-    bool _IsPointInstancer(const PXR_NS::SdfPath& primPath) const;
-
     std::string  _viewportId;
 
     SelectionPtr _isolateSelection{};

--- a/lib/flowViewport/selection/fvpSelection.cpp
+++ b/lib/flowViewport/selection/fvpSelection.cpp
@@ -259,6 +259,12 @@ HdDataSourceBaseHandle Selection::GetVectorDataSource(
     );
 }
 
+PrimSelections Selection::GetPrimSelections(const PXR_NS::SdfPath& primPath) const
+{
+    auto it = _pathToSelections.find(primPath);
+    return (it == _pathToSelections.end()) ? PrimSelections() : it->second;
+}
+
 Selection::PrimSelectionsMap::const_iterator Selection::begin() const
 {
     return _pathToSelections.begin();

--- a/lib/flowViewport/selection/fvpSelection.h
+++ b/lib/flowViewport/selection/fvpSelection.h
@@ -111,6 +111,9 @@ public:
     PXR_NS::HdDataSourceBaseHandle
     GetVectorDataSource(const PXR_NS::SdfPath& primPath) const;
 
+    FVP_API
+    PrimSelections GetPrimSelections(const PXR_NS::SdfPath& primPath) const;
+
     PrimSelectionsMap::const_iterator begin() const;
     PrimSelectionsMap::const_iterator end() const;
 

--- a/test/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
+++ b/test/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
@@ -87,6 +87,7 @@ if (MAYA_HAS_VIEW_SELECTED_OBJECT_API)
     list(APPEND INTERACTIVE_TEST_SCRIPT_FILES
         cpp/testIsolateSelect.py
         cpp/testUsdNativeInstancingIsolateSelect.py
+        cpp/testUsdPointInstancingIsolateSelect.py
     )
 endif()
 

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/CMakeLists.txt
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/CMakeLists.txt
@@ -20,7 +20,6 @@ target_sources(${TARGET_NAME}
         testColorPreferences.cpp
         testCppFramework.cpp
         testHydraPrim.cpp
-        testIsolateSelect.cpp
         testMayaSceneFlattening.cpp
         testMayaUsdUfeItems.cpp
         testMergingSceneIndex.cpp
@@ -49,6 +48,13 @@ target_sources(${TARGET_NAME}
         testSceneIndexDirtying.cpp
         testGeomSubsetsWireframeHighlight.cpp
 )
+
+if (MAYA_HAS_VIEW_SELECTED_OBJECT_API)
+    target_sources(${TARGET_NAME}
+        PRIVATE
+        testIsolateSelect.cpp
+    )
+endif()
 
 # -----------------------------------------------------------------------------
 # compiler configuration

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testUsdPointInstancingIsolateSelect.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testUsdPointInstancingIsolateSelect.py
@@ -16,7 +16,6 @@
 import fixturesUtils
 import mtohUtils
 import mayaUsd
-import mayaUsd_createStageWithNewLayer
 import maya.cmds as cmds
 import maya.mel as mel
 import usdUtils

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testUsdPointInstancingIsolateSelect.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testUsdPointInstancingIsolateSelect.py
@@ -1,0 +1,249 @@
+# Copyright 2024 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import fixturesUtils
+import mtohUtils
+import mayaUsd
+import mayaUsd_createStageWithNewLayer
+import maya.cmds as cmds
+import maya.mel as mel
+import usdUtils
+from pxr import UsdGeom
+import testUtils
+
+def enableIsolateSelect(modelPanel):
+    # Surprisingly
+    # 
+    # cmds.isolateSelect('modelPanel1', state=1)
+    # 
+    # is insufficient to turn on isolate selection in a viewport, and we must
+    # use the MEL script used by the menu and Ctrl-1 hotkey.  This is because
+    # the viewport uses the selectionConnection command to filter the selection
+    # it receives and create its isolate selection, and the the
+    # mainListConnection, lockMainConnection and unlockMainConnection flags of
+    # the editor command to suspend changes to its selection connection.  See
+    # the documentation for more details.
+    cmds.setFocus(modelPanel)
+    mel.eval("enableIsolateSelect %s 1" % modelPanel)
+    
+def disableIsolateSelect(modelPanel):
+    cmds.setFocus(modelPanel)
+    mel.eval("enableIsolateSelect %s 0" % modelPanel)
+
+# This test is identical to the one in testIsolateSelect.py, except for
+# disabled tests.  See HYDRA-1245.
+
+class TestUsdPointInstancingIsolateSelect(mtohUtils.MayaHydraBaseTestCase):
+    # MayaHydraBaseTestCase.setUpClass requirement.
+    _file = __file__
+
+    # Base class setUp() defines HdStorm as the renderer.
+
+    _pluginsToLoad = ['mayaHydraCppTests', 'mayaHydraFlowViewportAPILocator']
+    _pluginsToUnload = []
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestUsdPointInstancingIsolateSelect, cls).setUpClass()
+        for p in cls._pluginsToLoad:
+            if not cmds.pluginInfo(p, q=True, loaded=True):
+                cls._pluginsToUnload.append(p)
+                cmds.loadPlugin(p, quiet=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TestUsdPointInstancingIsolateSelect, cls).tearDownClass()
+        # Clean out the scene to allow all plugins to unload cleanly.
+        cmds.file(new=True, force=True)
+        for p in reversed(cls._pluginsToUnload):
+            if p != 'mayaHydraFlowViewportAPILocator':
+                cmds.unloadPlugin(p)
+
+    def setupScene(self):
+
+        # Read in a scene with native instancing.
+        usdScenePath = testUtils.getTestScene('testUsdNativeInstances', 'instancedCubeHierarchies.usda')
+
+        self.proxyShapePathStr = usdUtils.createStageFromFile(usdScenePath)
+
+        stage = mayaUsd.lib.GetPrim(self.proxyShapePathStr).GetStage()
+
+        # Add in non-instanced USD prims.
+        stage.DefinePrim('/parent1', 'Xform')
+        stage.DefinePrim('/parent2', 'Xform')
+
+        cylinder1 = UsdGeom.Cylinder.Define(stage, "/parent1/cylinder1")
+        cone1 = UsdGeom.Cone.Define(stage, "/parent2/cone1")
+        sphere1 = UsdGeom.Sphere.Define(stage, "/parent2/sphere1")
+
+        # Add in a point instancer and its point instances.
+        ref = stage.DefinePrim('/ref')
+        piScenePath = testUtils.getTestScene('testUsdPointInstances', 'pointInstancer.usda')
+        ref.GetReferences().AddReference(str(piScenePath))
+        self.pointInstancerPath = self.proxyShapePathStr + ',/ref/CubePointInstancer'
+
+        # Move objects around so that snapshot comparison is significant.
+
+        # Move USD objects.  Can also use undoable Maya cmds.move(), but using
+        # the USD APIs is simpler.
+        cylinder1.AddTranslateOp().Set(value=(0, 2, 0))
+        cone1.AddTranslateOp().Set(value=(2, 0, 0))
+        sphere1.AddTranslateOp().Set(value=(-2, 0, 0))
+        xformRef = UsdGeom.Xformable(ref)
+        xformRef.AddTranslateOp().Set(value=(0, 0, -2))
+
+        cmds.polyTorus()
+        cmds.polySphere()
+        cmds.move(2, 0, 0, r=True)
+        cmds.polyCube()
+        cmds.move(-2, 0, 0, r=True)
+        cmds.polyCone()
+        cmds.group('pSphere1', 'pCube1')
+        cmds.move(0, 0, 2, r=True)
+        cmds.group('pCone1')
+        cmds.move(0, 0, 2, r=True)
+
+        # Add a Hydra-only data producer.
+        cmds.createNode("MhFlowViewportAPILocator")
+        self.cubeGenPath = '|transform1|MhFlowViewportAPILocator1'
+        cmds.setAttr("MhFlowViewportAPILocator1.numCubesX", 2)
+        cmds.setAttr("MhFlowViewportAPILocator1.numCubesY", 2)
+        cmds.setAttr("MhFlowViewportAPILocator1.cubeHalfSize", 0.25)
+        cmds.setAttr("MhFlowViewportAPILocator1.cubesDeltaTrans", 1, 1, 1)
+
+        cmds.move(0, 0, 4, "transform1", r=True)
+
+        cmds.refresh()
+
+        scene = [
+            # Maya objects
+            '|pTorus1', 
+            '|pTorus1|pTorusShape1', 
+            '|group1',
+            '|group1|pSphere1',
+            '|group1|pSphere1|pSphereShape1',
+            '|group1|pCube1',
+            '|group1|pCube1|pCubeShape1',
+            '|group2',
+            '|group2|pCone1',
+            '|group2|pCone1|pConeShape1',
+            # Non-instanced USD objects
+            self.proxyShapePathStr + ',/parent1',
+            self.proxyShapePathStr + ',/parent1/cylinder1',
+            self.proxyShapePathStr + ',/parent2',
+            self.proxyShapePathStr + ',/parent2/cone1',
+            self.proxyShapePathStr + ',/parent2/sphere1',
+            # Native instanced USD objects
+            self.proxyShapePathStr + ',/cubeHierarchies/cubes_1',
+            self.proxyShapePathStr + ',/cubeHierarchies/cubes_2',
+            # USD point instancer
+            self.pointInstancerPath,
+            # Flow Viewport API procedural cube generator.
+            self.cubeGenPath]
+
+        # Cube generator cubes
+        for i in range(0, 2):
+            for j in range(0, 2):
+                scene.append(self.cubeGenPath + (',/cube_%s_%s_0' % (i, j)))
+
+        # Point instances
+        for i in range(0, 14):
+            scene.append(self.pointInstancerPath + ('/%s' % i))
+
+        return scene
+
+    def assertVisible(self, visible):
+        for v in visible:
+            self.trace("Testing %s for visibility\n" % v)
+            cmds.mayaHydraCppTest(v, f="TestHydraPrim.isVisible")
+
+    def assertNotVisible(self, notVisible):
+        for nv in notVisible:
+            self.trace("Testing %s for invisibility\n" % nv)
+            cmds.mayaHydraCppTest(nv, f="TestHydraPrim.notVisible")
+
+    def assertVisibility(self, visible, notVisible):
+        self.assertVisible(visible)
+        self.assertNotVisible(notVisible)
+
+    def assertIsolateSelect(self, modelPanel, visible, scene):
+        cmds.select(*visible)
+        cmds.editor(modelPanel, edit=True, updateMainConnection=True)
+        cmds.isolateSelect(modelPanel, loadSelected=True)
+
+        notVisible = scene.copy()
+
+        for p in visible:
+            notVisible.remove(p)
+
+        cmds.refresh()
+
+        self.assertVisibility(visible, notVisible)
+
+    def test_isolateSelectPointInstancing(self):
+
+        scene = self.setupScene()
+
+        cmds.select(clear=True)
+
+        # Isolate select not turned on, everything visible.
+        visible = scene
+        notVisible = []
+
+        cmds.refresh()
+
+        self.assertVisibility(visible, notVisible)
+
+        # Turn isolate select on, nothing selected, nothing visible.
+        visible = []
+        notVisible = scene
+
+        modelPanel = 'modelPanel4'
+        enableIsolateSelect(modelPanel)
+        
+        cmds.refresh()
+
+        self.assertVisibility(visible, notVisible)
+
+        # Select various point instances.  The instancer itself will be visible,
+        # everything else not visible.
+        visible = [
+            self.pointInstancerPath,        self.pointInstancerPath + '/0',
+            self.pointInstancerPath + '/3', self.pointInstancerPath + '/12']
+        self.assertIsolateSelect(modelPanel, visible, scene)
+
+        # Add in some Maya objects, a non-instanced USD object, a native
+        # instanced USD object, and a generated cube.
+        visible = [
+            # Point instanced USD objects
+            self.pointInstancerPath,        self.pointInstancerPath + '/0',
+            self.pointInstancerPath + '/3', self.pointInstancerPath + '/12',
+            # Maya objects
+            '|pTorus1', '|pTorus1|pTorusShape1', '|group2', '|group2|pCone1',
+            '|group2|pCone1|pConeShape1',
+            # Non-instanced USD object
+            self.proxyShapePathStr + ',/parent1',
+            self.proxyShapePathStr + ',/parent1/cylinder1',
+            # Native instanced USD object
+            self.proxyShapePathStr + ',/cubeHierarchies/cubes_1',
+            # Generated cube
+            self.cubeGenPath + ',/cube_0_0_0']
+
+        self.assertIsolateSelect(modelPanel, visible, scene)
+
+        disableIsolateSelect(modelPanel)
+
+if __name__ == '__main__':
+    fixturesUtils.runTests(globals())

--- a/test/testSamples/testUsdPointInstances/pointInstancer.usda
+++ b/test/testSamples/testUsdPointInstances/pointInstancer.usda
@@ -1,0 +1,93 @@
+#usda 1.0
+(
+    defaultPrim = "Root"
+    metersPerUnit = 0.01
+    upAxis = "Z"
+)
+
+def Xform "Root"
+{
+    def PointInstancer "CubePointInstancer" (
+    )
+    {
+        float3[] extent = [(-5, -0.5, -0.5), (5, 2, 0.5)]
+        point3f[] positions = [(-4.5, 0, 0), (-3, 0, 0), (-1.5, 0, 0), (0, 0, 0), (1.5, 0, 0), (3, 0, 0), (4.5, 0, 0), (-4.5, 1.5, 0), (-3, 1.5, 0), (-1.5, 1.5, 0), (0, 1.5, 0), (1.5, 1.5, 0), (3, 1.5, 0), (4.5, 1.5, 0)]
+        int[] protoIndices = [0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3, 4, 5, 6]
+        rel prototypes = [
+            </Root/CubePointInstancer/prototypes/RedCube>,
+            </Root/CubePointInstancer/prototypes/OrangeCube>,
+            </Root/CubePointInstancer/prototypes/YellowCube>,
+            </Root/CubePointInstancer/prototypes/GreenCube>,
+            </Root/CubePointInstancer/prototypes/BlueCube>,
+            </Root/CubePointInstancer/prototypes/IndigoCube>,
+            </Root/CubePointInstancer/prototypes/VioletCube>,
+        ]
+
+        def "prototypes" (
+        )
+        {
+            def "BlueCube" (
+                prepend references = @./CubeModel.usda@
+                variants = {
+                    string shadingVariant = "Blue"
+                }
+            )
+            {
+            }
+
+            def "GreenCube" (
+                prepend references = @./CubeModel.usda@
+                variants = {
+                    string shadingVariant = "Green"
+                }
+            )
+            {
+            }
+
+            def "IndigoCube" (
+                prepend references = @./CubeModel.usda@
+                variants = {
+                    string shadingVariant = "Indigo"
+                }
+            )
+            {
+            }
+
+            def "OrangeCube" (
+                prepend references = @./CubeModel.usda@
+                variants = {
+                    string shadingVariant = "Orange"
+                }
+            )
+            {
+            }
+
+            def "RedCube" (
+                prepend references = @./CubeModel.usda@
+                variants = {
+                    string shadingVariant = "Red"
+                }
+            )
+            {
+            }
+
+            def "VioletCube" (
+                prepend references = @./CubeModel.usda@
+                variants = {
+                    string shadingVariant = "Violet"
+                }
+            )
+            {
+            }
+
+            def "YellowCube" (
+                prepend references = @./CubeModel.usda@
+                variants = {
+                    string shadingVariant = "Yellow"
+                }
+            )
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Point instancing isolate select support. Nested point instancing isolate select support deferred, as there is no clear immediate use case for it: selecting a nested instance does not mean you can change it.

Code is still in rough shape, with a lot of duplication and conditionals, to be cleaned up in a later pull request.
