### PR TITLE
HYDRA-1743 - Enable cameraAdapter when MAYA_HYDRA_USE_MESH_ADAPTER is 0

### DIFF
--- a/lib/mayaHydra/hydraExtensions/adapters/adapterRegistry.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/adapterRegistry.cpp
@@ -83,7 +83,13 @@ void MayaHydraAdapterRegistry::RegisterCameraAdapter(
 MayaHydraAdapterRegistry::CameraAdapterCreator
 MayaHydraAdapterRegistry::GetCameraAdapterCreator(const MDagPath& dag)
 {
-    MFnDependencyNode    depNode(dag.node());
+    return GetCameraAdapterCreator(dag.node());
+}
+
+MayaHydraAdapterRegistry::CameraAdapterCreator
+MayaHydraAdapterRegistry::GetCameraAdapterCreator(const MObject& node)
+{
+    MFnDependencyNode   depNode(node);
     CameraAdapterCreator ret = nullptr;
     TfMapLookup(GetInstance()._cameraAdapters, TfToken(depNode.typeName().asChar()), &ret);
     return ret;

--- a/lib/mayaHydra/hydraExtensions/adapters/adapterRegistry.h
+++ b/lib/mayaHydra/hydraExtensions/adapters/adapterRegistry.h
@@ -76,6 +76,9 @@ public:
     static void RegisterCameraAdapter(const TfToken& type, CameraAdapterCreator creator);
 
     MAYAHYDRALIB_API
+    static CameraAdapterCreator GetCameraAdapterCreator(const MObject& node);
+
+    MAYAHYDRALIB_API
     static CameraAdapterCreator GetCameraAdapterCreator(const MDagPath& dag);
 
     /// Find all MayaHydraAdapter plug-ins, and load them all

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
@@ -987,6 +987,18 @@ void MayaHydraSceneIndex::PreFrame(const MHWRender::MDrawContext& context)
         _lightsToAdd.clear();
     }
 
+    if (!_camerasToAdd.empty()) {
+        for (auto& cameraToAdd : _camerasToAdd) {
+            MDagPath dag;
+            MStatus  status = MDagPath::getAPathTo(cameraToAdd.first, dag);
+            if (!status) {
+                return;
+            }
+            CreateCameraAdapter(dag);
+        }
+        _camerasToAdd.clear();
+    }
+
     if (useMeshAdapter() && !_addedNodes.empty()) {
         for (const auto& obj : _addedNodes) {
             if (obj.isNull()) {
@@ -1615,11 +1627,14 @@ void MayaHydraSceneIndex::OnDagNodeAdded(const MObject& obj)
         return;
     }
 
-    // When not using the mesh adapter we care only about lights for this
-    // callback.  It is used to create a LightAdapter when adding a new light
+    // When not using the mesh adapter we care only about lights and cameras for this
+    // callback.  It is used to create a LightAdapter/CameraAdapter when adding a new light/camera
     // in the scene for Hydra rendering.
     if (auto lightFn = MayaHydraAdapterRegistry::GetLightAdapterCreator(obj)) {
         _lightsToAdd.push_back({ obj, lightFn });
+    }
+    else if (auto cameraFn = MayaHydraAdapterRegistry::GetCameraAdapterCreator(obj)) {
+        _camerasToAdd.push_back({ obj, cameraFn });
     }
     else if (useMeshAdapter()) {
         _addedNodes.push_back(obj);
@@ -1635,8 +1650,19 @@ void MayaHydraSceneIndex::OnDagNodeRemoved(const MObject& obj)
 
     if (it != _lightsToAdd.end()) {
         _lightsToAdd.erase(it, _lightsToAdd.end());
+        return;
     }
-    else if (useMeshAdapter()) {
+
+    const auto itCamera
+        = std::remove_if(_camerasToAdd.begin(), _camerasToAdd.end(), [&obj](const auto& item) {
+            return item.first == obj;
+        });
+    if (itCamera != _camerasToAdd.end()) {
+        _camerasToAdd.erase(itCamera, _camerasToAdd.end());
+        return;
+    }
+
+    if (useMeshAdapter()) {
         const auto it = std::remove_if(_addedNodes.begin(), _addedNodes.end(), [&obj](const auto& item) { return item == obj; });
 
         if (it != _addedNodes.end()) {

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
@@ -516,6 +516,7 @@ void MayaHydraSceneIndex::_Destroy()
         _renderItemsAdapters,
         _shapeAdapters,
         _lightAdapters,
+        _cameraAdapters,
         _materialAdapters);
 
     _renderItemsAdapters.clear();
@@ -1063,14 +1064,15 @@ void MayaHydraSceneIndex::PreFrame(const MHWRender::MDrawContext& context)
                             a->RemoveCallbacks();
                             a->CreateCallbacks();
                         }
-                if (std::get<1>(it) & MayaHydraSceneIndex::RebuildFlagPrim) {
-                    a->RemovePrim();
-                    a->Populate();
-                }
+                        if (std::get<1>(it) & MayaHydraSceneIndex::RebuildFlagPrim) {
+                            a->RemovePrim();
+                            a->Populate();
+                        }
                     },
                     _shapeAdapters,
-                        _lightAdapters,
-                        _materialAdapters);
+                    _lightAdapters,
+                    _cameraAdapters,
+                    _materialAdapters);
             }
             _adaptersToRebuild.clear();
         }
@@ -1284,12 +1286,12 @@ void MayaHydraSceneIndex::SetParams(const MayaHydraParams& params)
                 else if (a->HasType(HdPrimTypeTokens->camera)) {
                     a->MarkDirty(HdCamera::DirtyParams);
                 }
-        a->InvalidateTransform();
-        a->MarkDirty(HdChangeTracker::DirtyTransform);
+                a->InvalidateTransform();
+                a->MarkDirty(HdChangeTracker::DirtyTransform);
             },
             _shapeAdapters,
-                _lightAdapters,
-                _cameraAdapters);
+            _lightAdapters,
+            _cameraAdapters);
     }
     // We need to trigger rebuilding shaders.
     if (oldParams.textureMemoryPerTexture != params.textureMemoryPerTexture) {
@@ -1381,6 +1383,7 @@ void MayaHydraSceneIndex::RemoveAdapter(const SdfPath& id)
         _renderItemsAdapters,
             _shapeAdapters,
             _lightAdapters,
+            _cameraAdapters,
             _materialAdapters)) {
         TF_WARN(
             "MayaHydraSceneIndex::RemoveAdapter(%s) -- Adapter does not exists", id.GetText());
@@ -1519,9 +1522,10 @@ void MayaHydraSceneIndex::RecreateAdapter(const SdfPath& id, const MObject& obj)
         id,
         [](MayaHydraAdapter* a) {
             a->RemoveCallbacks();
-    a->RemovePrim();
+            a->RemovePrim();
         },
-        _lightAdapters)) {
+        _lightAdapters,
+        _cameraAdapters)) {
         if (MObjectHandle(obj).isValid()) {
             OnDagNodeAdded(obj);
         }

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.h
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.h
@@ -334,6 +334,9 @@ private:
     using LightAdapterCreator
         = std::function<MayaHydraLightAdapterPtr(MayaHydraSceneIndex*, const MDagPath&)>;
     std::vector<std::pair<MObject, LightAdapterCreator>> _lightsToAdd;
+    using CameraAdapterCreator
+        = std::function<MayaHydraCameraAdapterPtr(MayaHydraSceneIndex*, const MDagPath&)>;
+    std::vector<std::pair<MObject, CameraAdapterCreator>> _camerasToAdd;
     std::vector<SdfPath> _materialTagsChanged;
 
     bool _defaultMaterialCreated = false;

--- a/test/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
+++ b/test/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
@@ -93,6 +93,7 @@ set(INTERACTIVE_TEST_SCRIPT_FILES
     cpp/testSinglePicking.py
     cpp/testSceneIndexDirtying.py
     cpp/testUsdStageInvalidate.py
+    cpp/testCamera.py
 	#CPP tests disabled on OSX
     cpp/testWriteFile.py|skipOnPlatform:osx # HYDRA-1127 : refinedWire not working on OSX
 )

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/CMakeLists.txt
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/CMakeLists.txt
@@ -47,6 +47,7 @@ target_sources(${TARGET_NAME}
         testSceneIndexDirtying.cpp
         testUsdStageInvalidate.cpp
         testWriteFile.cpp
+        testCamera.cpp
 )
 
 if (MAYA_HAS_VIEW_SELECTED_OBJECT_API)

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testCamera.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testCamera.cpp
@@ -40,7 +40,7 @@ FindPrimPredicate getCameraPrimPredicate(const std::string& cameraName, const Tf
     };
 }
 
-void VerifyCameraPrims(const std::string& prefix, int primCount)
+void VerifyCameraPrims(const std::string& prefix, size_t primCount)
 {
     const SceneIndicesVector& sceneIndices = GetTerminalSceneIndices();
     ASSERT_GT(sceneIndices.size(), 0u);
@@ -61,16 +61,16 @@ void VerifyCameraPrims(const std::string& prefix, int primCount)
 
 TEST(Camera, defaultCameras)
 { 
-    VerifyCameraPrims("sprims", 4);
+    VerifyCameraPrims("sprims", 4u);
 }
 
 TEST(Camera, addMayaCamera)
 { 
-    VerifyCameraPrims("sprims", 5);
+    VerifyCameraPrims("sprims", 5u);
 }
 
 TEST(Camera, removeMayaCamera)
 { 
-    VerifyCameraPrims("sprims", 4);
+    VerifyCameraPrims("sprims", 4u);
 }
 }

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testCamera.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testCamera.cpp
@@ -1,0 +1,76 @@
+// Copyright 2025 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "testUtils.h"
+
+#include <mayaHydraLib/hydraUtils.h>
+#include <mayaHydraLib/mayaUtils.h>
+
+#include <pxr/imaging/hd/tokens.h>
+
+#include <gtest/gtest.h>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+using namespace MayaHydra;
+
+namespace {
+
+FindPrimPredicate getCameraPrimPredicate(const std::string& cameraName, const TfToken& primType)
+{
+    return [cameraName,
+            primType](const HdSceneIndexBasePtr& sceneIndex, const SdfPath& primPath) -> bool {
+        if (primPath.GetAsString().find(cameraName) == std::string::npos) {
+            return false;
+        }
+        HdSceneIndexPrim prim = sceneIndex->GetPrim(primPath);
+        return prim.primType == primType;
+    };
+}
+
+void VerifyCameraPrims(const std::string& prefix, int primCount)
+{
+    const SceneIndicesVector& sceneIndices = GetTerminalSceneIndices();
+    ASSERT_GT(sceneIndices.size(), 0u);
+    SceneIndexInspector inspector(sceneIndices.front());
+
+    PrimEntriesVector cameraPrims
+        = inspector.FindPrims(getCameraPrimPredicate(prefix, HdPrimTypeTokens->camera));
+    ASSERT_EQ(cameraPrims.size(), primCount);
+    auto testCameraPrims = [cameraPrims]() -> void {
+        for (PrimEntry cameraPrim : cameraPrims) {
+            EXPECT_EQ(cameraPrim.prim.primType, HdPrimTypeTokens->camera);
+            ASSERT_NE(cameraPrim.prim.dataSource, nullptr);
+        }
+    };
+
+    testCameraPrims();
+}
+
+TEST(Camera, defaultCameras)
+{ 
+    VerifyCameraPrims("sprims", 4);
+}
+
+TEST(Camera, addMayaCamera)
+{ 
+    VerifyCameraPrims("sprims", 5);
+}
+
+TEST(Camera, removeMayaCamera)
+{ 
+    VerifyCameraPrims("sprims", 4);
+}
+}

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testCamera.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testCamera.py
@@ -1,0 +1,46 @@
+# Copyright 2025 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import maya.cmds as cmds
+import fixturesUtils
+import mtohUtils
+
+class TestCamera(mtohUtils.MayaHydraBaseTestCase):
+    # MayaHydraBaseTestCase.setUpClass requirement.
+    _file = __file__
+
+    def setupScene(self):
+        self.setHdStormRenderer()
+        cmds.refresh()
+
+    def test_DefaultCameras(self):
+        self.setupScene()
+        self.runCppTest("Camera.defaultCameras")
+
+    def test_AddMayaCamera(self):
+        self.setupScene()
+        cmds.camera()
+        cmds.refresh()
+        self.runCppTest("Camera.addMayaCamera")
+
+    def test_RemoveMayaCamera(self):
+        self.setupScene()
+        cameraName = cmds.camera()
+        cmds.refresh()
+        cmds.delete(cameraName[0])
+        cmds.refresh()
+        self.runCppTest("Camera.removeMayaCamera")
+
+if __name__ == '__main__':
+    fixturesUtils.runTests(globals())

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testSceneCorrectness.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testSceneCorrectness.cpp
@@ -84,13 +84,8 @@ void VerifyDataSource(DataSourceEntry rootDataSourceEntry)
             if (auto containerDataSource
                 = pxr::HdContainerDataSource::Cast(dataSourceEntry.dataSource)) {
                 pxr::TfTokenVector childNames = containerDataSource->GetNames();
-                for (auto itChildNames = childNames.rbegin(); itChildNames != childNames.rend();
-                     itChildNames++) {
-                    if (*itChildNames == "camera") {
-                        hasMayaPerspCameraDataSource = true;
-                        break;
-                    }
-                }
+                auto it = std::find(childNames.rbegin(), childNames.rend(), pxr::TfToken("camera"));
+                hasMayaPerspCameraDataSource = it != childNames.rend();
             }
             EXPECT_TRUE(hasMayaPerspCameraDataSource);
         }

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testSceneCorrectness.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testSceneCorrectness.cpp
@@ -78,6 +78,22 @@ void VerifyDataSource(DataSourceEntry rootDataSourceEntry)
                 }
             }
         }
+        else if (dataSourceEntry.name == "perspShape") {
+            // Verify that the "persp" camera's data source
+            bool hasMayaPerspCameraDataSource = false;
+            if (auto containerDataSource
+                = pxr::HdContainerDataSource::Cast(dataSourceEntry.dataSource)) {
+                pxr::TfTokenVector childNames = containerDataSource->GetNames();
+                for (auto itChildNames = childNames.rbegin(); itChildNames != childNames.rend();
+                     itChildNames++) {
+                    if (*itChildNames == "camera") {
+                        hasMayaPerspCameraDataSource = true;
+                        break;
+                    }
+                }
+            }
+            EXPECT_TRUE(hasMayaPerspCameraDataSource);
+        }
 
         // Prepare next step
         dataSourceStack.pop();

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testSceneCorrectness.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testSceneCorrectness.cpp
@@ -78,17 +78,6 @@ void VerifyDataSource(DataSourceEntry rootDataSourceEntry)
                 }
             }
         }
-        else if (dataSourceEntry.name == "perspShape") {
-            // Verify that the "persp" camera's data source
-            bool hasMayaPerspCameraDataSource = false;
-            if (auto containerDataSource
-                = pxr::HdContainerDataSource::Cast(dataSourceEntry.dataSource)) {
-                pxr::TfTokenVector childNames = containerDataSource->GetNames();
-                auto it = std::find(childNames.rbegin(), childNames.rend(), pxr::TfToken("camera"));
-                hasMayaPerspCameraDataSource = it != childNames.rend();
-            }
-            EXPECT_TRUE(hasMayaPerspCameraDataSource);
-        }
 
         // Prepare next step
         dataSourceStack.pop();


### PR DESCRIPTION
The problem is cameraAdapter is only enabled when meshAdapter is enabled, make a fix to also enable cameraAdapter when meshAdapter is disabled.