### PR TITLE
MSVC 14.3 fixes (adding <optional> includes)

### DIFF
--- a/lib/flowViewport/sceneIndex/fvpDisplayStyleOverrideSceneIndex.h
+++ b/lib/flowViewport/sceneIndex/fvpDisplayStyleOverrideSceneIndex.h
@@ -22,6 +22,7 @@
 #include "pxr/imaging/hd/filteringSceneIndex.h"
 
 #include <set>
+#include <optional>
 
 namespace FVP_NS_DEF {
 

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraMayaDataProducerSceneIndexData.h
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraMayaDataProducerSceneIndexData.h
@@ -27,6 +27,8 @@
 #include <ufe/sceneNotification.h>
 #include <ufe/transform3d.h>
 
+#include <optional>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 class MayaDataProducerSceneIndexData;

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraMayaFilteringSceneIndexData.h
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraMayaFilteringSceneIndexData.h
@@ -28,6 +28,8 @@
 #include <ufe/scene.h>
 #include <ufe/sceneNotification.h>
 
+#include <optional>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 class MayaFilteringSceneIndexData;

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mhMayaUsdProxyShapeSceneIndex.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mhMayaUsdProxyShapeSceneIndex.cpp
@@ -33,6 +33,8 @@
 #include <pxr/imaging/hd/instancerTopologySchema.h>
 #include <pxr/usdImaging/usdImaging/usdPrimInfoSchema.h>
 
+#include <optional>
+
 PXR_NAMESPACE_USING_DIRECTIVE
 
 namespace {


### PR DESCRIPTION
Hi,

I've just compiled with Visual Studio 17 2022 and found that a few `#include <optional>` were required, so I've tweaked that up here.

Cheers