### PR TITLE
Added cleanup code such that all code coverage run tests pass.

### DIFF
--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
@@ -534,6 +534,11 @@ MayaHydraSceneIndex::MayaHydraSceneIndex(
 
 MayaHydraSceneIndex::~MayaHydraSceneIndex()
 {
+    _Destroy();
+}
+
+void MayaHydraSceneIndex::_Destroy()
+{
     //Remove global materials
     if (_mayaDefaultMaterialFallback.IsHolding<HdMaterialNetworkMap>()){
         //Remove the fallback material in case it was created

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.h
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.h
@@ -299,6 +299,12 @@ private:
         const SdfPath&          id,
         HdDirtyBits             dirtyBits,
         DirtyBitsToLocatorsFunc dirtyBitsToLocatorsFunc);
+
+#ifdef CODE_COVERAGE_WORKAROUND
+    friend class MtohRenderOverride;
+#endif
+    void _Destroy();
+
 private:
     // ------------------------------------------------------------------------
     // HdSceneIndexBase implementations

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mhMayaUsdProxyShapeSceneIndex.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mhMayaUsdProxyShapeSceneIndex.cpp
@@ -56,6 +56,11 @@ MayaUsdProxyShapeSceneIndex::MayaUsdProxyShapeSceneIndex(
 
 MayaUsdProxyShapeSceneIndex::~MayaUsdProxyShapeSceneIndex()
 {
+    _Destroy();
+}
+
+void MayaUsdProxyShapeSceneIndex::_Destroy()
+{
     TfNotice::Revoke(_stageSetNoticeKey);
     TfNotice::Revoke(_stageInvalidateNoticeKey);
     TfNotice::Revoke(_objectsChangedNoticeKey);

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mhMayaUsdProxyShapeSceneIndex.h
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mhMayaUsdProxyShapeSceneIndex.h
@@ -99,6 +99,11 @@ public:
         _SendPrimsDirtied(entries);
     }
 
+#ifndef CODE_COVERAGE_WORKAROUND
+private:
+#endif
+    void _Destroy();
+
 private:
     void _ObjectsChanged(const MAYAUSDAPI_NS::ProxyStageObjectsChangedNotice& notice);
     void _StageSet(const MAYAUSDAPI_NS::ProxyStageSetNotice& notice);

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/registration.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/registration.cpp
@@ -58,6 +58,10 @@
 
 #include <optional>
 
+PXR_NAMESPACE_OPEN_SCOPE
+struct MayaUsdSceneIndexRegistration;
+PXR_NAMESPACE_CLOSE_SCOPE
+
 namespace {
 
 const std::string digits = "0123456789";
@@ -90,6 +94,9 @@ private:
         }
     }
 };
+
+class PathInterfaceSceneIndex;
+typedef TfRefPtr<PathInterfaceSceneIndex> PathInterfaceSceneIndexRefPtr;
 
 /// \class PathInterfaceSceneIndex
 ///
@@ -306,6 +313,14 @@ private:
     }
 
     ~PathInterfaceSceneIndex() {
+        Destroy();
+    }
+
+#ifdef CODE_COVERAGE_WORKAROUND
+    friend struct PXR_NS::MayaUsdSceneIndexRegistration;
+#endif
+
+    void Destroy() {
         // Unregister our path mapper.
         TF_AXIOM(Fvp::PathMapperRegistry::Instance().Unregister(
                      _sceneIndexAppPath));
@@ -339,6 +354,18 @@ struct MayaUsdSceneIndexRegistration : public MayaHydraSceneIndexRegistration
         auto proxyShapeSceneIndex = TfDynamic_cast<MayaUsdProxyShapeSceneIndexRefPtr>(pluginSceneIndex);
         proxyShapeSceneIndex->UpdateTime();
     }
+
+#ifdef CODE_COVERAGE_WORKAROUND
+    void Destroy() override {
+        auto proxyShapeSceneIndex = TfDynamic_cast<MayaUsdProxyShapeSceneIndexRefPtr>(pluginSceneIndex);
+        proxyShapeSceneIndex->_Destroy();
+
+        auto pathInterfaceSceneIndex = TfDynamic_cast<PathInterfaceSceneIndexRefPtr>(rootSceneIndex);
+        if (pathInterfaceSceneIndex) {
+            pathInterfaceSceneIndex->Destroy();
+        }
+    }
+#endif
 };
 
 // MayaHydraSceneIndexRegistration is used to register a scene index for
@@ -440,6 +467,7 @@ bool MayaHydraSceneIndexRegistry::_RemoveSceneIndexForNode(const MObject& dagNod
         _registrationsByObjectHandle.erase(dagNodeHandle);
         _registrations.erase(registration->sceneIndexPathPrefix);
 #ifdef CODE_COVERAGE_WORKAROUND
+        registration->Destroy();
         Fvp::leakSceneIndex(registration->rootSceneIndex);
 #endif
         return true;

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/registration.h
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/registration.h
@@ -61,6 +61,9 @@ struct MayaHydraSceneIndexRegistration
     MayaHydraInterpretRprimPath interpretRprimPathFn = nullptr;
 
     virtual void Update() = 0;
+#ifdef CODE_COVERAGE_WORKAROUND
+    virtual void Destroy() = 0;
+#endif
 };
 
 /**

--- a/lib/mayaHydra/mayaPlugin/renderOverride.cpp
+++ b/lib/mayaHydra/mayaPlugin/renderOverride.cpp
@@ -1008,7 +1008,13 @@ void MtohRenderOverride::_SetRenderPurposeTags(const MayaHydraParams& delegatePa
 
 void MtohRenderOverride::_ClearMayaHydraSceneIndex()
 {
+#ifdef CODE_COVERAGE_WORKAROUND
+    // Leak the Maya scene index for code coverage, as its base class
+    // HdRetainedSceneIndex dtor crashes in Windows clang code coverage build.
+    _mayaHydraSceneIndex->_Destroy();
+#else
     _renderIndexProxy->RemoveSceneIndex(_mayaHydraSceneIndex);
+#endif
     _mayaHydraSceneIndex.Reset();
 }
 
@@ -1145,13 +1151,7 @@ void MtohRenderOverride::ClearHydraResources(bool fullReset)
     // Remove the scene index registry
     _sceneIndexRegistry.reset();
 
-    #ifdef CODE_COVERAGE_WORKAROUND
-        // Leak the Maya scene index, as its base class HdRetainedSceneIndex
-        // destructor crashes under Windows clang code coverage build.
-        _mayaHydraSceneIndex.Reset();
-    #else
-       _ClearMayaHydraSceneIndex();
-    #endif
+    _ClearMayaHydraSceneIndex();
 
     _displayStyleSceneIndex = nullptr;
     _pruneTexturesSceneIndex = nullptr;


### PR DESCRIPTION
Code coverage builds have to leak retained scene indices because of a crash in the retained scene index destructor, on Clang code coverage builds alone.  This creates a maintenance burden when such scene indices also manage other resources.  This pull request adds a Destroy() method to certain classes so that proper cleanup can be done in code coverage builds, even if retained scene indices are leaked to avoid crashing.