### PR TITLE
HYDRA-1317 : re-enable tests with mtoa and lookdevX builds compatible…

### DIFF
--- a/test/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
+++ b/test/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
@@ -19,7 +19,7 @@ set(INTERACTIVE_TEST_SCRIPT_FILES
     testStageAddPrim.py
     testTransforms.py
     testRefinement.py
-    #testMaterialXOnNative.py|depOnPlugins:lookdevx HYDRA-1320 : disable this test until we get a new build of lookdevX
+    testMaterialXOnNative.py|depOnPlugins:lookdevx
     testNewSceneWithStage.py
     # To be reenabled after investigation
     #testMayaDisplayModes.py|skipOnPlatform:osx
@@ -36,7 +36,7 @@ set(INTERACTIVE_TEST_SCRIPT_FILES
     testOpenPBRSurface.py
     testFlowViewportAPI.py
     testStageVariants.py|skipOnPlatform:osx # HYDRA-1127 : refinedWire not working on OSX
-    #testStagePayloadsReferences.py #Disabled for usd 24.11 HYDRA-1317
+    testStagePayloadsReferences.py
     testNurbsPrimitives.py
     testCurveTools.py
     testPolygonPrimitives.py
@@ -48,7 +48,7 @@ set(INTERACTIVE_TEST_SCRIPT_FILES
     # To be reenabled after investigation
     testDataProducerSelHighlight.py|skipOnPlatform:osx # HYDRA-1127 : refinedWire not working on OSX
     testPassingNormalsOnMayaNative.py
-    #testViewportFilters.py #Disabled for usd 24.11 HYDRA-1317
+    testViewportFilters.py|depOnPlugins:mtoa
     testMayaComponentsPicking.py
     testFlowPluginsHierarchicalProperties.py
     testCustomShadersNode.py

--- a/test/lib/mayaUsd/render/mayaToHydra/testStagePayloadsReferences.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/testStagePayloadsReferences.py
@@ -117,6 +117,8 @@ class TestUsdStagePayloadsAndReferences(mtohUtils.MayaHydraBaseTestCase): #Subcl
         cmd.execute()
         self.assertTrue(prim.HasPayload())
         self.assertTrue(prim.IsLoaded())
+        #Is needed with usd 24.11 to keep the same images
+        self.modifyDefaultLightIntensityByUsdVersion()
         self.assertSnapshotClose("cubeLoaded.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
 
         # Verify unload payload
@@ -142,6 +144,8 @@ class TestUsdStagePayloadsAndReferences(mtohUtils.MayaHydraBaseTestCase): #Subcl
         cmd.execute()
         self.assertTrue(prim.IsLoaded())
         self.assertSnapshotClose("cubeLoadWithDescendants.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
+
+        self.resetDefaultLightIntensityByUsdVersion()
 
     def test_UsdStagePayloadsFromScene(self):
         from mayaUsd import lib as mayaUsdLib


### PR DESCRIPTION
… with usd 24.11, maya 2026 API update and ufe 6 bump.