### PR TITLE
Do not register pick handler twice.

### DIFF
--- a/lib/mayaHydra/hydraExtensions/pick/mhPickHandlerRegistry.cpp
+++ b/lib/mayaHydra/hydraExtensions/pick/mhPickHandlerRegistry.cpp
@@ -106,6 +106,14 @@ bool PickHandlerRegistry::Unregister(const SdfPath& prefix)
     return true;
 }
 
+PickHandlerConstPtr PickHandlerRegistry::RegisteredHandler(
+    const PXR_NS::SdfPath& path
+) const
+{
+    auto found = pickHandlers.find(path);
+    return (found == pickHandlers.end()) ? nullptr : found->second;
+}
+
 PickHandlerConstPtr PickHandlerRegistry::GetHandler(const SdfPath& path) const
 {
     // No entries yet?  Fail.

--- a/lib/mayaHydra/hydraExtensions/pick/mhPickHandlerRegistry.h
+++ b/lib/mayaHydra/hydraExtensions/pick/mhPickHandlerRegistry.h
@@ -54,6 +54,12 @@ public:
     MAYAHYDRALIB_API
     bool Unregister(const PXR_NS::SdfPath& prefix);
 
+    //! Query the pick handler registered for that exact Hydra scene index
+    //! path.  If no pick handler has been registered, return a nullptr.
+    //! To obtain a handler that handles a given path, use GetHandler().
+    MAYAHYDRALIB_API
+    PickHandlerConstPtr RegisteredHandler(const PXR_NS::SdfPath& path) const;
+
     //! Get a pick handler for the argument Hydra scene index path.  This
     //! handler has a prefix that is an ancestor of the argument path.  If no
     //! pick handler is found, returns a null pointer.

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
@@ -466,9 +466,13 @@ MayaHydraSceneIndex::MayaHydraSceneIndex(
         _fallbackMaterial = SdfPath::EmptyPath(); // Empty path for hydra fallback material
     });
 
-    // Add our pick handler to the pick handler registry.
-    auto pickHandler = std::make_shared<MayaPickHandler>(*this);
-    TF_AXIOM(MayaHydra::PickHandlerRegistry::Instance().Register(_rprimPath, pickHandler));
+    // Add our pick handler to the pick handler registry if there is none.
+    auto& phr = MayaHydra::PickHandlerRegistry::Instance();
+    _unregisterPickHandler = (phr.RegisteredHandler(_rprimPath) == nullptr);
+    if (_unregisterPickHandler) {
+      auto pickHandler = std::make_shared<MayaPickHandler>(*this);
+      TF_AXIOM(phr.Register(_rprimPath, pickHandler));
+    }
 
     //Always add the mayaHydraFacesSelectionMaterialDataSource to display faces selection
     // Always Create the material since it will update the color from the preferences if it has
@@ -525,7 +529,9 @@ void MayaHydraSceneIndex::_Destroy()
     Fvp::PathMapperRegistry::Instance().SetFallbackMapper(nullptr);
 
     // Remove our pick handler from the pick handler registry.
-    TF_AXIOM(MayaHydra::PickHandlerRegistry::Instance().Unregister(_rprimPath));
+    if (_unregisterPickHandler) {
+      TF_AXIOM(MayaHydra::PickHandlerRegistry::Instance().Unregister(_rprimPath));
+    }
 }
 
 void MayaHydraSceneIndex::HandleCompleteViewportScene(const MDataServerOperation::MViewportScene& scene, MFrameContext::DisplayStyle ds)

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.h
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.h
@@ -363,6 +363,8 @@ private:
     const Fvp::PathMapperConstPtr _mayaPathMapper{};
 
     Fvp::LightsManagementSceneIndexRefPtr _lightsManagementSceneIndex { nullptr };
+
+    bool _unregisterPickHandler{false};
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
I was unable to write an automated test for this.  In the automated test, the renderer switch on the second viewport does not occur, even if I force refresh, so the duplicate pick handler registration does not happen.

Manually tested the fix interactively.
