### PR TITLE
HYDRA-1626: Hydra Primitive Scene Stats 

### DIFF
--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
@@ -1349,6 +1349,15 @@ HdMeshTopology MayaHydraSceneIndex::GetMeshTopology(const SdfPath& id)
         _renderItemsAdapters);
 }
 
+HdBasisCurvesTopology MayaHydraSceneIndex::GetBasisCurvesTopology(const SdfPath& id)
+{
+    return _GetValue<MayaHydraAdapter, HdBasisCurvesTopology>(
+        id,
+        [](MayaHydraAdapter* a) -> HdBasisCurvesTopology { return a->GetBasisCurvesTopology(); },
+        _shapeAdapters,
+        _renderItemsAdapters);
+}
+
 void MayaHydraSceneIndex::RemoveAdapter(const SdfPath& id)
 {
     if (!_RemoveAdapter<MayaHydraAdapter>(

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.h
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.h
@@ -193,6 +193,8 @@ public:
 
     HdMeshTopology GetMeshTopology(const SdfPath& id);
 
+    HdBasisCurvesTopology GetBasisCurvesTopology(const SdfPath& id);
+
     SdfPath GetPrimPath(const MDagPath& dg, bool isSprim) const;
 
     SdfPath GetRprimPath() const { return _rprimPath; }

--- a/lib/mayaHydra/mayaPlugin/renderOverride.cpp
+++ b/lib/mayaHydra/mayaPlugin/renderOverride.cpp
@@ -86,15 +86,12 @@
 #include <pxr/imaging/hd/rprim.h>
 #include <pxr/imaging/hd/sceneIndexPluginRegistry.h>
 #include <pxr/imaging/hd/dataSource.h>
-#include <pxr/imaging/hd/basisCurvesTopology.h>
-#include <pxr/imaging/hd/meshTopology.h>
 #include <pxr/imaging/hd/meshSchema.h>
 #include <pxr/imaging/hd/basisCurvesSchema.h>
 #include <pxr/imaging/hd/sceneIndexPrimView.h>
 #include <pxr/imaging/hd/mesh.h>
 #include <pxr/imaging/hd/basisCurves.h>
 #include <pxr/imaging/hd/points.h>
-#include <pxr/imaging/hd/tokens.h>
 #include <pxr/imaging/hdx/selectionTask.h>
 #include <pxr/imaging/hdx/colorizeSelectionTask.h>
 #include <pxr/imaging/hdx/pickTask.h>
@@ -131,7 +128,6 @@
 #include <chrono>
 #include <exception>
 #include <limits>
-#include <numeric>
 
 int _profilerCategory = MProfiler::addCategory(
     "MtohRenderOverride (mayaHydra)",
@@ -456,6 +452,8 @@ std::map<std::string, int> MtohRenderOverride::GetSceneStatistics()
     std::map<std::string, int> stats = {
         {"primitives", 0},
         {"mesh", 0},
+        {"mesh.points", 0},
+        {"mesh.faces", 0},
         {"curve", 0},
         {"curve.points", 0},
         {"point", 0},

--- a/lib/mayaHydra/mayaPlugin/renderOverride.cpp
+++ b/lib/mayaHydra/mayaPlugin/renderOverride.cpp
@@ -88,7 +88,13 @@
 #include <pxr/imaging/hd/dataSource.h>
 #include <pxr/imaging/hd/basisCurvesTopology.h>
 #include <pxr/imaging/hd/meshTopology.h>
+#include <pxr/imaging/hd/meshSchema.h>
+#include <pxr/imaging/hd/basisCurvesSchema.h>
 #include <pxr/imaging/hd/sceneIndexPrimView.h>
+#include <pxr/imaging/hd/mesh.h>
+#include <pxr/imaging/hd/basisCurves.h>
+#include <pxr/imaging/hd/points.h>
+#include <pxr/imaging/hd/tokens.h>
 #include <pxr/imaging/hdx/selectionTask.h>
 #include <pxr/imaging/hdx/colorizeSelectionTask.h>
 #include <pxr/imaging/hdx/pickTask.h>
@@ -125,6 +131,7 @@
 #include <chrono>
 #include <exception>
 #include <limits>
+#include <numeric>
 
 int _profilerCategory = MProfiler::addCategory(
     "MtohRenderOverride (mayaHydra)",
@@ -449,8 +456,6 @@ std::map<std::string, int> MtohRenderOverride::GetSceneStatistics()
     std::map<std::string, int> stats = {
         {"primitives", 0},
         {"mesh", 0},
-        {"mesh.points", 0},
-        {"mesh.faces", 0},
         {"curve", 0},
         {"curve.points", 0},
         {"point", 0},
@@ -481,35 +486,55 @@ std::map<std::string, int> MtohRenderOverride::GetSceneStatistics()
         }
 
         stats["primitives"]++;
-
-        HdSceneIndexPrim prim;
-        TfToken primType;
-        if (instance->_mayaHydraSceneIndex) {
-            prim = instance->_mayaHydraSceneIndex->GetPrim(primId);
-            primType = prim.primType;
-        }
-
-        if (primType.IsEmpty()) {
+        auto* mesh = dynamic_cast<const HdMesh*>(rprim);
+        if (mesh) {
+            stats["mesh"]++;
+            auto sceneIndexPrim = renderIndex->GetTerminalSceneIndex()->GetPrim(primId);
+            auto meshSchema = HdMeshSchema::GetFromParent(sceneIndexPrim.dataSource);
+            if (meshSchema.IsDefined()) {
+                auto meshTopology = meshSchema.GetTopology();
+                if (meshTopology.IsDefined()) {
+                    auto faceVertexCounts = meshTopology.GetFaceVertexCounts();
+                    auto faceVertexIndices = meshTopology.GetFaceVertexIndices();
+                    if (faceVertexCounts && faceVertexIndices) {
+                        auto counts = faceVertexCounts->GetTypedValue(0.0f);
+                        auto indices = faceVertexIndices->GetTypedValue(0.0f);
+                        stats["mesh.faces"] += counts.size();
+                        if (!indices.empty()) {
+                            int maxIndex = *std::max_element(indices.begin(), indices.end());
+                            stats["mesh.points"] += maxIndex + 1;
+                        }
+                    }
+                }
+            }
             continue;
         }
 
-        if (primType == HdPrimTypeTokens->mesh) {
-            stats["mesh"]++;
-            if (instance->_mayaHydraSceneIndex && prim.dataSource) {
-                HdMeshTopology meshTopology = instance->_mayaHydraSceneIndex->GetMeshTopology(primId);
-                stats["mesh.points"] += meshTopology.GetNumPoints();
-                stats["mesh.faces"] += meshTopology.GetNumFaces();
-            }
-        }
-        else if (primType == HdPrimTypeTokens->basisCurves) {
+        auto* curves = dynamic_cast<const HdBasisCurves*>(rprim);
+        if (curves) {
             stats["curve"]++;
-            if (instance->_mayaHydraSceneIndex && prim.dataSource) {
-                HdBasisCurvesTopology curvesTopology = instance->_mayaHydraSceneIndex->GetBasisCurvesTopology(primId);
-                stats["curve.points"] += curvesTopology.GetNumPoints();
+            auto sceneIndexPrim = renderIndex->GetTerminalSceneIndex()->GetPrim(primId);
+            auto curvesSchema = HdBasisCurvesSchema::GetFromParent(sceneIndexPrim.dataSource);
+            if (curvesSchema.IsDefined()) { 
+                auto curvesTopology  = curvesSchema.GetTopology();
+                if (curvesTopology.IsDefined()) {
+                    auto curveIndices = curvesTopology.GetCurveIndices();
+                    if (curveIndices) {
+                        auto indices = curveIndices->GetTypedValue(0.0f);
+                        if (!indices.empty()) {
+                            int maxIndex = *std::max_element(indices.begin(), indices.end());
+                            stats["curve.points"] += maxIndex + 1;
+                        }
+                    }
+                }
             }
+            continue;
         }
-        else if (primType == HdPrimTypeTokens->points) {
+
+        auto* points = dynamic_cast<const HdPoints*>(rprim);
+        if (points) {
             stats["point"]++;
+            continue;
         }
     }
     return stats;

--- a/lib/mayaHydra/mayaPlugin/renderOverride.cpp
+++ b/lib/mayaHydra/mayaPlugin/renderOverride.cpp
@@ -85,6 +85,10 @@
 #include <pxr/imaging/hd/rendererPluginRegistry.h>
 #include <pxr/imaging/hd/rprim.h>
 #include <pxr/imaging/hd/sceneIndexPluginRegistry.h>
+#include <pxr/imaging/hd/dataSource.h>
+#include <pxr/imaging/hd/basisCurvesTopology.h>
+#include <pxr/imaging/hd/meshTopology.h>
+#include <pxr/imaging/hd/sceneIndexPrimView.h>
 #include <pxr/imaging/hdx/selectionTask.h>
 #include <pxr/imaging/hdx/colorizeSelectionTask.h>
 #include <pxr/imaging/hdx/pickTask.h>
@@ -438,6 +442,77 @@ int MtohRenderOverride::GetUsedGPUMemory()
         totalGPUMemory += instance->_GetUsedGPUMemory().UncheckedGet<int>();
     }
     return totalGPUMemory / (1024*1024); 
+}
+
+std::map<std::string, int> MtohRenderOverride::GetSceneStatistics()
+{
+    std::map<std::string, int> stats = {
+        {"primitives", 0},
+        {"mesh", 0},
+        {"mesh.points", 0},
+        {"mesh.faces", 0},
+        {"curve", 0},
+        {"curve.points", 0},
+        {"point", 0},
+    };
+
+    MtohRenderOverride* instance = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(_allInstancesMutex);
+        for (auto* inst : _allInstances) {
+            if (inst->_initializationSucceeded && inst->_renderIndex) {
+                instance = inst;
+                break;
+            }
+        }
+    }
+
+    if (!instance || !instance->_renderIndex) {
+        return stats;
+    }
+
+    auto* renderIndex = instance->_renderIndex;
+    auto primIds = renderIndex->GetRprimIds();
+
+    for (const auto& primId : primIds) {
+        auto* rprim = renderIndex->GetRprim(primId);
+        if (!rprim) {
+            continue;
+        }
+
+        stats["primitives"]++;
+
+        HdSceneIndexPrim prim;
+        TfToken primType;
+        if (instance->_mayaHydraSceneIndex) {
+            prim = instance->_mayaHydraSceneIndex->GetPrim(primId);
+            primType = prim.primType;
+        }
+
+        if (primType.IsEmpty()) {
+            continue;
+        }
+
+        if (primType == HdPrimTypeTokens->mesh) {
+            stats["mesh"]++;
+            if (instance->_mayaHydraSceneIndex && prim.dataSource) {
+                HdMeshTopology meshTopology = instance->_mayaHydraSceneIndex->GetMeshTopology(primId);
+                stats["mesh.points"] += meshTopology.GetNumPoints();
+                stats["mesh.faces"] += meshTopology.GetNumFaces();
+            }
+        }
+        else if (primType == HdPrimTypeTokens->basisCurves) {
+            stats["curve"]++;
+            if (instance->_mayaHydraSceneIndex && prim.dataSource) {
+                HdBasisCurvesTopology curvesTopology = instance->_mayaHydraSceneIndex->GetBasisCurvesTopology(primId);
+                stats["curve.points"] += curvesTopology.GetNumPoints();
+            }
+        }
+        else if (primType == HdPrimTypeTokens->points) {
+            stats["point"]++;
+        }
+    }
+    return stats;
 }
 
 std::vector<MString> MtohRenderOverride::AllActiveRendererNames()

--- a/lib/mayaHydra/mayaPlugin/renderOverride.h
+++ b/lib/mayaHydra/mayaPlugin/renderOverride.h
@@ -151,6 +151,9 @@ public:
     // Utility function to get GPU memory usage stats
     static int GetUsedGPUMemory();
 
+    // Returns scene statistics as a map for the currently active render delegate from Hydra primitives
+    static std::map<std::string, int> GetSceneStatistics();
+
     bool                         startOperationIterator() override;
     MHWRender::MRenderOperation* renderOperation() override;
     bool                         nextRenderOperation() override;

--- a/lib/mayaHydra/mayaPlugin/viewCommand.cpp
+++ b/lib/mayaHydra/mayaPlugin/viewCommand.cpp
@@ -100,6 +100,9 @@ constexpr auto _rendererIdLong = "-renderer";
 constexpr auto _userDefaultsId = "-u";
 constexpr auto _userDefaultsIdLong = "-userDefaults";
 
+constexpr auto _sceneStats = "-ss";
+constexpr auto _sceneStatsLong = "-sceneStats";
+
 constexpr auto _helpText = R"HELP(For details on args usage please see 
 https://github.com/Autodesk/maya-hydra/tree/dev/doc/mayaHydraCommads.md
 )HELP";
@@ -151,6 +154,8 @@ MSyntax MtohViewCmd::createSyntax()
 
     syntax.addFlag(_usdVersion, _usdVersionLong);
 
+    syntax.addFlag(_sceneStats, _sceneStatsLong);
+
     return syntax;
 }
 
@@ -176,8 +181,14 @@ MStatus MtohViewCmd::doIt(const MArgList& args)
 
     if (db.isFlagSet(_hdGPUMem)) {
         appendToResult(MtohRenderOverride::GetUsedGPUMemory());
-    } if (db.isFlagSet(_currentProcessMemory)) {
+    } else if (db.isFlagSet(_currentProcessMemory)) {
         appendToResult(getProcessMemory());
+    } else if (db.isFlagSet(_sceneStats)) {
+        auto stats = MtohRenderOverride::GetSceneStatistics();
+        for (const auto& pair : stats) {
+            appendToResult(pair.first.c_str()); 
+            appendToResult(std::to_string(pair.second).c_str());
+        }
     } else if (db.isFlagSet(_listRenderers)) {
         for (auto& plugin : MtohGetRendererDescriptions())
             appendToResult(plugin.rendererName.GetText());

--- a/test/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
+++ b/test/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
@@ -6,6 +6,7 @@
 # only single platform exclusion is supported currently.
 # For specifying exclusion based on plugin dependency, look at: test_to_run.json
 set(INTERACTIVE_TEST_SCRIPT_FILES
+    testSceneStat.py
     testImageDiffing.py
     testMtohCommand.py
     testBasicRender.py

--- a/test/lib/mayaUsd/render/mayaToHydra/testSceneStat.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/testSceneStat.py
@@ -1,0 +1,72 @@
+# Copyright 2025 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import maya.cmds as cmds
+import maya.mel as mel
+import unittest
+
+import fixturesUtils
+import mtohUtils
+
+class TestSceneStatistics(mtohUtils.MayaHydraBaseTestCase):
+    _file = __file__
+
+    def test_sceneStatistics(self):
+        # empty scene, no primitives
+        cmds.file(new=True, force=True)
+        cmds.refresh()
+        empty_stats = cmds.mayaHydra(sceneStats=True)
+        empty_info = {empty_stats[i]: int(empty_stats[i + 1]) for i in range(0, len(empty_stats), 2)}
+        
+        # simple primitive scene -- 1 mesh, curve, point
+        cmds.polyCube()
+        cmds.circle() 
+        cmds.particle(position=[(0, 0, 0)])
+        cmds.refresh()
+        primitive_stats = cmds.mayaHydra(sceneStats=True)
+        primitive_info = {primitive_stats[i]: int(primitive_stats[i + 1]) for i in range(0, len(primitive_stats), 2)}
+
+        expected_empty_counts = {
+            "primitives": 0,
+            "mesh": 0,
+            "mesh.points": 0,
+            "mesh.faces": 0,
+            "curve": 0,
+            "curve.points": 0,
+            "point": 0,
+        }
+        
+        expected_primitive_counts = {
+            "primitives": 3,
+            "mesh": 1,
+            "mesh.points": 24,
+            "mesh.faces": 12,
+            "curve": 1,
+            "curve.points": 41,
+            "point": 1,
+        }
+        
+        for stat_type, expected_count in expected_empty_counts.items():
+            actual_count = empty_info.get(stat_type, 0)
+            self.assertEqual(actual_count, expected_count, 
+                           f"Empty scene {stat_type} should be {expected_count}, got {actual_count}")
+        
+        for stat_type, expected_count in expected_primitive_counts.items():
+            actual_count = primitive_info.get(stat_type, 0)
+            self.assertEqual(actual_count, expected_count, 
+                           f"{stat_type} count should be {expected_count}, got {actual_count}")
+
+if __name__ == '__main__':
+    fixturesUtils.runTests(globals()) 


### PR DESCRIPTION
* Adding a scene stat data dump function to be called by the performance automation framework that works for non-Mesh geometry types in Maya surface, USD or custom meshes
* Unit tests added for empty scene and scene with basic prims