### PR TITLE
Disconnected Fvp::PathInterface in code base, replaced with path mapper

### DIFF
--- a/lib/flowViewport/sceneIndex/fvpBlockPrimRemovalPropagationSceneIndex.h
+++ b/lib/flowViewport/sceneIndex/fvpBlockPrimRemovalPropagationSceneIndex.h
@@ -71,7 +71,11 @@ public:
     //from PathInterface
     FVP_API
     PrimSelections UfePathToPrimSelections(const Ufe::Path& appPath) const override{
-        return _pathInterface->UfePathToPrimSelections(appPath);
+        PXR_NAMESPACE_USING_DIRECTIVE
+
+        TF_FATAL_ERROR("Illegal call to deprecated %s", TF_FUNC_NAME().data());
+
+        return PrimSelections();
     }
 
 protected:

--- a/lib/flowViewport/sceneIndex/fvpLightsManagementSceneIndex.cpp
+++ b/lib/flowViewport/sceneIndex/fvpLightsManagementSceneIndex.cpp
@@ -17,6 +17,8 @@
 //Local headers
 #include "fvpLightsManagementSceneIndex.h"
 
+#include <flowViewport/selection/fvpPathMapperRegistry.h>
+
 //USD/Hydra headers
 #include <pxr/imaging/hd/tokens.h>
 #include <pxr/imaging/hd/retainedDataSource.h>
@@ -125,7 +127,7 @@ HdSceneIndexPrim LightsManagementSceneIndex::GetPrim(const SdfPath& primPath) co
              //Convert ufe selection to SdfPath
              SdfPathVector selectedLightsSdfPath;
              for (const auto& snItem : ufeSelection) {
-                 auto primSelections = _pathInterface.UfePathToPrimSelections(snItem->path());
+                 auto primSelections = ufePathToPrimSelections(snItem->path());
                  for (const auto& primSelection : primSelections) {
                      selectedLightsSdfPath.push_back(primSelection.primPath);
                  }

--- a/lib/flowViewport/sceneIndex/fvpMergingSceneIndex.cpp
+++ b/lib/flowViewport/sceneIndex/fvpMergingSceneIndex.cpp
@@ -36,26 +36,8 @@ MergingSceneIndex::MergingSceneIndex() : HdMergingSceneIndex()
 
 PrimSelections MergingSceneIndex::UfePathToPrimSelections(const Ufe::Path& appPath) const
 {
-    // FLOW_VIEWPORT_TODO  May be able to use a caching scheme for app path to
-    // scene index path conversion using the run-time ID of the UFE path, as it
-    // is likely that the input scene index that provided a previous answer
-    // will do so again.  To be determined if the following direct approach has
-    // a measurable performance impact.  PPT, 18-Sep-2023.
+    TF_FATAL_ERROR("Illegal call to deprecated %s", TF_FUNC_NAME().data());
 
-    // Iterate over input scene indices and ask them to convert the path if
-    // they support the path interface.
-    auto inputScenes = GetInputScenes();
-    for (const auto& inputScene : inputScenes) {
-        // Unfortunate that we have to dynamic cast, as soon as we add an input
-        // scene we know whether it supports the PathInterface or not.
-        auto pathInterface = dynamic_cast<const PathInterface*>(&*inputScene);
-        if (pathInterface) {
-            auto primSelections = pathInterface->UfePathToPrimSelections(appPath);
-            if (!primSelections.empty()) {
-                return primSelections;
-            }
-        }
-    }
     return PrimSelections();
 }
 

--- a/lib/flowViewport/sceneIndex/fvpPathInterface.cpp
+++ b/lib/flowViewport/sceneIndex/fvpPathInterface.cpp
@@ -28,8 +28,8 @@ PathInterface::~PathInterface() {}
 SdfPath PathInterface::SceneIndexPath(const Ufe::Path& appPath) const
 {
     auto primSelections = UfePathToPrimSelections(appPath);
-    if (!TF_VERIFY(primSelections.size() <= 1u)) {
-        throw PrimPathsCountOutOfRangeException(0, 1, primSelections.size());
+    if (!TF_VERIFY(primSelections.size() <= 2u)) {
+        throw PrimPathsCountOutOfRangeException(0, 2, primSelections.size());
     }
     return primSelections.empty() ? SdfPath() : primSelections.front().primPath;
 }

--- a/lib/flowViewport/sceneIndex/fvpPathInterface.h
+++ b/lib/flowViewport/sceneIndex/fvpPathInterface.h
@@ -43,7 +43,7 @@ namespace FVP_NS_DEF {
 ///
 class PathInterface
 {
-public:
+protected:
 
     //! Return the prim path(s) corresponding to the argument application path,
     //! as well as their associated selection data source(s).
@@ -52,19 +52,6 @@ public:
     FVP_API
     virtual PrimSelections UfePathToPrimSelections(const Ufe::Path& appPath) const = 0;
 
-    //! Return the prim path corresponding to the argument application path,
-    //! for when an application path maps to at most a single prim path.
-    //! If no such path exists, an empty SdfPath should be returned.
-    //! \return Scene index path.
-    FVP_API
-    PXR_NS::SdfPath SceneIndexPath(const Ufe::Path& appPath) const;
-
-    //! Return the prim paths corresponding to the argument application path.
-    //! If no such paths exist, an empty SdfPathVector should be returned.
-    //! \return Scene index paths.
-    FVP_API
-    PXR_NS::SdfPathVector SceneIndexPaths(const Ufe::Path& appPath) const;
-
 protected:
 
     FVP_API
@@ -72,6 +59,19 @@ protected:
 
     FVP_API
     virtual ~PathInterface();
+
+private:
+
+    //! Return the prim path corresponding to the argument application path,
+    //! for when an application path maps to at most a single prim path.
+    //! If no such path exists, an empty SdfPath should be returned.
+    //! \return Scene index path.
+    PXR_NS::SdfPath SceneIndexPath(const Ufe::Path& appPath) const;
+
+    //! Return the prim paths corresponding to the argument application path.
+    //! If no such paths exist, an empty SdfPathVector should be returned.
+    //! \return Scene index paths.
+    PXR_NS::SdfPathVector SceneIndexPaths(const Ufe::Path& appPath) const;
 };
 
 class PrimPathsCountOutOfRangeException : public std::out_of_range

--- a/lib/flowViewport/sceneIndex/fvpSelectionSceneIndex.cpp
+++ b/lib/flowViewport/sceneIndex/fvpSelectionSceneIndex.cpp
@@ -269,25 +269,10 @@ bool SelectionSceneIndex::HasFullySelectedAncestorInclusive(const SdfPath& primP
 
 PrimSelections SelectionSceneIndex::UfePathToPrimSelections(const Ufe::Path& appPath) const
 {
-    auto primSelections = _inputSceneIndexPathInterface->UfePathToPrimSelections(appPath);
+    auto primSelections = ufePathToPrimSelections(appPath);
 
     if (primSelections.empty()) {
-        // Path interface of input scene index didn't provide information.
-        // Try path mapper registry.
-        auto mapper = Fvp::PathMapperRegistry::Instance().GetMapper(appPath);
-        
-        auto warnEmptyPath = [](const Ufe::Path& appPath) {
-            TF_WARN("SelectionSceneIndex::UfePathToPrimSelections(%s) returned no path, Hydra selection will be incorrect", Ufe::PathString::string(appPath).c_str());
-        };
-
-        if (!mapper) {
-            warnEmptyPath(appPath);
-        } else {
-            primSelections = mapper->UfePathToPrimSelections(appPath);
-            if (primSelections.empty()) {
-                warnEmptyPath(appPath);
-            }
-        }
+        TF_WARN("SelectionSceneIndex::UfePathToPrimSelections(%s) returned no path, Hydra selection will be incorrect", Ufe::PathString::string(appPath).c_str());
     }
 
     return primSelections;

--- a/lib/flowViewport/sceneIndex/fvpWireframeSelectionHighlightSceneIndex.cpp
+++ b/lib/flowViewport/sceneIndex/fvpWireframeSelectionHighlightSceneIndex.cpp
@@ -333,6 +333,11 @@ WireframeSelectionHighlightSceneIndex(
     TF_AXIOM(_wireframeColorInterface);
 
     auto operation = [this](const SdfPath& primPath, const HdSceneIndexPrim& prim) -> bool {
+
+        if (_IsExcluded(primPath)) {
+            return true;
+        }
+
         if (prim.primType == HdPrimTypeTokens->instancer) {
             _CreateSelectionHighlightsForInstancer(prim, primPath);
         }
@@ -682,6 +687,11 @@ WireframeSelectionHighlightSceneIndex::_PrimsAdded(
 
     _SendPrimsAdded(entries);
     for (const auto& entry : entries) {
+
+        if (_IsExcluded(entry.primPath)) {
+            continue;
+        }
+
         HdSceneIndexPrim prim = GetInputSceneIndex()->GetPrim(entry.primPath);
         if (prim.primType == HdPrimTypeTokens->instancer) {
             _CreateSelectionHighlightsForInstancer(prim, entry.primPath);

--- a/lib/flowViewport/selection/fvpPathMapper.h
+++ b/lib/flowViewport/selection/fvpPathMapper.h
@@ -40,6 +40,10 @@ namespace FVP_NS_DEF {
 
 class PathMapper : public PathInterface
 {
+public:
+
+    using PathInterface::UfePathToPrimSelections;
+
 protected:
 
     FVP_API

--- a/lib/flowViewport/selection/fvpPathMapperRegistry.cpp
+++ b/lib/flowViewport/selection/fvpPathMapperRegistry.cpp
@@ -34,6 +34,8 @@ PXR_NAMESPACE_OPEN_SCOPE
 TF_INSTANTIATE_SINGLETON(Fvp::PathMapperRegistry);
 PXR_NAMESPACE_CLOSE_SCOPE
 
+PXR_NAMESPACE_USING_DIRECTIVE
+
 namespace FVP_NS_DEF {
 
 /* static */
@@ -58,6 +60,17 @@ bool PathMapperRegistry::Unregister(const Ufe::Path& prefix)
     return mappers.remove(prefix) != nullptr;
 }
 
+bool PathMapperRegistry::Update(const Ufe::Path& oldPrefix, const Ufe::Path& newPrefix)
+{
+    auto mapper = GetMapper(oldPrefix);
+    if (!mapper) {
+        return false;
+    }
+    TF_AXIOM(Unregister(oldPrefix));
+    TF_AXIOM(Register(newPrefix, mapper));
+    return true;
+}
+
 void PathMapperRegistry::SetFallbackMapper(
     const PathMapperConstPtr& pathMapper
 )
@@ -70,14 +83,12 @@ PathMapperConstPtr PathMapperRegistry::GetFallbackMapper() const
     return fallbackMapper;
 }
 
-PathMapperConstPtr PathMapperRegistry::GetMapper(const Ufe::Path& path) const
+PathMapperConstPtr PathMapperRegistry::_GetMapper(const Ufe::Path& path) const
 {
-    if (path.empty()) {
-        return nullptr;
-    }
+    TF_AXIOM(!path.empty());
 
     if (mappers.empty()) {
-        return fallbackMapper;
+        return nullptr;
     }
 
     // We are looking for the closest ancestor of the argument.  Internal trie
@@ -90,7 +101,7 @@ PathMapperConstPtr PathMapperRegistry::GetMapper(const Ufe::Path& path) const
         // If we've reached a trie leaf node before the end of our path, there
         // is no trie node with data as ancestor of the path.
         if (!child) {
-            return fallbackMapper;
+            return nullptr;
         }
         trieNode = child;
 
@@ -101,16 +112,26 @@ PathMapperConstPtr PathMapperRegistry::GetMapper(const Ufe::Path& path) const
     }
     // We reached the end of the parent path without returning true, therefore
     // there are no ancestors.
-    return fallbackMapper;
+    return nullptr;
 }
 
-Fvp::PrimSelections ufePathToPrimSelections(const Ufe::Path& appPath)
+PathMapperConstPtr PathMapperRegistry::GetMapper(const Ufe::Path& path) const
 {
-    PXR_NAMESPACE_USING_DIRECTIVE
+    if (path.empty()) {
+        return nullptr;
+    }
 
-    Fvp::PrimSelections primSelections;
+    auto mapper = _GetMapper(path);
+    return mapper ? mapper : fallbackMapper;
+}
 
-    auto mapper = Fvp::PathMapperRegistry::Instance().GetMapper(appPath);
+PrimSelections PathMapperRegistry::UfePathToPrimSelections(
+    const Ufe::Path& appPath
+)
+{
+    PrimSelections primSelections;
+
+    auto mapper = GetMapper(appPath);
         
     if (!mapper) {
         TF_WARN("No registered mapping for path %s, no prim path returned.", Ufe::PathString::string(appPath).c_str());
@@ -118,11 +139,53 @@ Fvp::PrimSelections ufePathToPrimSelections(const Ufe::Path& appPath)
     else {
         primSelections = mapper->UfePathToPrimSelections(appPath);
         if (primSelections.empty()) {
-            TF_WARN("Mapping for path %s returned no prim path.", Ufe::PathString::string(appPath).c_str());
+
+            mapper = GetFallbackMapper();
+        
+            if (!mapper) {
+                TF_WARN("No registered fallback mapping, no prim path returned.");
+            }
+            else {
+                primSelections = mapper->UfePathToPrimSelections(appPath);
+                if (primSelections.empty()) {
+                    TF_WARN("Mapping for path %s returned no prim path.", Ufe::PathString::string(appPath).c_str());
+                }
+            }
         }
     }
 
     return primSelections;
+}
+
+bool PathMapperRegistry::HasMapper(const Ufe::Path& path) const
+{
+    return _GetMapper(path) != nullptr;
+}
+
+PrimSelections ufePathToPrimSelections(const Ufe::Path& appPath)
+{
+    return PathMapperRegistry::Instance().UfePathToPrimSelections(appPath);
+}
+
+SdfPathVector sceneIndexPaths(const Ufe::Path& appPath)
+{
+    auto primSelections = ufePathToPrimSelections(appPath);
+
+    SdfPathVector outVector;
+    outVector.reserve(primSelections.size());
+    for (const auto& primSelection : primSelections) {
+        outVector.emplace_back(primSelection.primPath);
+    }
+    return outVector;
+}
+
+SdfPath sceneIndexPath(const Ufe::Path& appPath)
+{
+    auto primSelections = ufePathToPrimSelections(appPath);
+    if (!TF_VERIFY(primSelections.size() <= 2u)) {
+        throw PrimPathsCountOutOfRangeException(0, 2, primSelections.size());
+    }
+    return primSelections.empty() ? SdfPath() : primSelections.front().primPath;
 }
 
 }

--- a/lib/flowViewport/selection/fvpPathMapperRegistry.cpp
+++ b/lib/flowViewport/selection/fvpPathMapperRegistry.cpp
@@ -159,6 +159,9 @@ PrimSelections PathMapperRegistry::UfePathToPrimSelections(
 
 bool PathMapperRegistry::HasMapper(const Ufe::Path& path) const
 {
+    if (path.empty()) {
+        return false;
+    }
     return _GetMapper(path) != nullptr;
 }
 

--- a/lib/flowViewport/selection/fvpPathMapperRegistry.h
+++ b/lib/flowViewport/selection/fvpPathMapperRegistry.h
@@ -68,21 +68,40 @@ public:
     FVP_API
     bool Unregister(const Ufe::Path& prefix);
 
+    //! Update path mapper with new prefix.
+    /*!
+      \return False if old prefix was not found in the registry, true otherwise.
+    */
+    FVP_API
+    bool Update(const Ufe::Path& oldPrefix, const Ufe::Path& newPrefix);
+
     //! Set a fallback path mapper.  If set, it will be returned by
     //! GetMapper() if no mapper is registered for a given argument path.
+    //! The fallback mapper is also invoked by UfePathToPrimSelections()
+    //! if the prefix-registered mapper returns an empty result.
     //! A null pointer argument removes the fallback path mapper.
     FVP_API
     void SetFallbackMapper(const PathMapperConstPtr& pathMapper);
     FVP_API
     PathMapperConstPtr GetFallbackMapper() const;
 
+    FVP_API
+    PrimSelections UfePathToPrimSelections(const Ufe::Path& appPath);
+
+    //! Testing interface
+    FVP_API
+    bool HasMapper(const Ufe::Path& path) const;
+
+private:
+
+    //! Calls _GetMapper().  If no path mapper is found, returns the
+    //! fallback path mapper.
+    PathMapperConstPtr GetMapper(const Ufe::Path& path) const;
+
     //! Get a path mapper for the argument application path.  This
     //! mapper has a prefix that is an ancestor of the argument path.  If no
     //! path mapper is found, returns a null pointer.
-    FVP_API
-    PathMapperConstPtr GetMapper(const Ufe::Path& path) const;
-
-private:
+    PathMapperConstPtr _GetMapper(const Ufe::Path& path) const;
 
     PathMapperRegistry() = default;
     ~PathMapperRegistry() = default;
@@ -106,6 +125,28 @@ private:
  */
 FVP_API
 PrimSelections ufePathToPrimSelections(const Ufe::Path& appPath);
+
+/**
+ * @brief Get the prim paths for a given application path.
+ *
+ * Calls ufePathToPrimSelections, then extracts the Hydra prim paths.
+ *
+ * @param[in] appPath The application path for which prim selections should be returned.
+ * @return Zero or more prim paths.
+ */
+FVP_API
+PXR_NS::SdfPathVector sceneIndexPaths(const Ufe::Path& appPath);
+
+/**
+ * @brief Get the first prim path for a given application path.
+ *
+ * Calls ufePathToPrimSelections, then extracts the first Hydra prim path.
+ *
+ * @param[in] appPath The application path for which prim selections should be returned.
+ * @return A prim path, empty if no prim path corresponds to the argument.
+ */
+FVP_API
+PXR_NS::SdfPath sceneIndexPath(const Ufe::Path& appPath);
 
 }
 

--- a/lib/mayaHydra/hydraExtensions/mhLeadObjectPathTracker.cpp
+++ b/lib/mayaHydra/hydraExtensions/mhLeadObjectPathTracker.cpp
@@ -21,6 +21,7 @@
 #include <flowViewport/colorPreferences/fvpColorPreferences.h>
 #include <flowViewport/colorPreferences/fvpColorPreferencesTokens.h>
 #include <flowViewport/selection/fvpSelection.h>
+#include <flowViewport/selection/fvpPathMapperRegistry.h>
 
 //ufe
 #include <ufe/globalSelection.h>
@@ -83,7 +84,7 @@ MhLeadObjectPathTracker::MhLeadObjectPathTracker(const HdSceneIndexBaseRefPtr& s
         _leadObjectUfePath = leadObjectSceneItem->path();
         //_leadObjectPrimPaths can be empty with a valid _leadObjectUfePath when the lead object is in a data producer scene index not yet added to the merging scene index
         //This is fixed at some point by calling updatePrimPaths()
-        _leadObjectPrimPaths = _pathInterface->SceneIndexPaths(_leadObjectUfePath);
+        _leadObjectPrimPaths = Fvp::sceneIndexPaths(_leadObjectUfePath);
     }
 
    // Add ourself as an observer to the selection
@@ -119,7 +120,7 @@ void MhLeadObjectPathTracker::setLeadObjectUfePath(const Ufe::Path& newLeadObjec
     auto oldLeadObjectPrimPaths = _leadObjectPrimPaths;
 
     _leadObjectUfePath  = newLeadObjectUfePath;
-    _leadObjectPrimPaths = _pathInterface->SceneIndexPaths(_leadObjectUfePath);
+    _leadObjectPrimPaths = Fvp::sceneIndexPaths(_leadObjectUfePath);
 
     // Dirty the previous lead object
     if(_dirtyLeadObjectSceneIndex){
@@ -131,7 +132,7 @@ void MhLeadObjectPathTracker::updatePrimPaths()
 { 
    // Update the lead object prim paths in case it was not valid yet
     if ( (_leadObjectUfePath.size() > 0) && _leadObjectPrimPaths.empty()) {
-        _leadObjectPrimPaths = _pathInterface->SceneIndexPaths(_leadObjectUfePath);
+        _leadObjectPrimPaths = Fvp::sceneIndexPaths(_leadObjectUfePath);
     }
 }
 

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
@@ -62,8 +62,6 @@
 #include <pxr/imaging/hd/rprim.h>
 #include <pxr/usdImaging/usdImaging/tokens.h>
 
-#include <iostream>
-
 namespace
 {
 // Pick handler for the Maya scene index.  As the Maya pick handler and the
@@ -477,8 +475,6 @@ public:
 
     Fvp::PrimSelections 
     UfePathToPrimSelections(const Ufe::Path& appPath) const override {
-        std::cout << "PPT: in MayaPathMapper::UfePathToPrimSelections("
-                  << Ufe::PathString::string(appPath) << ")" << std::endl;
         auto litPaths = _piSi.UfePathToPrimSelectionsLit(appPath);
         auto unlitPaths = _piSi.UfePathToPrimSelections(appPath);
         unlitPaths.insert(unlitPaths.end(), litPaths.begin(), litPaths.end());
@@ -806,14 +802,9 @@ Fvp::PrimSelections MayaHydraSceneIndex::UfePathToPrimSelections(const Ufe::Path
     TF_DEBUG(MAYAHYDRALIB_SCENE_INDEX)
         .Msg("MayaHydraSceneIndex::UfePathToPrimSelections(const Ufe::Path& %s) called.\n", Ufe::PathString::string(appPath).c_str());
 
-    std::cout << "PPT: in MayaHydraSceneIndex::UfePathToPrimSelections("
-              << Ufe::PathString::string(appPath) << ")" << std::endl;
-
     // We only handle Maya objects, so if the UFE path is not a Maya object,
     // early out with failure.
     if (appPath.runTimeId() != UfeExtensions::getMayaRunTimeId()) {
-        std::cout << "PPT:     early out, not a Maya run-time UFE path."
-                  << std::endl;
         return {};
     }
 

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
@@ -62,6 +62,8 @@
 #include <pxr/imaging/hd/rprim.h>
 #include <pxr/usdImaging/usdImaging/tokens.h>
 
+#include <iostream>
+
 namespace
 {
 // Pick handler for the Maya scene index.  As the Maya pick handler and the
@@ -475,6 +477,8 @@ public:
 
     Fvp::PrimSelections 
     UfePathToPrimSelections(const Ufe::Path& appPath) const override {
+        std::cout << "PPT: in MayaPathMapper::UfePathToPrimSelections("
+                  << Ufe::PathString::string(appPath) << ")" << std::endl;
         auto litPaths = _piSi.UfePathToPrimSelectionsLit(appPath);
         auto unlitPaths = _piSi.UfePathToPrimSelections(appPath);
         unlitPaths.insert(unlitPaths.end(), litPaths.begin(), litPaths.end());
@@ -802,9 +806,14 @@ Fvp::PrimSelections MayaHydraSceneIndex::UfePathToPrimSelections(const Ufe::Path
     TF_DEBUG(MAYAHYDRALIB_SCENE_INDEX)
         .Msg("MayaHydraSceneIndex::UfePathToPrimSelections(const Ufe::Path& %s) called.\n", Ufe::PathString::string(appPath).c_str());
 
+    std::cout << "PPT: in MayaHydraSceneIndex::UfePathToPrimSelections("
+              << Ufe::PathString::string(appPath) << ")" << std::endl;
+
     // We only handle Maya objects, so if the UFE path is not a Maya object,
     // early out with failure.
     if (appPath.runTimeId() != UfeExtensions::getMayaRunTimeId()) {
+        std::cout << "PPT:     early out, not a Maya run-time UFE path."
+                  << std::endl;
         return {};
     }
 
@@ -850,6 +859,13 @@ Fvp::PrimSelections MayaHydraSceneIndex::UfePathToPrimSelectionsLit(
     // UfePathToPrimSelections() would allow factoring out into a single path
     // mapper for Usd and Maya (see registration.cpp).
     if (appPath.runTimeId() != UfeExtensions::getMayaRunTimeId()) {
+        return {};
+    }
+
+    // If the Maya node described by the appPath is in fact a path mapper
+    // registry entry, nothing to do, the path mapper for that entry will
+    // handle things.
+    if (Fvp::PathMapperRegistry::Instance().HasMapper(appPath)) {
         return {};
     }
 

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/registration.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/registration.cpp
@@ -259,13 +259,8 @@ private:
                     _pi.SetSceneIndexAppPath(newPath);
 
                     // Update our entry in the path mapper registry.
-                    auto mapper = Fvp::PathMapperRegistry::Instance().GetMapper(
-                        oldPath);
-                    TF_AXIOM(mapper);
-                    TF_AXIOM(Fvp::PathMapperRegistry::Instance().Unregister(
-                                 oldPath));
-                    TF_AXIOM(Fvp::PathMapperRegistry::Instance().Register(
-                                 newPath, mapper));
+                    TF_AXIOM(Fvp::PathMapperRegistry::Instance().Update(
+                                 oldPath, newPath));
                 }
             }
         }

--- a/test/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
+++ b/test/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
@@ -8,7 +8,6 @@
 set(INTERACTIVE_TEST_SCRIPT_FILES
     testImageDiffing.py
     testMtohCommand.py
-# Fail as of 22-Feb-2023.  Entered as MAYA-127898.
     testBasicRender.py
     testDagChanges.py
     testMeshes.py
@@ -61,7 +60,7 @@ set(INTERACTIVE_TEST_SCRIPT_FILES
     cpp/testDataProducerExample.py
     cpp/testMayaSceneFlattening.py
     cpp/testMayaUsdUfeItems.py
-    cpp/testMergingSceneIndex.py
+    # cpp/testMergingSceneIndex.py
     cpp/testPathInterface.py
     cpp/testPathMapperRegistry.py
     cpp/testPickHandlerRegistry.py

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/CMakeLists.txt
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/CMakeLists.txt
@@ -22,7 +22,7 @@ target_sources(${TARGET_NAME}
         testHydraPrim.cpp
         testMayaSceneFlattening.cpp
         testMayaUsdUfeItems.cpp
-        testMergingSceneIndex.cpp
+        # testMergingSceneIndex.cpp
         testPathInterface.cpp
         testPrimPath.cpp
         testSelectionSceneIndex.cpp

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testGeomSubsetsPicking.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testGeomSubsetsPicking.cpp
@@ -15,6 +15,8 @@
 
 #include "testUtils.h"
 
+#include <flowViewport/selection/fvpPathMapperRegistry.h>
+
 #include <pxr/imaging/hd/sceneIndex.h>
 #include <pxr/imaging/hd/selectionSchema.h>
 #include <pxr/imaging/hd/selectionsSchema.h>
@@ -97,10 +99,7 @@ void testPicking(const Ufe::Path& clickMarkerUfePath, const Ufe::Path& selectedO
     auto ufeSelection = Ufe::GlobalSelection::get();
     ASSERT_TRUE(ufeSelection->empty());
 
-    const auto selectionSceneIndex = findSelectionSceneIndexInTree(inspector.GetSceneIndex());
-    ASSERT_TRUE(selectionSceneIndex);
-
-    const auto selectedObjectSceneIndexPaths = selectionSceneIndex->SceneIndexPaths(selectedObjectUfePath);
+    const auto selectedObjectSceneIndexPaths = Fvp::sceneIndexPaths(selectedObjectUfePath);
 
     for (const auto& selectedObjectSceneIndexPath : selectedObjectSceneIndexPaths) {
         HdSceneIndexPrim selectedObjectSceneIndexPrim = inspector.GetSceneIndex()->GetPrim(selectedObjectSceneIndexPath);
@@ -110,7 +109,7 @@ void testPicking(const Ufe::Path& clickMarkerUfePath, const Ufe::Path& selectedO
 
     // Picking
     M3dView active3dView = M3dView::active3dView();
-    const auto clickMarkerSceneIndexPath = selectionSceneIndex->SceneIndexPath(clickMarkerUfePath);
+    const auto clickMarkerSceneIndexPath = Fvp::sceneIndexPath(clickMarkerUfePath);
     auto primMouseCoords = getPrimMouseCoords(inspector.GetSceneIndex()->GetPrim(clickMarkerSceneIndexPath), active3dView);
 
     mouseClick(Qt::MouseButton::LeftButton, active3dView.widget(), primMouseCoords);

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testGeomSubsetsWireframeHighlight.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testGeomSubsetsWireframeHighlight.cpp
@@ -16,8 +16,8 @@
 
 #include <mayaHydraLib/mayaHydra.h>
 
-#include <flowViewport/sceneIndex/fvpMergingSceneIndex.h>
 #include <flowViewport/sceneIndex/fvpWireframeSelectionHighlightSceneIndex.h>
+#include <flowViewport/selection/fvpPathMapperRegistry.h>
 
 #include <pxr/imaging/hd/instancedBySchema.h>
 #include <pxr/imaging/hd/meshSchema.h>
@@ -66,10 +66,6 @@ void testGeomSubsetHighlight(const Ufe::Path& geomSubsetPath)
     ASSERT_FALSE(terminalSceneIndices.empty());
     SceneIndexInspector inspector(terminalSceneIndices.front());
 
-    auto isFvpMergingSceneIndexPredicate = SceneIndexDisplayNamePred("Flow Viewport Merging Scene Index");
-    auto fvpMergingSceneIndex = TfDynamic_cast<Fvp::MergingSceneIndexRefPtr>(
-        findSceneIndexInTree(terminalSceneIndices.front(), isFvpMergingSceneIndexPredicate));
-
     auto isFvpWireframeSelectionHighlightSceneIndex = SceneIndexDisplayNamePred(
         "Flow Viewport Wireframe Selection Highlight Scene Index");
     auto fvpWireframeSelectionHighlightSceneIndex = TfDynamic_cast<Fvp::WireframeSelectionHighlightSceneIndexRefPtr>(
@@ -97,7 +93,7 @@ void testGeomSubsetHighlight(const Ufe::Path& geomSubsetPath)
 
     // Validate scene structure and data source values
     ASSERT_FALSE(inspector.FindPrims(findMeshPrimsPredicate).empty());
-    auto geomSubsetPrimSelections = fvpMergingSceneIndex->UfePathToPrimSelections(geomSubsetPath);
+    auto geomSubsetPrimSelections = Fvp::ufePathToPrimSelections(geomSubsetPath);
     for (size_t iSelection = 0; iSelection < geomSubsetPrimSelections.size(); iSelection++) {
         const auto& meshPath = geomSubsetPrimSelections[iSelection].primPath.GetParentPath();
         auto meshHighlightPath = fvpWireframeSelectionHighlightSceneIndex->GetSelectionHighlightPath(meshPath);

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testHydraPrim.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testHydraPrim.cpp
@@ -15,6 +15,8 @@
 
 #include "testUtils.h"
 
+#include <flowViewport/selection/fvpPathMapperRegistry.h>
+
 #include <mayaHydraLib/hydraUtils.h>
 
 #include <ufe/path.h>
@@ -25,20 +27,6 @@
 PXR_NAMESPACE_USING_DIRECTIVE
 
 using namespace MayaHydra;
-
-namespace {
-
-SdfPath fromAppPath(const Ufe::Path& appPath)
-{
-    auto siRoot = GetTerminalSceneIndices().front();
-
-    // Translate the application path into a scene index path using the
-    // selection scene index.
-    const auto snSi = findSelectionSceneIndexInTree(siRoot);
-    return snSi->SceneIndexPath(appPath);
-}
-
-}
 
 TEST(TestHydraPrim, fromAppPath)
 {
@@ -55,7 +43,7 @@ TEST(TestHydraPrim, fromAppPath)
     const auto snSi = findSelectionSceneIndexInTree(siRoot);
     ASSERT_TRUE(snSi);
 
-    const auto sceneIndexPath = snSi->SceneIndexPath(appPath);
+    const auto sceneIndexPath = Fvp::sceneIndexPath(appPath);
 
     ASSERT_FALSE(sceneIndexPath.IsEmpty());
 }
@@ -69,7 +57,7 @@ TEST(TestHydraPrim, isFound)
     ASSERT_EQ(argc, 1);
     const Ufe::Path appPath(Ufe::PathString::path(argv[0]));
 
-    const auto sceneIndexPath = fromAppPath(appPath);
+    const auto sceneIndexPath = Fvp::sceneIndexPath(appPath);
 
     ASSERT_TRUE(siRoot->GetPrim(sceneIndexPath).dataSource);
 }
@@ -83,7 +71,7 @@ TEST(TestHydraPrim, isNotFound)
     ASSERT_EQ(argc, 1);
     const Ufe::Path appPath(Ufe::PathString::path(argv[0]));
 
-    const auto sceneIndexPath = fromAppPath(appPath);
+    const auto sceneIndexPath = Fvp::sceneIndexPath(appPath);
 
     ASSERT_FALSE(siRoot->GetPrim(sceneIndexPath).dataSource);
 }
@@ -99,7 +87,7 @@ TEST(TestHydraPrim, translation)
     const GfVec3d expectedTranslation(
         std::stod(argv[1]), std::stod(argv[2]), std::stod(argv[3]));
 
-    const auto sceneIndexPath = fromAppPath(appPath);
+    const auto sceneIndexPath = Fvp::sceneIndexPath(appPath);
     const auto prim = siRoot->GetPrim(sceneIndexPath);
     GfMatrix4d m;
     ASSERT_TRUE(MayaHydra::GetXformMatrixFromPrim(prim, m));

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testPathInterface.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testPathInterface.cpp
@@ -16,6 +16,7 @@
 #include "testUtils.h"
 
 #include <flowViewport/sceneIndex/fvpSelectionSceneIndex.h>
+#include <flowViewport/selection/fvpPathMapperRegistry.h>
 
 #include <ufe/pathString.h>
 
@@ -29,7 +30,7 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 namespace {
 
-SdfPath getArgSceneIndexPath(const Fvp::SelectionSceneIndexRefPtr& snSi)
+SdfPath getArgSceneIndexPath()
 {
     // Object path string is in command line arguments.
     auto [argc, argv] = getTestingArgs();
@@ -38,7 +39,7 @@ SdfPath getArgSceneIndexPath(const Fvp::SelectionSceneIndexRefPtr& snSi)
     const auto mayaPath = Ufe::PathString::path(argv[0]);
 
     // Translate the application path into a scene index path.
-    return snSi->SceneIndexPath(mayaPath);
+    return Fvp::sceneIndexPath(mayaPath);
 }
 
 Fvp::SelectionSceneIndexRefPtr getSelectionSceneIndex()
@@ -67,7 +68,7 @@ TEST(TestPathInterface, testSelected)
     
     // Selected object path string is in command line arguments.
     // Get it and translate it into a scene index path.
-    const auto sceneIndexPath = getArgSceneIndexPath(snSi);
+    const auto sceneIndexPath = getArgSceneIndexPath();
 
     // Confirm the object is selected in scene index scene.
     ASSERT_TRUE(snSi->IsFullySelected(sceneIndexPath));
@@ -80,7 +81,7 @@ TEST(TestPathInterface, testUnselected)
     
     // Unselected object path string is in command line arguments.
     // Get it and translate it into a scene index path.
-    const auto sceneIndexPath = getArgSceneIndexPath(snSi);
+    const auto sceneIndexPath = getArgSceneIndexPath();
 
     // Confirm the object is not selected in scene index scene.
     ASSERT_FALSE(snSi->IsFullySelected(sceneIndexPath));

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testPathMapperRegistry.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testPathMapperRegistry.cpp
@@ -48,10 +48,6 @@ TEST(TestPathMapperRegistry, testRegistry)
     // Exercise the path mapper registry.
     auto& r = Fvp::PathMapperRegistry::Instance();
     
-    // For the duration of this test set a null fallback mapper.
-    auto fbm = r.GetFallbackMapper();
-    r.SetFallbackMapper(nullptr);
-
     auto dummy = TestPathMapper::create();
 
     // Can't register for an empty path.
@@ -106,10 +102,15 @@ TEST(TestPathMapperRegistry, testRegistry)
     ASSERT_TRUE(r.HasMapper(Ufe::PathString::path("|apple|pear")));
     ASSERT_TRUE(r.HasMapper(Ufe::PathString::path("|wizard|sorcerer")));
 
+    // Update the path for an entry.
+    auto potatoP = Ufe::PathString::path("|potato");
+    ASSERT_TRUE(r.Update(appleP, potatoP));
+    ASSERT_FALSE(r.HasMapper(Ufe::PathString::path("|apple|pear")));
+    ASSERT_TRUE(r.HasMapper(Ufe::PathString::path("|potato|baked")));
+    ASSERT_TRUE(r.Update(potatoP, appleP));
+
     // Clean up.
     for (const auto& h : registered) {
         ASSERT_TRUE(r.Unregister(h));
     }
-    r.SetFallbackMapper(fbm);
-    ASSERT_EQ(r.GetFallbackMapper(), fbm);
 }

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testPathMapperRegistry.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testPathMapperRegistry.cpp
@@ -63,15 +63,15 @@ TEST(TestPathMapperRegistry, testRegistry)
     auto fooP = Ufe::PathString::path("|foo");
 
     ASSERT_TRUE(r.Register(fooBarP, fooBarM));
-    ASSERT_EQ(r.GetMapper(fooBarP), fooBarM);
+    ASSERT_TRUE(r.HasMapper(fooBarP));
     registered.push_back(fooBarP);
 
     // fooBarM is the mapper for its own path and descendants, not ancestors
     // or unrelated paths.
-    ASSERT_EQ(r.GetMapper(Ufe::PathString::path("|foo|bar|bli")), fooBarM);
-    ASSERT_FALSE(r.GetMapper(fooP));
-    ASSERT_FALSE(r.GetMapper(Ufe::PathString::path("|bar")));
-    ASSERT_FALSE(r.GetMapper(Ufe::PathString::path("|zebra")));
+    ASSERT_TRUE(r.HasMapper(Ufe::PathString::path("|foo|bar|bli")));
+    ASSERT_FALSE(r.HasMapper(fooP));
+    ASSERT_FALSE(r.HasMapper(Ufe::PathString::path("|bar")));
+    ASSERT_FALSE(r.HasMapper(Ufe::PathString::path("|zebra")));
 
     // Add mappers for siblings, legal.
     auto fooBackM = TestPathMapper::create();
@@ -84,9 +84,9 @@ TEST(TestPathMapperRegistry, testRegistry)
     registered.push_back(fooBackP);
     registered.push_back(fooRedP);
 
-    ASSERT_EQ(r.GetMapper(Ufe::PathString::path("|foo|bar|bli")), fooBarM);
-    ASSERT_EQ(r.GetMapper(Ufe::PathString::path("|foo|back|bli")), fooBackM);
-    ASSERT_EQ(r.GetMapper(Ufe::PathString::path("|foo|red|bli")), fooRedM);
+    ASSERT_TRUE(r.HasMapper(Ufe::PathString::path("|foo|bar|bli")));
+    ASSERT_TRUE(r.HasMapper(Ufe::PathString::path("|foo|back|bli")));
+    ASSERT_TRUE(r.HasMapper(Ufe::PathString::path("|foo|red|bli")));
 
     // Add mappers for ancestors, descendants, illegal.
     ASSERT_FALSE(r.Register(fooP, dummy));
@@ -103,8 +103,8 @@ TEST(TestPathMapperRegistry, testRegistry)
     registered.push_back(appleP);
     registered.push_back(wizardP);
 
-    ASSERT_EQ(r.GetMapper(Ufe::PathString::path("|apple|pear")), appleM);
-    ASSERT_EQ(r.GetMapper(Ufe::PathString::path("|wizard|sorcerer")), wizardM);
+    ASSERT_TRUE(r.HasMapper(Ufe::PathString::path("|apple|pear")));
+    ASSERT_TRUE(r.HasMapper(Ufe::PathString::path("|wizard|sorcerer")));
 
     // Clean up.
     for (const auto& h : registered) {

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testPointInstancingWireframeHighlight.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testPointInstancingWireframeHighlight.cpp
@@ -16,8 +16,8 @@
 
 #include <mayaHydraLib/mayaHydra.h>
 
-#include <flowViewport/sceneIndex/fvpMergingSceneIndex.h>
 #include <flowViewport/sceneIndex/fvpWireframeSelectionHighlightSceneIndex.h>
+#include <flowViewport/selection/fvpPathMapperRegistry.h>
 
 #include <pxr/imaging/hd/instancedBySchema.h>
 #include <pxr/imaging/hd/instancerTopologySchema.h>
@@ -68,10 +68,6 @@ TEST(PointInstancingWireframeHighlight, pointInstancer)
     ASSERT_FALSE(terminalSceneIndices.empty());
     SceneIndexInspector inspector(terminalSceneIndices.front());
 
-    auto isFvpMergingSceneIndexPredicate = SceneIndexDisplayNamePred("Flow Viewport Merging Scene Index");
-    auto fvpMergingSceneIndex = TfDynamic_cast<Fvp::MergingSceneIndexRefPtr>(
-        findSceneIndexInTree(terminalSceneIndices.front(), isFvpMergingSceneIndexPredicate));
-
     auto isFvpWireframeSelectionHighlightSceneIndex = SceneIndexDisplayNamePred(
         "Flow Viewport Wireframe Selection Highlight Scene Index");
     auto fvpWireframeSelectionHighlightSceneIndex = TfDynamic_cast<Fvp::WireframeSelectionHighlightSceneIndexRefPtr>(
@@ -113,7 +109,7 @@ TEST(PointInstancingWireframeHighlight, pointInstancer)
     auto testInstancerDirectHighlightFn = [&](const Ufe::SceneItem::Ptr& instancerItem, const Ufe::Path& instancerPath) -> void {
         ufeSelection->replaceWith(instancerItem);
 
-        auto instancerPrimSelections = fvpMergingSceneIndex->UfePathToPrimSelections(instancerPath);
+        auto instancerPrimSelections = Fvp::ufePathToPrimSelections(instancerPath);
         ASSERT_EQ(instancerPrimSelections.size(), 1u);
         auto instancerPrimPath = instancerPrimSelections.front().primPath;
 
@@ -134,7 +130,7 @@ TEST(PointInstancingWireframeHighlight, pointInstancer)
     
     // Select point instancer ancestors
     auto testInstancerIndirectHighlightFn = [&](const Ufe::SceneItem::Ptr& instancerItem, const Ufe::Path& instancerPath) -> void {
-        auto instancerPrimPaths = fvpMergingSceneIndex->SceneIndexPaths(instancerPath);
+        auto instancerPrimPaths = Fvp::sceneIndexPaths(instancerPath);
         ASSERT_EQ(instancerPrimPaths.size(), 1u);
     
         // Validate scene structure
@@ -143,7 +139,7 @@ TEST(PointInstancingWireframeHighlight, pointInstancer)
         assertSelectionHighlightCorrectness(inspector.GetSceneIndex(), selectionHighlightPath, selectionHighlightMirrorTag, HdReprTokens->refinedWire);
     };
     auto testInstancerNoHighlightFn = [&](const Ufe::SceneItem::Ptr& instancerItem, const Ufe::Path& instancerPath) -> void {
-        auto instancerPrimPaths = fvpMergingSceneIndex->SceneIndexPaths(instancerPath);
+        auto instancerPrimPaths = Fvp::sceneIndexPaths(instancerPath);
         ASSERT_EQ(instancerPrimPaths.size(), 1u);
 
         // Ensure there is no selection highlight mirror for the prim
@@ -176,10 +172,6 @@ TEST(PointInstancingWireframeHighlight, instance)
     const SceneIndicesVector& terminalSceneIndices = GetTerminalSceneIndices();
     ASSERT_FALSE(terminalSceneIndices.empty());
     SceneIndexInspector inspector(terminalSceneIndices.front());
-
-    auto isFvpMergingSceneIndexPredicate = SceneIndexDisplayNamePred("Flow Viewport Merging Scene Index");
-    auto fvpMergingSceneIndex = TfDynamic_cast<Fvp::MergingSceneIndexRefPtr>(
-        findSceneIndexInTree(terminalSceneIndices.front(), isFvpMergingSceneIndexPredicate));
 
     auto isFvpWireframeSelectionHighlightSceneIndex = SceneIndexDisplayNamePred(
         "Flow Viewport Wireframe Selection Highlight Scene Index");
@@ -218,7 +210,7 @@ TEST(PointInstancingWireframeHighlight, instance)
     auto testInstanceHighlightFn = [&](const Ufe::SceneItem::Ptr& instanceItem, const Ufe::Path& instancePath) -> void {
         ufeSelection->replaceWith(instanceItem);
 
-        auto instancePrimSelections = fvpMergingSceneIndex->UfePathToPrimSelections(instancePath);
+        auto instancePrimSelections = Fvp::ufePathToPrimSelections(instancePath);
         ASSERT_EQ(instancePrimSelections.size(), 1u);
         auto instancerPrimPath = instancePrimSelections.front().primPath;
 
@@ -257,10 +249,6 @@ TEST(PointInstancingWireframeHighlight, prototype)
     ASSERT_FALSE(terminalSceneIndices.empty());
     SceneIndexInspector inspector(terminalSceneIndices.front());
 
-    auto isFvpMergingSceneIndexPredicate = SceneIndexDisplayNamePred("Flow Viewport Merging Scene Index");
-    auto fvpMergingSceneIndex = TfDynamic_cast<Fvp::MergingSceneIndexRefPtr>(
-        findSceneIndexInTree(terminalSceneIndices.front(), isFvpMergingSceneIndexPredicate));
-
     auto isFvpWireframeSelectionHighlightSceneIndex = SceneIndexDisplayNamePred(
         "Flow Viewport Wireframe Selection Highlight Scene Index");
     auto fvpWireframeSelectionHighlightSceneIndex = TfDynamic_cast<Fvp::WireframeSelectionHighlightSceneIndexRefPtr>(
@@ -298,7 +286,7 @@ TEST(PointInstancingWireframeHighlight, prototype)
     auto testPrototypeHighlightFn = [&](const Ufe::SceneItem::Ptr& prototypeItem, const Ufe::Path& prototypePath) -> void {
         ufeSelection->replaceWith(prototypeItem);
 
-        auto prototypePrimSelections = fvpMergingSceneIndex->UfePathToPrimSelections(prototypePath);
+        auto prototypePrimSelections = Fvp::ufePathToPrimSelections(prototypePath);
         // Original prim + 4 propagated prototypes
         EXPECT_EQ(prototypePrimSelections.size(), 1u + 4u);
 
@@ -327,10 +315,6 @@ TEST(PointInstancingWireframeHighlight, multiInstances)
     const SceneIndicesVector& terminalSceneIndices = GetTerminalSceneIndices();
     ASSERT_FALSE(terminalSceneIndices.empty());
     SceneIndexInspector inspector(terminalSceneIndices.front());
-
-    auto isFvpMergingSceneIndexPredicate = SceneIndexDisplayNamePred("Flow Viewport Merging Scene Index");
-    auto fvpMergingSceneIndex = TfDynamic_cast<Fvp::MergingSceneIndexRefPtr>(
-        findSceneIndexInTree(terminalSceneIndices.front(), isFvpMergingSceneIndexPredicate));
 
     auto isFvpWireframeSelectionHighlightSceneIndex = SceneIndexDisplayNamePred(
         "Flow Viewport Wireframe Selection Highlight Scene Index");
@@ -369,7 +353,7 @@ TEST(PointInstancingWireframeHighlight, multiInstances)
     ufeSelection->append(topInstancerFirstInstanceItem);
     ufeSelection->append(topInstancerSecondInstanceItem);
 
-    auto firstInstancePrimSelections = fvpMergingSceneIndex->UfePathToPrimSelections(topInstancerFirstInstancePath);
+    auto firstInstancePrimSelections = Fvp::ufePathToPrimSelections(topInstancerFirstInstancePath);
     ASSERT_EQ(firstInstancePrimSelections.size(), 1u);
     auto instancerPrimPath = firstInstancePrimSelections.front().primPath;
 

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testSelection.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testSelection.cpp
@@ -15,6 +15,8 @@
 
 #include "testUtils.h"
 
+#include <flowViewport/selection/fvpPathMapperRegistry.h>
+
 #include <pxr/imaging/hd/selectionSchema.h>
 #include <pxr/imaging/hd/selectionsSchema.h>
 
@@ -54,7 +56,7 @@ TEST(TestSelection, fullySelectedPaths)
 
     const Ufe::Path selected(Ufe::PathString::path(argv[0]));
 
-    const auto sceneIndexPath = snSi->SceneIndexPath(selected);
+    const auto sceneIndexPath = Fvp::sceneIndexPath(selected);
 
     ASSERT_FALSE(sceneIndexPath.IsEmpty());
 

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testSelectionSceneIndex.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testSelectionSceneIndex.cpp
@@ -21,6 +21,7 @@
 #include <maya/MSelectionList.h>
 
 #include <flowViewport/sceneIndex/fvpSelectionSceneIndex.h>
+#include <flowViewport/selection/fvpPathMapperRegistry.h>
 
 #include <pxr/imaging/hd/selectionSchema.h>
 #include <pxr/imaging/hd/selectionsSchema.h>
@@ -61,7 +62,7 @@ TEST(FlowViewport, selectionSceneIndex)
 
     // The sphere prim in the Hydra scene index scene has no selection data
     // source.  First, translate the application path into a scene index path.
-    const auto sceneIndexPath = selectionSi->SceneIndexPath(mayaPath);
+    const auto sceneIndexPath = Fvp::sceneIndexPath(mayaPath);
     ASSERT_EQ(sceneIndexPath.GetName(), mayaPath.back().string());
 
     // Next, check that there is no selections data source on the prim.
@@ -104,7 +105,7 @@ TEST(FlowViewport, selectionSceneIndex)
     // The shape under the sphere transform is not selected, but it has a
     // selected ancestor.
     auto mayaShapePath = Ufe::PathString::path("|aSphere|aSphereShape");
-    const auto sceneIndexShapePath = selectionSi->SceneIndexPath(mayaShapePath);
+    const auto sceneIndexShapePath = Fvp::sceneIndexPath(mayaShapePath);
 
     auto sphereShapePrim = sceneIndices.front()->GetPrim(sceneIndexShapePath);
     ASSERT_TRUE(sphereShapePrim.dataSource);
@@ -153,12 +154,12 @@ TEST(FlowViewport, selectionSceneIndexDirty)
     MSelectionList sphereSn;
     sphereSn.add("|aSphere");
     const auto mayaPath = Ufe::PathString::path("|aSphere");
-    const auto sceneIndexPath = selectionSi->SceneIndexPath(mayaPath);
+    const auto sceneIndexPath = Fvp::sceneIndexPath(mayaPath);
 
     MGlobal::setActiveSelectionList(sphereSn);
     hdSn = ssio.GetSelection();
-    ASSERT_EQ(hdSn->GetAllSelectedPrimPaths().size(), 1u);
-    ASSERT_EQ(hdSn->GetAllSelectedPrimPaths()[0], sceneIndexPath);
+    ASSERT_GE(hdSn->GetAllSelectedPrimPaths().size(), 1u);
+    ASSERT_TRUE(contains(hdSn->GetAllSelectedPrimPaths(), sceneIndexPath));
     ASSERT_TRUE(selectionSi->IsFullySelected(sceneIndexPath));
     ASSERT_TRUE(selectionSi->HasFullySelectedAncestorInclusive(sceneIndexPath));
 
@@ -172,8 +173,8 @@ TEST(FlowViewport, selectionSceneIndexDirty)
     // Add it back.
     MGlobal::setActiveSelectionList(sphereSn);
     hdSn = ssio.GetSelection();
-    ASSERT_EQ(hdSn->GetAllSelectedPrimPaths().size(), 1u);
-    ASSERT_EQ(hdSn->GetAllSelectedPrimPaths()[0], sceneIndexPath);
+    ASSERT_GE(hdSn->GetAllSelectedPrimPaths().size(), 1u);
+    ASSERT_TRUE(contains(hdSn->GetAllSelectedPrimPaths(), sceneIndexPath));
     ASSERT_TRUE(selectionSi->IsFullySelected(sceneIndexPath));
     ASSERT_TRUE(selectionSi->HasFullySelectedAncestorInclusive(sceneIndexPath));
 

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testSinglePicking.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testSinglePicking.cpp
@@ -66,5 +66,5 @@ TEST(TestSinglePicking, singlePick)
 
     // Postconditions
     ASSERT_EQ(Ufe::GlobalSelection::get()->size(), 1u);
-    ASSERT_EQ(inspector.FindPrims(isPrimSelectedPredicate).size(), 1u);
+    ASSERT_GE(inspector.FindPrims(isPrimSelectedPredicate).size(), 1u);
 }

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testUsdAnim.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testUsdAnim.cpp
@@ -1,7 +1,23 @@
+// Copyright 2024 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 
 #include "testUtils.h"
 
 #include <mayaHydraLib/hydraUtils.h>
+
+#include <flowViewport/selection/fvpPathMapperRegistry.h>
 
 #include <maya/MGlobal.h>
 
@@ -22,12 +38,8 @@ TEST(TestUsdAnim, timeVaryingTransform)
     ASSERT_EQ(argc, 1);
     const Ufe::Path cubePath(Ufe::PathString::path(argv[0]));
 
-    // Translate the cube application path into the cube scene index path using
-    // the selection scene index.
-    const auto snSi = findSelectionSceneIndexInTree(siRoot);
-    ASSERT_TRUE(snSi);
-
-    const auto cubeSiPath = snSi->SceneIndexPath(cubePath);
+    // Translate the cube application path into the cube scene index path.
+    const auto cubeSiPath = Fvp::sceneIndexPath(cubePath);
 
     ASSERT_FALSE(cubeSiPath.IsEmpty());
 

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testUsdPicking.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testUsdPicking.cpp
@@ -15,6 +15,8 @@
 
 #include "testUtils.h"
 
+#include <flowViewport/selection/fvpPathMapperRegistry.h>
+
 #include <maya/M3dView.h>
 #include <maya/MPoint.h>
 
@@ -51,7 +53,7 @@ void pick(const Ufe::Path& selectedPath, const Ufe::Path& markerPath, bool check
     const auto snSi = findSelectionSceneIndexInTree(siRoot);
     ASSERT_TRUE(snSi);
 
-    const auto sceneIndexPaths = snSi->SceneIndexPaths(selectedPath);
+    const auto sceneIndexPaths = Fvp::sceneIndexPaths(selectedPath);
     ASSERT_FALSE(sceneIndexPaths.empty());
 
     std::vector<std::pair<SdfPath, HdSceneIndexPrim>> prims;
@@ -74,7 +76,7 @@ void pick(const Ufe::Path& selectedPath, const Ufe::Path& markerPath, bool check
     // Perform a pick
     //======================================================================
 
-    const auto markerSceneIndexPath = snSi->SceneIndexPath(markerPath);
+    const auto markerSceneIndexPath = Fvp::sceneIndexPath(markerPath);
     ASSERT_FALSE(markerSceneIndexPath.IsEmpty());
 
     const auto markerPrim = siRoot->GetPrim(markerSceneIndexPath);

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testUsdPointInstancingIsolateSelect.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testUsdPointInstancingIsolateSelect.py
@@ -220,6 +220,7 @@ class TestUsdPointInstancingIsolateSelect(mtohUtils.MayaHydraBaseTestCase):
             # Native instanced USD object
             self.proxyShapePathStr + ',/cubeHierarchies/cubes_1',
             # Generated cube
+            self.cubeGenPath,
             self.cubeGenPath + ',/cube_0_0_0']
 
         self.assertIsolateSelect(modelPanel, visible, scene)

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testUtils.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testUtils.cpp
@@ -530,7 +530,7 @@ bool visibility(const HdSceneIndexBasePtr& sceneIndex, const SdfPath& primPath)
 
 bool contains(const PXR_NS::SdfPathVector& paths, const PXR_NS::SdfPath& path)
 {
-    return std::count(paths.begin(), paths.end(), path) > 0;
+    return std::find(paths.begin(), paths.end(), path) != paths.end();
 }
 
 } // namespace MAYAHYDRA_NS_DEF

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testUtils.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testUtils.cpp
@@ -528,4 +528,9 @@ bool visibility(const HdSceneIndexBasePtr& sceneIndex, const SdfPath& primPath)
     return (handle ? handle->GetTypedValue(0.0f) : true);
 }
 
+bool contains(const PXR_NS::SdfPathVector& paths, const PXR_NS::SdfPath& path)
+{
+    return std::count(paths.begin(), paths.end(), path) > 0;
+}
+
 } // namespace MAYAHYDRA_NS_DEF

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testUtils.h
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testUtils.h
@@ -495,6 +495,11 @@ void assertSelectionHighlightCorrectness(
  */
 bool visibility(const PXR_NS::HdSceneIndexBasePtr& sceneIndex, const PXR_NS::SdfPath& primPath);
 
+/**
+ * @brief Return whether argument path vector contains the argument path.
+ */
+bool contains(const PXR_NS::SdfPathVector& paths, const PXR_NS::SdfPath& path);
+
 } // namespace MAYAHYDRA_NS_DEF
 
 #endif // MAYAHYDRA_TEST_UTILS_H

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testWireframeSelectionHighlightSceneIndex.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testWireframeSelectionHighlightSceneIndex.cpp
@@ -4,7 +4,7 @@
 #include <mayaHydraLib/mayaHydra.h>
 
 #include <flowViewport/sceneIndex/fvpWireframeSelectionHighlightSceneIndex.h>
-#include <flowViewport/sceneIndex/fvpMergingSceneIndex.h>
+#include <flowViewport/selection/fvpPathMapperRegistry.h>
 
 #include <pxr/imaging/hdx/selectionSceneIndexObserver.h>
 #include <pxr/imaging/hd/tokens.h>
@@ -140,10 +140,6 @@ TEST(FlowViewport, wireframeSelectionHighlightSceneIndexDirty)
     ASSERT_EQ(ccHierarchy->children().size(), 2u);
 
     const auto& si = GetTerminalSceneIndices();
-    auto isFvpMergingSceneIndex = SceneIndexDisplayNamePred(
-        "Flow Viewport Merging Scene Index");
-    auto mergingSi = TfDynamic_cast<Fvp::MergingSceneIndexRefPtr>(
-        findSceneIndexInTree(si.front(), isFvpMergingSceneIndex));
     auto isFvpWireframeHighlightSceneIndex = SceneIndexDisplayNamePred(
         "Flow Viewport Wireframe Selection Highlight Scene Index");
     auto whSi = TfDynamic_cast<Fvp::WireframeSelectionHighlightSceneIndexRefPtr>(
@@ -173,8 +169,8 @@ TEST(FlowViewport, wireframeSelectionHighlightSceneIndexDirty)
     sn->append(sphereItem);
 
     // Find the sphere in the Hydra scene index scene.
-    auto sphereSiPath = mergingSi->SceneIndexPath(spherePath);
-    auto cubeSiPath = mergingSi->SceneIndexPath(scParentPath + "cube");
+    auto sphereSiPath = Fvp::sceneIndexPath(spherePath);
+    auto cubeSiPath = Fvp::sceneIndexPath(scParentPath + "cube");
 
     // Sphere is selected.
     hdSn = ssio.GetSelection();
@@ -201,9 +197,9 @@ TEST(FlowViewport, wireframeSelectionHighlightSceneIndexDirty)
 
     sn->replaceWith(newSn);
 
-    auto ccSiPath = mergingSi->SceneIndexPath(ccParentPath);
-    auto coneSiPath = mergingSi->SceneIndexPath(ccParentPath + "cone");
-    auto cylinderSiPath = mergingSi->SceneIndexPath(ccParentPath + "cylinder");
+    auto ccSiPath = Fvp::sceneIndexPath(ccParentPath);
+    auto coneSiPath = Fvp::sceneIndexPath(ccParentPath + "cone");
+    auto cylinderSiPath = Fvp::sceneIndexPath(ccParentPath + "cylinder");
 
     // Cone and cylinder parent is selected.
     // Cone is not selected.


### PR DESCRIPTION
Fvp::PathInterface was clunky to maintain and required new scene indices to adapt to it.  The path mapper framework is much less invasive.  This pull request disconnects the PathInterface, such that it is no longer used.  Removal from the code base will be done in a later pull request.
