### PR TITLE
HYDRA-1218 - remove the geometry shader optimization env var

### DIFF
--- a/lib/mayaHydra/mayaPlugin/plugin.cpp
+++ b/lib/mayaHydra/mayaPlugin/plugin.cpp
@@ -145,9 +145,6 @@ PLUGIN_EXPORT MStatus initializePlugin(MObject obj)
     // For now this is required for the HdSt backend to use lights.
     setEnv("USDIMAGING_ENABLE_SCENE_LIGHTS", "1");
 
-    // Performance optimization: disable RENDER_SELECTED_EDGE_FROM_FACE feature that could trigger unnecessary running of gometry shader.
-    setEnv("HDST_RENDER_SELECTED_EDGE_FROM_FACE", "0");
-
     MFnPlugin plugin(obj, "Autodesk", PLUGIN_VERSION, "Any");
 
     if (!plugin.registerCommand(


### PR DESCRIPTION
Remove the setting of geometry shader optimization env var as it's not needed anymore in USD 24.11.

See https://github.com/PixarAnimationStudios/OpenUSD/commit/436f4a7fa90ed9da252a2be371cf98e433316d45#diff-2cb369effe734e874e1c41dc47253250827dcbf233f81bf764e95af237a49c8f