### PR TITLE
Refactored test case plugin loading and unloading.

### DIFF
--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testDataProducerExample.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testDataProducerExample.py
@@ -21,31 +21,13 @@ class TestDataProducerExample(mtohUtils.MayaHydraBaseTestCase):
     # MayaHydraBaseTestCase.setUpClass requirement.
     _file = __file__
 
-    _pluginsToLoad = ['mayaHydraCppTests', 'mayaHydraFlowViewportAPILocator']
-    _pluginsToUnload = []
+    _requiredPlugins = ['mayaHydraCppTests', 'mayaHydraFlowViewportAPILocator']
 
     def createScene(self):
         self._locator = cmds.createNode('MhFlowViewportAPILocator')
         cmds.setAttr(self._locator + '.numCubesX', 3)
         cmds.setAttr(self._locator + '.numCubesY', 3)
         cmds.setAttr(self._locator + '.numCubesZ', 3)
-
-    @classmethod
-    def setUpClass(cls):
-        super(TestDataProducerExample, cls).setUpClass()
-        for p in cls._pluginsToLoad:
-            if not cmds.pluginInfo(p, q=True, loaded=True):
-                cls._pluginsToUnload.append(p)
-                cmds.loadPlugin(p, quiet=True)
-
-    @classmethod
-    def tearDownClass(cls):
-        super(TestDataProducerExample, cls).tearDownClass()
-        # Clean out the scene to allow all plugins to unload cleanly.
-        cmds.file(new=True, force=True)
-        for p in reversed(cls._pluginsToUnload):
-            if p != 'mayaHydraFlowViewportAPILocator':
-                cmds.unloadPlugin(p)
 
     def setUp(self):
         super(TestDataProducerExample, self).setUp()

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testIsolateSelect.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testIsolateSelect.py
@@ -51,25 +51,7 @@ class TestIsolateSelect(mtohUtils.MayaHydraBaseTestCase):
 
     # Base class setUp() defines HdStorm as the renderer.
 
-    _pluginsToLoad = ['mayaHydraCppTests', 'mayaHydraFlowViewportAPILocator']
-    _pluginsToUnload = []
-
-    @classmethod
-    def setUpClass(cls):
-        super(TestIsolateSelect, cls).setUpClass()
-        for p in cls._pluginsToLoad:
-            if not cmds.pluginInfo(p, q=True, loaded=True):
-                cls._pluginsToUnload.append(p)
-                cmds.loadPlugin(p, quiet=True)
-
-    @classmethod
-    def tearDownClass(cls):
-        super(TestIsolateSelect, cls).tearDownClass()
-        # Clean out the scene to allow all plugins to unload cleanly.
-        cmds.file(new=True, force=True)
-        for p in reversed(cls._pluginsToUnload):
-            if p != 'mayaHydraFlowViewportAPILocator':
-                cmds.unloadPlugin(p)
+    _requiredPlugins = ['mayaHydraCppTests', 'mayaHydraFlowViewportAPILocator']
 
     def setupScene(self):
         proxyShapePathStr = mayaUsd_createStageWithNewLayer.createStageWithNewLayer()

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testIsolateSelectMayaSelectionHighlighting.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testIsolateSelectMayaSelectionHighlighting.py
@@ -45,24 +45,7 @@ class TestIsolateSelectMayaSelectionHighlighting(mtohUtils.MayaHydraBaseTestCase
 
     # Base class setUp() defines HdStorm as the renderer.
 
-    _pluginsToLoad = ['mayaHydraCppTests']
-    _pluginsToUnload = []
-
-    @classmethod
-    def setUpClass(cls):
-        super(TestIsolateSelectMayaSelectionHighlighting, cls).setUpClass()
-        for p in cls._pluginsToLoad:
-            if not cmds.pluginInfo(p, q=True, loaded=True):
-                cls._pluginsToUnload.append(p)
-                cmds.loadPlugin(p, quiet=True)
-
-    @classmethod
-    def tearDownClass(cls):
-        super(TestIsolateSelectMayaSelectionHighlighting, cls).tearDownClass()
-        # Clean out the scene to allow all plugins to unload cleanly.
-        cmds.file(new=True, force=True)
-        for p in reversed(cls._pluginsToUnload):
-            cmds.unloadPlugin(p)
+    _requiredPlugins = ['mayaHydraCppTests']
 
     def setupScene(self):
 

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testIsolateSelectSwitchToVP2.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testIsolateSelectSwitchToVP2.py
@@ -45,24 +45,7 @@ class TestIsolateSelectSwitchToVP2(mtohUtils.MayaHydraBaseTestCase):
 
     # Base class setUp() defines HdStorm as the renderer.
 
-    _pluginsToLoad = ['mayaHydraCppTests']
-    _pluginsToUnload = []
-
-    @classmethod
-    def setUpClass(cls):
-        super(TestIsolateSelectSwitchToVP2, cls).setUpClass()
-        for p in cls._pluginsToLoad:
-            if not cmds.pluginInfo(p, q=True, loaded=True):
-                cls._pluginsToUnload.append(p)
-                cmds.loadPlugin(p, quiet=True)
-
-    @classmethod
-    def tearDownClass(cls):
-        super(TestIsolateSelectSwitchToVP2, cls).tearDownClass()
-        # Clean out the scene to allow all plugins to unload cleanly.
-        cmds.file(new=True, force=True)
-        for p in reversed(cls._pluginsToUnload):
-            cmds.unloadPlugin(p)
+    _requiredPlugins = ['mayaHydraCppTests']
 
     def setupScene(self):
 

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testUsdNativeInstancingIsolateSelect.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testUsdNativeInstancingIsolateSelect.py
@@ -51,25 +51,7 @@ class TestUsdNativeInstancingIsolateSelect(mtohUtils.MayaHydraBaseTestCase):
 
     # Base class setUp() defines HdStorm as the renderer.
 
-    _pluginsToLoad = ['mayaHydraCppTests', 'mayaHydraFlowViewportAPILocator']
-    _pluginsToUnload = []
-
-    @classmethod
-    def setUpClass(cls):
-        super(TestUsdNativeInstancingIsolateSelect, cls).setUpClass()
-        for p in cls._pluginsToLoad:
-            if not cmds.pluginInfo(p, q=True, loaded=True):
-                cls._pluginsToUnload.append(p)
-                cmds.loadPlugin(p, quiet=True)
-
-    @classmethod
-    def tearDownClass(cls):
-        super(TestUsdNativeInstancingIsolateSelect, cls).tearDownClass()
-        # Clean out the scene to allow all plugins to unload cleanly.
-        cmds.file(new=True, force=True)
-        for p in reversed(cls._pluginsToUnload):
-            if p != 'mayaHydraFlowViewportAPILocator':
-                cmds.unloadPlugin(p)
+    _requiredPlugins = ['mayaHydraCppTests', 'mayaHydraFlowViewportAPILocator']
 
     def setupScene(self):
         proxyShapePathStr = mayaUsd_createStageWithNewLayer.createStageWithNewLayer()

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testUsdPointInstancingIsolateSelect.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testUsdPointInstancingIsolateSelect.py
@@ -50,25 +50,7 @@ class TestUsdPointInstancingIsolateSelect(mtohUtils.MayaHydraBaseTestCase):
 
     # Base class setUp() defines HdStorm as the renderer.
 
-    _pluginsToLoad = ['mayaHydraCppTests', 'mayaHydraFlowViewportAPILocator']
-    _pluginsToUnload = []
-
-    @classmethod
-    def setUpClass(cls):
-        super(TestUsdPointInstancingIsolateSelect, cls).setUpClass()
-        for p in cls._pluginsToLoad:
-            if not cmds.pluginInfo(p, q=True, loaded=True):
-                cls._pluginsToUnload.append(p)
-                cmds.loadPlugin(p, quiet=True)
-
-    @classmethod
-    def tearDownClass(cls):
-        super(TestUsdPointInstancingIsolateSelect, cls).tearDownClass()
-        # Clean out the scene to allow all plugins to unload cleanly.
-        cmds.file(new=True, force=True)
-        for p in reversed(cls._pluginsToUnload):
-            if p != 'mayaHydraFlowViewportAPILocator':
-                cmds.unloadPlugin(p)
+    _requiredPlugins = ['mayaHydraCppTests', 'mayaHydraFlowViewportAPILocator']
 
     def setupScene(self):
 

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testUsdPointInstancingIsolateSelectBBox.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testUsdPointInstancingIsolateSelectBBox.py
@@ -51,25 +51,7 @@ class TestUsdPointInstancingIsolateSelectBBox(mtohUtils.MayaHydraBaseTestCase):
 
     # Base class setUp() defines HdStorm as the renderer.
 
-    _pluginsToLoad = ['mayaHydraCppTests', 'mayaHydraFlowViewportAPILocator']
-    _pluginsToUnload = []
-
-    @classmethod
-    def setUpClass(cls):
-        super(TestUsdPointInstancingIsolateSelectBBox, cls).setUpClass()
-        for p in cls._pluginsToLoad:
-            if not cmds.pluginInfo(p, q=True, loaded=True):
-                cls._pluginsToUnload.append(p)
-                cmds.loadPlugin(p, quiet=True)
-
-    @classmethod
-    def tearDownClass(cls):
-        super(TestUsdPointInstancingIsolateSelectBBox, cls).tearDownClass()
-        # Clean out the scene to allow all plugins to unload cleanly.
-        cmds.file(new=True, force=True)
-        for p in reversed(cls._pluginsToUnload):
-            if p != 'mayaHydraFlowViewportAPILocator':
-                cmds.unloadPlugin(p)
+    _requiredPlugins = ['mayaHydraCppTests', 'mayaHydraFlowViewportAPILocator']
 
     def setupScene(self):
         self.proxyShapePathStr = mayaUsd_createStageWithNewLayer.createStageWithNewLayer()

--- a/test/testUtils/mtohUtils.py
+++ b/test/testUtils/mtohUtils.py
@@ -52,6 +52,11 @@ class MayaHydraBaseTestCase(unittest.TestCase, ImageDiffingTestCase):
     _requiredPlugins = []
     _pluginsToUnload = []
 
+    # Unloading mayaHydraFlowViewportAPILocator crashes Maya (HYDRA-1304).
+    # Unloading mtoa succeeds on Linux, but fails on Windows and macOS
+    # with "cannot be unloaded because it is still in use" error.
+    _pluginsCantUnload = ['mayaHydraFlowViewportAPILocator', 'mtoa']
+
     @classmethod
     def setUpClass(cls):
         if cls._file is None:
@@ -100,7 +105,7 @@ class MayaHydraBaseTestCase(unittest.TestCase, ImageDiffingTestCase):
         # Clean out the scene to allow all plugins to unload cleanly.
         cmds.file(new=True, force=True)
         for p in reversed(cls._pluginsToUnload):
-            if p != 'mayaHydraFlowViewportAPILocator':
+            if p not in cls._pluginsCantUnload:
                 cmds.unloadPlugin(p)
 
         if platform.system() == "Windows":

--- a/test/testUtils/mtohUtils.py
+++ b/test/testUtils/mtohUtils.py
@@ -50,6 +50,7 @@ class MayaHydraBaseTestCase(unittest.TestCase, ImageDiffingTestCase):
     # Variables to be set in subclasses
     _file = None
     _requiredPlugins = []
+    _pluginsToUnload = []
 
     @classmethod
     def setUpClass(cls):
@@ -79,11 +80,13 @@ class MayaHydraBaseTestCase(unittest.TestCase, ImageDiffingTestCase):
         if MAYAUSD_PLUGIN_NAME not in cls._requiredPlugins:
             cls._requiredPlugins.append(MAYAUSD_PLUGIN_NAME)
 
-        for pluginToLoad in cls._requiredPlugins:
+        for p in cls._requiredPlugins:
             # If a plugin fails to load, the entire test suite will be immediately aborted.
             # Note that in the case of mtoa, the plugin might load successfully but not
             # initialize properly, which means issues will only be caught in the actual tests.
-            cmds.loadPlugin(pluginToLoad)
+            if not cmds.pluginInfo(p, q=True, loaded=True):
+                cls._pluginsToUnload.append(p)
+                cmds.loadPlugin(p, quiet=True)
         
     def setUp(self):
         # Maya is not closed/reset between each test of a test suite,
@@ -94,6 +97,12 @@ class MayaHydraBaseTestCase(unittest.TestCase, ImageDiffingTestCase):
 
     @classmethod
     def tearDownClass(cls):
+        # Clean out the scene to allow all plugins to unload cleanly.
+        cmds.file(new=True, force=True)
+        for p in reversed(cls._pluginsToUnload):
+            if p != 'mayaHydraFlowViewportAPILocator':
+                cmds.unloadPlugin(p)
+
         if platform.system() == "Windows":
             # On Windows, ADPClientService can linger around after a test ends and Maya closes,
             # keeping a handle open into the temporary test directory that holds preferences,


### PR DESCRIPTION
There was duplication of infrastructure for loading plugins needed for a test, and unloading them afterwards.  This has been removed, and the union of the support was kept, including the `_requiredPlugins` Python class variable that is presented in the Markdown documentation.