### PR TITLE
HYDRA-1460: Delete Ancestor Prim Folders from Hydra Scene Browser

### DIFF
--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
@@ -1188,6 +1188,22 @@ void MayaHydraSceneIndex::_AddPrimAncestors(const SdfPath& path)
 
 }
 
+void MayaHydraSceneIndex::_RemoveEmptyAncestors(const SdfPath& path)
+{
+    const auto& parentPath = path.GetParentPath();
+    if (parentPath == _rprimPath || parentPath == _sprimPath || parentPath == _materialPath) {
+        return;
+    }
+    auto parentPrim = GetPrim(parentPath);
+    if (parentPrim.dataSource && parentPrim.primType.IsEmpty()) {
+        auto childPaths = GetChildPrimPaths(parentPath);
+        if (childPaths.empty()) {
+            RemovePrims({ parentPath });
+            _RemoveEmptyAncestors(parentPath);
+        }
+    }
+}
+
 void MayaHydraSceneIndex::MarkRprimDirty(const SdfPath& id, HdDirtyBits dirtyBits) {
     _MarkPrimDirty(id, dirtyBits, HdDirtyBitsTranslator::RprimDirtyBitsToLocatorSet);
 }
@@ -1223,6 +1239,8 @@ void MayaHydraSceneIndex::_MarkPrimDirty(
 void MayaHydraSceneIndex::RemovePrim(const SdfPath& id)
 {
     RemovePrims({ id });
+
+    _RemoveEmptyAncestors(id);
 
     _renderCollectionChanged = true;
 }

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.h
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.h
@@ -289,6 +289,7 @@ private:
     // Utilites
     bool _GetRenderItem(int fastId, MayaHydraRenderItemAdapterPtr& adapter);
     void _AddPrimAncestors(const SdfPath& path);
+    void _RemoveEmptyAncestors(const SdfPath& path);
     void _AddRenderItem(const MayaHydraRenderItemAdapterPtr& ria);
     void _RemoveRenderItem(const MayaHydraRenderItemAdapterPtr& ria);
     bool _GetRenderItemMaterial(const MRenderItem& ri, SdfPath& material, MObject& shadingEngineNode);

--- a/test/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
+++ b/test/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
@@ -71,6 +71,7 @@ set(INTERACTIVE_TEST_SCRIPT_FILES
     cpp/testColorPreferences.py
     cpp/testCppFramework.py
     cpp/testDataProducerExample.py
+    cpp/testMayaHydraSceneIndex.py
     cpp/testMayaSceneFlattening.py
     cpp/testMayaUsdUfeItems.py
     cpp/testDataProducerMergingSceneIndex.py

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/CMakeLists.txt
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources(${TARGET_NAME}
         testColorPreferences.cpp
         testCppFramework.cpp
         testHydraPrim.cpp
+        testMayaHydraSceneIndex.cpp
         testMayaSceneFlattening.cpp
         testMayaUsdUfeItems.cpp
         testDataProducerMergingSceneIndex.cpp

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testMayaHydraSceneIndex.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testMayaHydraSceneIndex.cpp
@@ -1,0 +1,106 @@
+// Copyright 2025 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "testUtils.h"
+
+#include <mayaHydraLib/sceneIndex/mayaHydraSceneIndex.h>
+
+#include <pxr/imaging/hd/sceneIndexPrimView.h>
+
+#include <maya/MGlobal.h>
+#include <maya/MString.h>
+
+#include <gtest/gtest.h>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+using namespace MayaHydra;
+
+TEST(MayaHydraSceneIndex, PrimAncestors)
+{   
+    const auto& sceneIndices = GetTerminalSceneIndices();
+    ASSERT_GT(sceneIndices.size(), 0u);
+    
+    // Find the MayaHydraSceneIndex in the scene index tree
+    auto mayaSceneIndex = TfDynamic_cast<MayaHydraSceneIndexRefPtr>(sceneIndices.front());
+    if (!mayaSceneIndex) {
+        // Try to find it in the input scene indices if not at the root
+        auto isDataProducerMergingSceneIndex = SceneIndexDisplayNamePred("Data Producer Merging Scene Index");
+        auto mergingSiBase = findSceneIndexInTree(sceneIndices.front(), isDataProducerMergingSceneIndex);
+        
+        if (mergingSiBase) {
+            auto mergingSi = TfDynamic_cast<HdMergingSceneIndexRefPtr>(mergingSiBase);
+            if (mergingSi) {
+                auto producers = mergingSi->GetInputScenes();
+                auto isMayaProducerSceneIndex = SceneIndexDisplayNamePred("MayaHydraSceneIndex");
+                auto found = std::find_if(producers.begin(), producers.end(), isMayaProducerSceneIndex);
+                if (found != producers.end()) {
+                    mayaSceneIndex = TfDynamic_cast<MayaHydraSceneIndexRefPtr>(*found);
+                }
+            }
+        }
+    }
+    
+    ASSERT_TRUE(mayaSceneIndex) << "Could not find MayaHydraSceneIndex in scene index tree";
+    
+    // Setup
+    MString createGroupHierarchy = "group -em -n \"group1\"; group -em -n \"group2\" group1; polyCube -n \"leafShape\" -ch 0; parent leafShape group2;";
+    MStatus status = MGlobal::executeCommand(createGroupHierarchy);
+    ASSERT_EQ(status, MS::kSuccess);
+    ASSERT_EQ(MGlobal::executeCommand("refresh"), MS::kSuccess);
+    
+    // Test 1: _AddPrimAncestors, check ancestor creation
+    SdfPath leafPrimPath;
+
+    for (const auto& primPath : HdSceneIndexPrimView(mayaSceneIndex, SdfPath::AbsoluteRootPath())) {
+        if (primPath.GetName() == "leafShape") {
+            leafPrimPath = primPath;
+            break;
+        }
+    }
+    
+    ASSERT_FALSE(leafPrimPath.IsEmpty()) << "Could not find the leaf prim in the scene index";
+    
+    SdfPath currentPath = leafPrimPath;
+    while (!currentPath.IsAbsoluteRootPath() && currentPath != mayaSceneIndex->GetRprimPath()) {
+        auto prim = mayaSceneIndex->GetPrim(currentPath);
+        ASSERT_TRUE(prim.dataSource) << "Ancestor prim should exist at path: " << currentPath;
+        currentPath = currentPath.GetParentPath();
+    }
+    
+    // Test 2: _RemoveEmptyAncestors, check ancestor removal
+    status = MGlobal::executeCommand("delete leafShape");
+    ASSERT_EQ(status, MS::kSuccess);
+    
+    ASSERT_EQ(MGlobal::executeCommand("refresh"), MS::kSuccess);
+    
+    auto leafPrim = mayaSceneIndex->GetPrim(leafPrimPath);
+    ASSERT_FALSE(leafPrim.dataSource) << "Leaf prim should be removed after deletion";
+    
+    SdfPath parentPath = leafPrimPath.GetParentPath();
+    while (!parentPath.IsAbsoluteRootPath() && parentPath != mayaSceneIndex->GetRprimPath()) {
+        auto parentPrim = mayaSceneIndex->GetPrim(parentPath);
+        // Remaining ancestors should still have children
+        if (parentPrim.dataSource) { 
+            auto children = mayaSceneIndex->GetChildPrimPaths(parentPath);
+            ASSERT_GT(children.size(), 0u) << "Parent prim with no children should be cleaned up at path: " << parentPath;
+        }
+        parentPath = parentPath.GetParentPath();
+    }
+    
+    // Cleanup
+    ASSERT_EQ(MGlobal::executeCommand("delete group1"), MS::kSuccess);
+    ASSERT_EQ(MGlobal::executeCommand("refresh"), MS::kSuccess);
+} 

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testMayaHydraSceneIndex.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testMayaHydraSceneIndex.cpp
@@ -55,12 +55,7 @@ TEST(MayaHydraSceneIndex, PrimAncestors)
     
     ASSERT_TRUE(mayaSceneIndex) << "Could not find MayaHydraSceneIndex in scene index tree";
     
-    // Setup
-    MString createGroupHierarchy = "group -em -n \"group1\"; group -em -n \"group2\" group1; polyCube -n \"leafShape\" -ch 0; parent leafShape group2;";
-    MStatus status = MGlobal::executeCommand(createGroupHierarchy);
-    ASSERT_EQ(status, MS::kSuccess);
-    ASSERT_EQ(MGlobal::executeCommand("refresh"), MS::kSuccess);
-    
+    // Setup of group hierarchy done in the Python driver
     // Test 1: _AddPrimAncestors, check ancestor creation
     SdfPath leafPrimPath;
 
@@ -81,7 +76,7 @@ TEST(MayaHydraSceneIndex, PrimAncestors)
     }
     
     // Test 2: _RemoveEmptyAncestors, check ancestor removal
-    status = MGlobal::executeCommand("delete leafShape");
+    MStatus status = MGlobal::executeCommand("delete leafShape");
     ASSERT_EQ(status, MS::kSuccess);
     
     ASSERT_EQ(MGlobal::executeCommand("refresh"), MS::kSuccess);

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testMayaHydraSceneIndex.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testMayaHydraSceneIndex.py
@@ -23,6 +23,11 @@ class TestMayaHydraSceneIndex(mtohUtils.MayaHydraBaseTestCase):
 
     def setupScene(self):
         self.setHdStormRenderer()
+
+        cmds.group(empty=True, name="group1")
+        cmds.group(empty=True, name="group2", parent="group1")
+        cmds.polyCube(name="leafShape", constructionHistory=False)
+        cmds.parent("leafShape", "group2")
         cmds.refresh()
 
     def test_PrimAncestors(self):

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testMayaHydraSceneIndex.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testMayaHydraSceneIndex.py
@@ -1,0 +1,35 @@
+# Copyright 2025 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import maya.cmds as cmds
+import fixturesUtils
+import mtohUtils
+from testUtils import PluginLoaded
+
+class TestMayaHydraSceneIndex(mtohUtils.MayaHydraBaseTestCase):
+    # MayaHydraBaseTestCase.setUpClass requirement.
+    _file = __file__
+
+    def setupScene(self):
+        self.setHdStormRenderer()
+        cmds.refresh()
+
+    def test_PrimAncestors(self):
+        """Test _AddPrimAncestors and _RemoveEmptyAncestors functionality"""
+        self.setupScene()
+        with PluginLoaded('mayaHydraCppTests'):
+            cmds.mayaHydraCppTest(f="MayaHydraSceneIndex.PrimAncestors")
+
+if __name__ == '__main__':
+    fixturesUtils.runTests(globals()) 


### PR DESCRIPTION
* When primitives were being deleted from the scene, the data was deleted but the parent folders (e.g. `rprims/pPlatonic1/pPlatonicShape1/`) remained empty until another primitive of the same type was created.
* Solution: Recursively delete folders of deleted objects until rprim/sprim/material base paths.