### PR TITLE
HYDRA-1463 : Avoid translating a specific type of internal dummy render items to Hydra

### DIFF
--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
@@ -582,6 +582,12 @@ void MayaHydraSceneIndex::HandleCompleteViewportScene(const MDataServerOperation
 
         auto& ri = *scene.mItems[i];
 
+        // ProxyGeometryItems are a special type of dummy render item created internally by Maya
+        // to implement and handle MPxDrawOverride. We do not need to translate these to Hydra.
+        if (ri.name() == "ProxyGeometryItem") {
+            continue;
+        }
+
         // Meshes can optionally be handled by the mesh adapter, rather than by
         // render items.
         if (filterMesh(ri)) {


### PR DESCRIPTION
This fixes the numerous assertions encountered in the testMayaDefaultMaterial, but the assertions were not exclusive to it.