### PR TITLE
HYDRA-1701 - Add preliminary support for USD 25.05

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -17,7 +17,7 @@ Before building the project, consult the following table to ensure you use the r
 | Python Packages | PyYAML, PySide, PyOpenGL | PyYAML, PySide2, PyOpenGL | PyYAML, PySide, PyOpenGL |
 | Build generator | Visual Studio, Ninja (Recommended) | XCode, Ninja (Recommended) | Ninja (Recommended) |
 | Command processor | x64 Native Tools Command Prompt for VS 2022 | bash | bash |
-| Supported Maya Version | 2025, 2026 | 2025, 2026 | 2025, 2026 |
+| Supported Maya Version | 2025, 2026, PR | 2025, 2026, PR | 2025, 2026, PR |
 
 >Note: Maya 2024 is not officially supported. For more details about building for Maya 2024, [see this example.](./rebuildingWithCustomOpenUSDAndPreviousMayaVersion.md)
 
@@ -30,7 +30,7 @@ If you want to <B>be able to import usd data in maya through [MayaUSD](https://g
 
 | | ![](images/pxr.png) | USD version used in Maya | USD source for MayaUSD / MayaHydra |
 |:-: |:-: |:-:|:-:|
-| CommitID/Tags | [v23.11](https://github.com/PixarAnimationStudios/OpenUSD/releases/tag/v23.11)<BR>[v24.11](https://github.com/PixarAnimationStudios/OpenUSD/releases/tag/v24.11) | Maya 2025 = v23.11<br>Maya 2026 = v24.11 | [v23.11-MayaUsd-Public](https://github.com/autodesk-forks/USD/tree/v23.11-MayaUsd-Public)<br>[v24.11-MayaUsd-Public](https://github.com/autodesk-forks/USD/tree/v24.11-MayaUsd-Public) |
+| CommitID/Tags | [v23.11](https://github.com/PixarAnimationStudios/OpenUSD/releases/tag/v23.11)<BR>[v24.11](https://github.com/PixarAnimationStudios/OpenUSD/releases/tag/v24.11)<BR>[v25.05](https://github.com/PixarAnimationStudios/OpenUSD/releases/tag/v25.05) | Maya 2025 = v23.11<br>Maya 2026 = v24.11<br>Maya PR = v25.05 | [v23.11-MayaUsd-Public](https://github.com/autodesk-forks/USD/tree/v23.11-MayaUsd-Public)<br>[v24.11-MayaUsd-Public](https://github.com/autodesk-forks/USD/tree/v24.11-MayaUsd-Public)<br>[v25.05-MayaUsd-Public](https://github.com/autodesk-forks/USD/tree/v25.05-MayaUsd-Public) |
 
 For additional information on building Pixar USD, see the ***Additional Build Instruction*** section below.
 
@@ -48,7 +48,7 @@ The Universal Front End (UFE) is a DCC-agnostic component that allows Maya to br
 
 | UFE Version | Maya Version | UFE Docs (external) |
 |-|-|:-:|
-| v4.2.0<br>v6.0.0 | Maya 2025<br>Maya 2026 | https://help.autodesk.com/view/MAYADEV/2025/ENU/?guid=MAYA_API_REF_ufe_ref_index_html |
+| v4.2.0<br>v6.0.0<br>vTBD | Maya 2025<br>Maya 2026<br>Maya PR | https://help.autodesk.com/view/MAYADEV/2025/ENU/?guid=MAYA_API_REF_ufe_ref_index_html |
 
 To build the project with UFE support, you will need to use the headers and libraries included in the ***Maya Devkit***:
 

--- a/doc/build.md
+++ b/doc/build.md
@@ -11,7 +11,7 @@ Before building the project, consult the following table to ensure you use the r
 | Required | ![](images/windows.png) | ![](images/mac.png) | ![](images/linux.png) |
 |:-:|:-:|:-:|:-:|
 | Operating System | Windows 10 <br> Windows 11 | High Sierra (10.13)<br>Mojave (10.14)<br>Catalina (10.15)<br>Big Sur (11.2.x) | Rocky Linux 8.6 / Linux® Red Hat® Enterprise 8.6 WS |
-| Compiler Requirement| Maya 2025 (VS 2022)<br>Maya 2026 (VS 2022) | Maya 2025 (Xcode 13.4 or higher)<br>Maya 2026 (Xcode 13.4 or higher) | Maya 2025 (gcc 11.2.1)<br>Maya 2026 (gcc 11.2.1) |
+| Compiler Requirement| Maya 2025 (VS 2022)<br>Maya 2026 (VS 2022)<br>Maya PR (VS 2022) | Maya 2025 (Xcode 13.4 or higher)<br>Maya 2026 (Xcode 13.4 or higher)<br>Maya PR (Xcode 13.4 or higher) | Maya 2025 (gcc 11.2.1)<br>Maya 2026 (gcc 11.2.1)<br>Maya PR (gcc 11.2.1) |
 | CMake Version (min/max) | 3.14...3.30 | 3.14...3.30 | 3.14...3.30 |
 | Python | 3.11.4, 3.11.9 | 3.11.4, 3.11.9 | 3.11.4, 3.11.9 |
 | Python Packages | PyYAML, PySide, PyOpenGL | PyYAML, PySide2, PyOpenGL | PyYAML, PySide, PyOpenGL |

--- a/lib/flowViewport/API/samples/fvpDataProducerSceneIndexExample.cpp
+++ b/lib/flowViewport/API/samples/fvpDataProducerSceneIndexExample.cpp
@@ -88,9 +88,14 @@ namespace PrototypeInstancing
         static auto emptyArray = HdRetainedTypedSampledDataSource<VtIntArray>::New(VtIntArray());
 
         return HdPrimvarSchema::BuildRetained(getRetainedDataSource(value),
-            HdSampledDataSourceHandle(), emptyArray, //is an indexer on the primVars which we don't use, primVars are not indexed in our case.
+            HdSampledDataSourceHandle(),
+            emptyArray, //is an indexer on the primVars which we don't use, primVars are not indexed in our case.
             HdPrimvarSchema::BuildInterpolationDataSource(interpolation),
-            HdPrimvarSchema::BuildInterpolationDataSource(role));
+            HdPrimvarSchema::BuildInterpolationDataSource(role)
+#if PXR_VERSION >= 2505 // const HdIntDataSourceHandle& elementSize added in USD 25.05
+            , nullptr
+#endif
+        );
     }
 
     //Create an instancer topology data source for the instancer, and supply the matrices as a by-instance varying primvar.

--- a/lib/flowViewport/sceneIndex/wireframeHighlights/fvpBaseWhSi.cpp
+++ b/lib/flowViewport/sceneIndex/wireframeHighlights/fvpBaseWhSi.cpp
@@ -814,7 +814,7 @@ BaseWhSi::MakeGeomSubsetHighlight(
     if (!GetMaterialPath(geomSubsetPrimDataSource).IsEmpty()) {
         HdContainerDataSourceEditor dataSourceEditor(editedMeshPrimDataSource);
         dataSourceEditor.Set(HdMaterialBindingsSchema::GetDefaultLocator(), HdContainerDataSource::Get(geomSubsetPrimDataSource, HdMaterialBindingsSchema::GetDefaultLocator()));
-#if PXR_VERSION >= 2511
+#if PXR_VERSION >= 2505
         dataSourceEditor.Set(UsdImagingMaterialBindingsSchema::GetDefaultLocator(), HdContainerDataSource::Get(geomSubsetPrimDataSource, UsdImagingMaterialBindingsSchema::GetDefaultLocator()));
 #elif PXR_VERSION >= 2403
         dataSourceEditor.Set(UsdImagingDirectMaterialBindingsSchema::GetDefaultLocator(), HdContainerDataSource::Get(geomSubsetPrimDataSource, UsdImagingDirectMaterialBindingsSchema::GetDefaultLocator()));

--- a/lib/flowViewport/sceneIndex/wireframeHighlights/fvpBaseWhSi.cpp
+++ b/lib/flowViewport/sceneIndex/wireframeHighlights/fvpBaseWhSi.cpp
@@ -36,7 +36,9 @@
 #include <pxr/imaging/hd/sceneIndexPrimView.h>
 #include <pxr/imaging/hd/selectionsSchema.h>
 #include <pxr/imaging/hd/tokens.h>
-#if PXR_VERSION >= 2403
+#if PXR_VERSION >= 2505
+#include <pxr/usdImaging/usdImaging/materialBindingsSchema.h>
+#elif PXR_VERSION >= 2403
 #include <pxr/usdImaging/usdImaging/directMaterialBindingsSchema.h>
 #endif
 #include <pxr/usdImaging/usdImaging/usdPrimInfoSchema.h>
@@ -812,7 +814,9 @@ BaseWhSi::MakeGeomSubsetHighlight(
     if (!GetMaterialPath(geomSubsetPrimDataSource).IsEmpty()) {
         HdContainerDataSourceEditor dataSourceEditor(editedMeshPrimDataSource);
         dataSourceEditor.Set(HdMaterialBindingsSchema::GetDefaultLocator(), HdContainerDataSource::Get(geomSubsetPrimDataSource, HdMaterialBindingsSchema::GetDefaultLocator()));
-#if PXR_VERSION >= 2403
+#if PXR_VERSION >= 2511
+        dataSourceEditor.Set(UsdImagingMaterialBindingsSchema::GetDefaultLocator(), HdContainerDataSource::Get(geomSubsetPrimDataSource, UsdImagingMaterialBindingsSchema::GetDefaultLocator()));
+#elif PXR_VERSION >= 2403
         dataSourceEditor.Set(UsdImagingDirectMaterialBindingsSchema::GetDefaultLocator(), HdContainerDataSource::Get(geomSubsetPrimDataSource, UsdImagingDirectMaterialBindingsSchema::GetDefaultLocator()));
 #endif
         editedMeshPrimDataSource = dataSourceEditor.Finish();


### PR DESCRIPTION
- The header file `pxr/usdImaging/usdImaging/directMaterialBindingsSchema.h` was removed
    - Commit: https://github.com/PixarAnimationStudios/OpenUSD/commit/0380d05419a166f1a6535d2eafe33bf34522f8f0
    - According to the commit message, `materialBindingsSchema.h` should be used instead
- `HdPrimvarSchema::BuildRetained` now takes 6 arguments instead of 5
    - Commit: https://github.com/PixarAnimationStudios/OpenUSD/commit/83d6b3a24ed0af53fe8d27c4827e63fd2f0a51fb