### PR TITLE
Change erroneous USD version code switch from 2403 to 2405

### DIFF
--- a/lib/flowViewport/sceneIndex/fvpDefaultMaterialSceneIndex.cpp
+++ b/lib/flowViewport/sceneIndex/fvpDefaultMaterialSceneIndex.cpp
@@ -32,19 +32,17 @@ namespace{
     static const TfToken purposes[] = { HdMaterialBindingsSchemaTokens->allPurpose };
 
     // Support implicit surfaces from USD as well, not only meshes
-    bool _IsDefaultMaterialCompliantPrimitive(const TfToken& primType) 
-    { 
+    bool _IsDefaultMaterialCompliantPrimitive(const TfToken& primType)
+    {
         static std::set<TfToken> const compliantPrimitives = { HdPrimTypeTokens->cone,
                                                               HdPrimTypeTokens->cylinder,
                                                               HdPrimTypeTokens->cylinder_1,
                                                               HdPrimTypeTokens->cube,
-                                                              HdPrimTypeTokens->sphere,   
+                                                              HdPrimTypeTokens->sphere,
                                                               HdPrimTypeTokens->capsule,
                                                               HdPrimTypeTokens->capsule_1,
-                                                        #if PXR_VERSION >= 2403 // USD 24.03+
+                                                        #if PXR_VERSION >= 2405 // USD 24.05+
                                                               HdPrimTypeTokens->geomSubset,
-                                                        #endif
-                                                        #if HD_API_VERSION >= 67 // USD 24.05+
                                                               UsdGeomTokens->TetMesh,
                                                         #endif
                                                               UsdGeomTokens->Plane,
@@ -59,20 +57,20 @@ DefaultMaterialSceneIndex::New(
     const HdSceneIndexBaseRefPtr &inputSceneIndex,
     const PXR_NS::SdfPath& defaultMaterialPath,
     const PXR_NS::SdfPathVector& defaultMaterialExclusionList)
-{    
+{
     return TfCreateRefPtr(
         new DefaultMaterialSceneIndex(inputSceneIndex, defaultMaterialPath, defaultMaterialExclusionList));
 }
 
 DefaultMaterialSceneIndex::DefaultMaterialSceneIndex(
-    HdSceneIndexBaseRefPtr const &inputSceneIndex, 
+    HdSceneIndexBaseRefPtr const &inputSceneIndex,
     const PXR_NS::SdfPath& defaultMaterialPath,
     const PXR_NS::SdfPathVector& defaultMaterialExclusionList)
-  : HdSingleInputFilteringSceneIndexBase(inputSceneIndex), 
+  : HdSingleInputFilteringSceneIndexBase(inputSceneIndex),
     InputSceneIndexUtils(inputSceneIndex),
     _defaultMaterialPath(defaultMaterialPath),
     _defaultMaterialExclusionList(defaultMaterialExclusionList)
-{   
+{
 }
 
 HdSceneIndexPrim DefaultMaterialSceneIndex::GetPrim(const SdfPath& primPath) const
@@ -117,7 +115,7 @@ void DefaultMaterialSceneIndex::_SetDefaultMaterial(HdSceneIndexPrim& inoutPrim)
         = { HdMaterialBindingSchema::Builder()
                 .SetPath(HdRetainedTypedSampledDataSource<SdfPath>::New(_defaultMaterialPath))
                 .Build() };
-    
+
     if (_ShouldWeApplyTheDefaultMaterial(inoutPrim)) {
         inoutPrim.dataSource = HdContainerDataSourceEditor(inoutPrim.dataSource)
             .Set(
@@ -128,18 +126,18 @@ void DefaultMaterialSceneIndex::_SetDefaultMaterial(HdSceneIndexPrim& inoutPrim)
     }
 }
 
-void DefaultMaterialSceneIndex::Enable(bool enable) 
-{ 
+void DefaultMaterialSceneIndex::Enable(bool enable)
+{
     if (_isEnabled == enable){
         return;
     }
-    
-    _isEnabled = enable; 
+
+    _isEnabled = enable;
     _MarkMaterialsDirty();
 }
 
 void DefaultMaterialSceneIndex::_MarkMaterialsDirty()
-{ 
+{
     static const auto locator = HdMaterialBindingsSchema::GetDefaultLocator();
 
     HdSceneIndexObserver::DirtiedPrimEntries entries;

--- a/lib/flowViewport/sceneIndex/fvpIsolateSelectSceneIndex.cpp
+++ b/lib/flowViewport/sceneIndex/fvpIsolateSelectSceneIndex.cpp
@@ -94,14 +94,14 @@ Dependencies instancedPrim(
     auto prim = si.GetInputSceneIndex()->GetPrim(primPath);
     auto instanceSchema = HdInstanceSchema::GetFromParent(prim.dataSource);
     return (instanceSchema.IsDefined() ? Dependencies{{
-                instanceSchema.GetInstancer()->GetTypedValue(0)}} : 
+                instanceSchema.GetInstancer()->GetTypedValue(0)}} :
         Dependencies());
 }
 
 bool isGeomSubset(const HdSceneIndexPrim& prim) {
     // HYDRA-1339: PiPrototypePropagatingSceneIndex removes GeomSubset type
     // from Hydra prims
-#if PXR_VERSION >= 2403
+#if PXR_VERSION >= 2405
     return (prim.primType == HdPrimTypeTokens->geomSubset) ||
         HdGeomSubsetSchema::GetFromParent(prim.dataSource).IsDefined();
 #else
@@ -172,7 +172,7 @@ HdSceneIndexPrim IsolateSelectSceneIndex::GetPrim(const SdfPath& primPath) const
 
     auto instancerMask = _instancerMasks.find(primPath);
     if (instancerMask != _instancerMasks.end()) {
-        inputPrim.dataSource = 
+        inputPrim.dataSource =
             setInstancerMaskDataSource(inputPrim, instancerMask->second);
 
         return inputPrim;
@@ -180,7 +180,7 @@ HdSceneIndexPrim IsolateSelectSceneIndex::GetPrim(const SdfPath& primPath) const
 
     // If isolate selection is empty, then nothing is included (everything
     // is excluded), as desired.
-    const bool included = 
+    const bool included =
         _isolateSelection->HasAncestorOrDescendantInclusive(primPath);
 
     TF_DEBUG(FVP_ISOLATE_SELECT_SCENE_INDEX)
@@ -335,7 +335,7 @@ void IsolateSelectSceneIndex::_DirtyIsolateSelection(const SelectionConstPtr& ne
         (newIsolateSelection && newIsolateSelection->IsEmpty())) {
         return;
     }
-        
+
     // Keep paths in a set to minimize dirtying.
     std::set<SdfPath> dirtyPaths;
 
@@ -365,7 +365,7 @@ void IsolateSelectSceneIndex::_InsertSelectedPaths(
     if (!selection) {
         return;
     }
-    const auto& paths = selection->IsEmpty() ? 
+    const auto& paths = selection->IsEmpty() ?
         GetChildPrimPaths(SdfPath::AbsoluteRootPath()) :
         selection->GetFullySelectedPaths();
     for (const auto& primPath : paths) {
@@ -457,7 +457,7 @@ void IsolateSelectSceneIndex::_DirtyVisibility(
 }
 
 void IsolateSelectSceneIndex::_DirtyVisibilityRecursive(
-    const SdfPath&                            primPath, 
+    const SdfPath&                            primPath,
     HdSceneIndexObserver::DirtiedPrimEntries* dirtiedEntries
 ) const
 {
@@ -500,7 +500,7 @@ void IsolateSelectSceneIndex::_DirtyVisibilityRecursive(
     }
 
     for (const auto& childPath : GetChildPrimPaths(primPath)) {
-#if PXR_VERSION >= 2403
+#if PXR_VERSION >= 2405
         // Recursing down to set visibility on a geomSubset child is wasteful.
         auto childPrim = GetInputSceneIndex()->GetPrim(childPath);
         if (childPrim.primType == HdPrimTypeTokens->geomSubset) {
@@ -660,11 +660,11 @@ void IsolateSelectSceneIndex::_DirtyInstancerMasks(
     }
 
     _SendPrimsDirtied(dirtiedEntries);
-    
+
 }
 
 void IsolateSelectSceneIndex::_AddDirtyInstancerMaskEntry(
-    const SdfPath&                            primPath, 
+    const SdfPath&                            primPath,
     HdSceneIndexObserver::DirtiedPrimEntries* dirtiedEntries
 ) const
 {

--- a/lib/flowViewport/sceneIndex/wireframeHighlights/fvpBaseWhSi.cpp
+++ b/lib/flowViewport/sceneIndex/wireframeHighlights/fvpBaseWhSi.cpp
@@ -38,7 +38,7 @@
 #include <pxr/imaging/hd/tokens.h>
 #if PXR_VERSION >= 2505
 #include <pxr/usdImaging/usdImaging/materialBindingsSchema.h>
-#elif PXR_VERSION >= 2403
+#elif PXR_VERSION >= 2405
 #include <pxr/usdImaging/usdImaging/directMaterialBindingsSchema.h>
 #endif
 #include <pxr/usdImaging/usdImaging/usdPrimInfoSchema.h>
@@ -87,7 +87,7 @@ SdfPathVector _GetInstancingRelatedPaths(const HdSceneIndexPrim& prim, Fvp::Inst
 {
     HdInstancerTopologySchema instancerTopology = HdInstancerTopologySchema::GetFromParent(prim.dataSource);
     HdInstancedBySchema instancedBy = HdInstancedBySchema::GetFromParent(prim.dataSource);
-    
+
     SdfPathVector instancingRelatedPaths;
 
     if ((direction & Fvp::InstancingPathsCollectionDirection::Prototypes)
@@ -147,8 +147,8 @@ bool _IsPrototypeSubPrim(const HdSceneIndexPrim& prim, const SdfPath& primPath)
 VtArray<SdfPath> _GetHierarchyRoots(const HdSceneIndexPrim& prim)
 {
     HdInstancedBySchema instancedBy = HdInstancedBySchema::GetFromParent(prim.dataSource);
-    return instancedBy.IsDefined() && instancedBy.GetPrototypeRoots() 
-        ? instancedBy.GetPrototypeRoots()->GetTypedValue(0) 
+    return instancedBy.IsDefined() && instancedBy.GetPrototypeRoots()
+        ? instancedBy.GetPrototypeRoots()->GetTypedValue(0)
         : VtArray<SdfPath>({SdfPath::AbsoluteRootPath()});
 }
 
@@ -367,7 +367,7 @@ HdContainerDataSourceHandle SetWireframeRepr(const HdContainerDataSourceHandle& 
                             HdRetainedTypedSampledDataSource<VtVec4fArray>::New(VtVec4fArray{color}),
                             HdPrimvarSchemaTokens->constant,
                             HdPrimvarSchemaTokens->color));
-    
+
     //Is the prim having a DisplayStyle schema?
     if (HdLegacyDisplayStyleSchema styleSchema =
             HdLegacyDisplayStyleSchema::GetFromParent(dataSource)) {
@@ -395,8 +395,8 @@ HdContainerDataSourceHandle SetWireframeRepr(const HdContainerDataSourceHandle& 
 }
 
 PXR_NS::HdContainerDataSourceHandle RepathInstancingDataSources(
-    const PXR_NS::HdContainerDataSourceHandle& primDataSource, 
-    const PXR_NS::SdfPath& srcPrefix, 
+    const PXR_NS::HdContainerDataSourceHandle& primDataSource,
+    const PXR_NS::SdfPath& srcPrefix,
     const PXR_NS::SdfPath& dstPrefix)
 {
     static const std::set<HdDataSourceLocator> kInstancingDataSourceLocators = {
@@ -410,7 +410,7 @@ PXR_NS::HdContainerDataSourceHandle RepathInstancingDataSources(
     HdContainerDataSourceEditor dataSourceEditor(primDataSource);
     for (const auto& instancingDataSourceLocator : kInstancingDataSourceLocators) {
         auto instancingDataSource = HdContainerDataSource::Get(primDataSource, instancingDataSourceLocator);
-        
+
         if (auto containerDataSource = HdContainerDataSource::Cast(instancingDataSource)) {
             dataSourceEditor.Set(
                 instancingDataSourceLocator,
@@ -435,7 +435,7 @@ PXR_NS::HdContainerDataSourceHandle RepathInstancingDataSources(
     return dataSourceEditor.Finish();
 }
 
-#if PXR_VERSION >= 2403
+#if PXR_VERSION >= 2405
 HdContainerDataSourceHandle
 TrimMeshForGeomSubset(const HdContainerDataSourceHandle& meshPrimDataSource, const HdContainerDataSourceHandle& geomSubsetPrimDataSource)
 {
@@ -498,7 +498,7 @@ TrimMeshForGeomSubset(const HdContainerDataSourceHandle& meshPrimDataSource, con
     }
     auto faceVertexCountsLocator = HdMeshTopologySchema::GetDefaultLocator().Append(HdMeshTopologySchemaTokens->faceVertexCounts);
     auto faceVertexIndicesLocator = HdMeshTopologySchema::GetDefaultLocator().Append(HdMeshTopologySchemaTokens->faceVertexIndices);
-    
+
     dataSourceEditor.Set(faceVertexCountsLocator, HdRetainedTypedSampledDataSource<VtIntArray>::New(trimmedFaceVertexCounts));
     dataSourceEditor.Set(faceVertexIndicesLocator, HdRetainedTypedSampledDataSource<VtIntArray>::New(trimmedFaceVertexIndices));
 
@@ -731,7 +731,7 @@ SdfPath BaseWhSi::UnregisterSelection(const SelectionKey& selectionKey)
 
 void
 BaseWhSi::ForEachPrimInHierarchy(
-    const PXR_NS::SdfPath& hierarchyRoot, 
+    const PXR_NS::SdfPath& hierarchyRoot,
     const std::function<bool(const PXR_NS::SdfPath&, const PXR_NS::HdSceneIndexPrim&)>& operation
 ) const
 {
@@ -774,7 +774,7 @@ BaseWhSi::CollectInstancingPaths(const PXR_NS::SdfPath& primPath, InstancingPath
         }
         return;
     }
-    
+
     if (_IsPrototype(prim)) {
         if (outPrototypePaths.find(primPath) != outPrototypePaths.end()) {
             return;
@@ -816,7 +816,7 @@ BaseWhSi::CollectInstancingPaths(const PXR_NS::SdfPath& primPath, InstancingPath
     }
 }
 
-#if PXR_VERSION >= 2403
+#if PXR_VERSION >= 2405
 PXR_NS::HdContainerDataSourceHandle
 BaseWhSi::MakeGeomSubsetHighlight(
     const PXR_NS::HdContainerDataSourceHandle& meshPrimDataSource,
@@ -830,7 +830,7 @@ BaseWhSi::MakeGeomSubsetHighlight(
         dataSourceEditor.Set(HdMaterialBindingsSchema::GetDefaultLocator(), HdContainerDataSource::Get(geomSubsetPrimDataSource, HdMaterialBindingsSchema::GetDefaultLocator()));
 #if PXR_VERSION >= 2505
         dataSourceEditor.Set(UsdImagingMaterialBindingsSchema::GetDefaultLocator(), HdContainerDataSource::Get(geomSubsetPrimDataSource, UsdImagingMaterialBindingsSchema::GetDefaultLocator()));
-#elif PXR_VERSION >= 2403
+#else
         dataSourceEditor.Set(UsdImagingDirectMaterialBindingsSchema::GetDefaultLocator(), HdContainerDataSource::Get(geomSubsetPrimDataSource, UsdImagingDirectMaterialBindingsSchema::GetDefaultLocator()));
 #endif
         editedMeshPrimDataSource = dataSourceEditor.Finish();

--- a/lib/flowViewport/sceneIndex/wireframeHighlights/fvpBaseWhSi.h
+++ b/lib/flowViewport/sceneIndex/wireframeHighlights/fvpBaseWhSi.h
@@ -62,8 +62,8 @@ typedef PXR_NS::TfRefPtr<const BaseWhSi> BaseWhSiConstRefPtr;
 ///
 /// The BaseWhSi class is responsible for composing the four parts
 /// together; derived classes only need to register and unregister
-/// selection highlights as needed (through unique pairs composed of 
-/// a prim path + a selection identifier), and handle the processing 
+/// selection highlights as needed (through unique pairs composed of
+/// a prim path + a selection identifier), and handle the processing
 /// of their selection highlight sub-hierarchies.
 ///
 /// To do this, the BaseWhSi class overrides the typical HdSceneIndex
@@ -73,7 +73,7 @@ typedef PXR_NS::TfRefPtr<const BaseWhSi> BaseWhSiConstRefPtr;
 /// must be implemented by the derived classes. These are :
 ///
 /// 1. GetHighlightPrim & GetHighlightChildPrimPaths
-/// These methods are implemented by the derived scene index to return the 
+/// These methods are implemented by the derived scene index to return the
 /// selection highlight sub-hierarchies. This allows derived scene indices to
 /// focus only on handling their specific flavor of selection highlighting.
 /// These methods will be automatically called by BaseWhSi::GetPrim and
@@ -89,10 +89,10 @@ typedef PXR_NS::TfRefPtr<const BaseWhSi> BaseWhSiConstRefPtr;
 /// 3. ProcessFullySelectedChange
 /// This is an optional method that can be overriden by derived classes if desired.
 /// This method will be called whenever a prim becomes fully selected, or when it
-/// stops being so. This is useful for handling selection highlights for when a 
+/// stops being so. This is useful for handling selection highlights for when a
 /// parent prim is selected/deselected.
-/// 
-class BaseWhSi 
+///
+class BaseWhSi
     : public PXR_NS::HdSingleInputFilteringSceneIndexBase
     , public Fvp::InputSceneIndexUtils<BaseWhSi>
 {
@@ -130,10 +130,10 @@ protected:
     void _PrimsDirtied(
         const PXR_NS::HdSceneIndexBase &sender,
         const PXR_NS::HdSceneIndexObserver::DirtiedPrimEntries &entries) final;
-    
+
     FVP_API
     bool IsExcludedPath(const PXR_NS::SdfPath& path) const;
-    
+
     FVP_API
     PXR_NS::SdfPath SelectionPathFromKey(const SelectionKey& selectionKey) const;
 
@@ -160,17 +160,17 @@ protected:
     virtual void ProcessAddedPrims(
         const PXR_NS::HdSceneIndexBase &sender,
         const PXR_NS::HdSceneIndexObserver::AddedPrimEntries &entries) = 0;
-    
+
     FVP_API
     virtual void ProcessRemovedPrims(
         const PXR_NS::HdSceneIndexBase &sender,
         const PXR_NS::HdSceneIndexObserver::RemovedPrimEntries &entries) = 0;
-    
+
     FVP_API
     virtual void ProcessDirtiedPrims(
         const PXR_NS::HdSceneIndexBase &sender,
         const PXR_NS::HdSceneIndexObserver::DirtiedPrimEntries &entries) = 0;
-    
+
     // Optional helper method that can be overriden by derived classes;
     // this can help with handling highlights for when a parent prim is selected/deselected.
     FVP_API
@@ -179,19 +179,19 @@ protected:
     // Returns whether or not this prim or one of its parents is fully selected.
     FVP_API
     bool HasFullySelectedAncestorInclusive(const PXR_NS::SdfPath& primPath);
-    
+
     // Executes a given operation on a prim and all its descendants within the same hierarchy
     // (prototypes are considered separate hierarchies). When running the operation on a given
     // prim returns false, the prim's descendants are skipped.
     FVP_API
     void ForEachPrimInHierarchy(const PXR_NS::SdfPath& hierarchyRoot, const std::function<bool(const PXR_NS::SdfPath&, const PXR_NS::HdSceneIndexPrim&)>& operation) const;
-    
+
     // Collect the paths to the instancers and prototypes of the instancing graph/network that the given prim is a part of.
     // The direction parameter allows for specifying whether to only collect instancers, prototypes, or both.
     FVP_API
     void CollectInstancingPaths(const PXR_NS::SdfPath& primPath, InstancingPathsCollectionDirection direction, PXR_NS::SdfPathSet& outInstancerPaths, PXR_NS::SdfPathSet& outPrototypePaths) const;
 
-#if PXR_VERSION >= 2403
+#if PXR_VERSION >= 2405
     // Given a mesh and geomSubset data sources, edits and returns the mesh data source to fit the given geomSubset
     FVP_API
     PXR_NS::HdContainerDataSourceHandle MakeGeomSubsetHighlight(
@@ -220,7 +220,7 @@ PXR_NS::HdContainerDataSourceHandle RepathInstancingDataSources(
     const PXR_NS::SdfPath& srcPrefix,
     const PXR_NS::SdfPath& dstPrefix);
 
-#if PXR_VERSION >= 2403
+#if PXR_VERSION >= 2405
 // Edit the given mesh data source such that its topology matches the given geomSubset.
 PXR_NS::HdContainerDataSourceHandle
 TrimMeshForGeomSubset(const PXR_NS::HdContainerDataSourceHandle& meshPrimDataSource, const PXR_NS::HdContainerDataSourceHandle& geomSubsetPrimDataSource);

--- a/lib/flowViewport/sceneIndex/wireframeHighlights/fvpGeomSubsetWhSi.cpp
+++ b/lib/flowViewport/sceneIndex/wireframeHighlights/fvpGeomSubsetWhSi.cpp
@@ -19,7 +19,7 @@
 #include <pxr/imaging/hd/selectionsSchema.h>
 #include <pxr/imaging/hd/tokens.h>
 
-#if PXR_VERSION >= 2403
+#if PXR_VERSION >= 2405
 
 PXR_NAMESPACE_USING_DIRECTIVE
 
@@ -182,11 +182,11 @@ void GeomSubsetWhSi::_DeleteSelectionHighlight(const SdfPath& geomSubsetPath)
     // Erase from data structures
     SelectionKey selectionKey { geomSubsetPath, "" };
     SdfPath selectionPath = UnregisterSelection(selectionKey);
-    
+
     // Send notifications
     _SendPrimsRemoved({selectionPath});
 }
 
 }
 
-#endif // #if PXR_VERSION >= 2403
+#endif // #if PXR_VERSION >= 2405

--- a/lib/flowViewport/sceneIndex/wireframeHighlights/fvpGeomSubsetWhSi.h
+++ b/lib/flowViewport/sceneIndex/wireframeHighlights/fvpGeomSubsetWhSi.h
@@ -18,7 +18,7 @@
 
 #include "fvpBaseWhSi.h"
 
-#if PXR_VERSION >= 2403
+#if PXR_VERSION >= 2405
 
 namespace FVP_NS_DEF {
 
@@ -38,7 +38,7 @@ typedef PXR_NS::TfRefPtr<const GeomSubsetWhSi> GeomSubsetWhSiConstRefPtr;
 /// Highlight_<selectionIdentifier>
 /// |__<trimmedParentMesh>
 ///
-class GeomSubsetWhSi 
+class GeomSubsetWhSi
     : public BaseWhSi
 {
 public:
@@ -80,7 +80,7 @@ protected:
     void ProcessDirtiedPrims(
         const PXR_NS::HdSceneIndexBase &sender,
         const PXR_NS::HdSceneIndexObserver::DirtiedPrimEntries &entries) override;
-    
+
     FVP_API
     void ProcessFullySelectedChange(const PXR_NS::SdfPath& primPath, bool isFullySelected) override;
 
@@ -93,6 +93,6 @@ private:
 
 }
 
-#endif // #if PXR_VERSION >= 2403
+#endif // #if PXR_VERSION >= 2405
 
 #endif // FVP_GEOM_SUBSET_WH_SI_H

--- a/lib/flowViewport/sceneIndex/wireframeHighlights/fvpPiPrototypeWhSi.cpp
+++ b/lib/flowViewport/sceneIndex/wireframeHighlights/fvpPiPrototypeWhSi.cpp
@@ -29,7 +29,7 @@ namespace {
 
 const std::set<TfToken> kSupportedPrimTypes = {
     HdPrimTypeTokens->mesh,
-#if PXR_VERSION >= 2403
+#if PXR_VERSION >= 2405
     HdPrimTypeTokens->geomSubset,
 #endif
 };
@@ -70,7 +70,7 @@ HdSceneIndexPrim PiPrototypeWhSi::GetHighlightPrim(const SdfPath &selectionPath,
     HdSceneIndexPrim prim = GetInputSceneIndex()->GetPrim(originalPath);
     if (prim.primType == HdPrimTypeTokens->mesh) {
         prim.dataSource = SetWireframeRepr(prim.dataSource, _wireframeColorInterface->getWireframeColor(selectionKey.first));
-#if PXR_VERSION >= 2403
+#if PXR_VERSION >= 2405
         if (originalPrototypePrim.primType == HdPrimTypeTokens->geomSubset && originalPath == selectionKey.first.GetParentPath()) {
             prim.dataSource = MakeGeomSubsetHighlight(prim.dataSource, originalPrototypePrim.dataSource);
         }
@@ -89,15 +89,15 @@ SdfPathVector PiPrototypeWhSi::GetHighlightChildPrimPaths(const SdfPath &selecti
     auto originalPath = fullPrimPath.ReplacePrefix(selectionPath, SdfPath::AbsoluteRootPath());
     auto originalChildPaths = GetInputSceneIndex()->GetChildPrimPaths(originalPath);
     for (const auto& originalChildPath : originalChildPaths) {
-        bool isInstancerRelevantPath = 
+        bool isInstancerRelevantPath =
             FindSelfOrFirstParent(originalChildPath, _instancerPathsToSelections) != _instancerPathsToSelections.end()
             || FindSelfOrFirstChild(originalChildPath, _instancerPathsToSelections) != _instancerPathsToSelections.end();
-        bool isPrototypeRelevantPath = 
+        bool isPrototypeRelevantPath =
             FindSelfOrFirstParent(originalChildPath, _prototypePathsToSelections) != _prototypePathsToSelections.end()
             || FindSelfOrFirstChild(originalChildPath, _prototypePathsToSelections) != _prototypePathsToSelections.end();
         bool isRelevantPath = isInstancerRelevantPath || isPrototypeRelevantPath;
         if (isRelevantPath) {
-#if PXR_VERSION >= 2403
+#if PXR_VERSION >= 2405
             bool isSelectedGeomSubsetPrototypePath = originalPrototypePrim.primType == HdPrimTypeTokens->geomSubset && originalChildPath == selectionKey.first;
             if (!isSelectedGeomSubsetPrototypePath) {
                 childPaths.emplace_back(originalChildPath.ReplacePrefix(SdfPath::AbsoluteRootPath(), selectionPath));
@@ -255,7 +255,7 @@ void PiPrototypeWhSi::ProcessDirtiedPrims(
             }
         }
 
-        if ((_instancerPathsToSelections.find(entry.primPath) != _instancerPathsToSelections.end() || _prototypePathsToSelections.find(entry.primPath) != _prototypePathsToSelections.end()) 
+        if ((_instancerPathsToSelections.find(entry.primPath) != _instancerPathsToSelections.end() || _prototypePathsToSelections.find(entry.primPath) != _prototypePathsToSelections.end())
             && entry.dirtyLocators.Intersects(HdInstancerTopologySchema::GetDefaultLocator())) {
             // Instancing topology was changed : rebuild the highlights, since we don't know exactly how it was changed
             auto instancerSelectionKeysToRebuild = _instancerPathsToSelections.find(entry.primPath);
@@ -293,7 +293,7 @@ void PiPrototypeWhSi::ProcessDirtiedPrims(
             for (const auto& selectionKey : itPrototype->second) {
                 auto selectionPath = SelectionPathFromKey(selectionKey);
                 auto dirtiedPath = entry.primPath.ReplacePrefix(SdfPath::AbsoluteRootPath(), selectionPath);
-#if PXR_VERSION >= 2403
+#if PXR_VERSION >= 2405
                 if (prim.primType == HdPrimTypeTokens->geomSubset && entry.primPath == selectionKey.first) {
                     dirtiedPath = dirtiedPath.GetParentPath();
                 }

--- a/lib/mayaHydra/hydraExtensions/pick/mhUsdPickHandler.cpp
+++ b/lib/mayaHydra/hydraExtensions/pick/mhUsdPickHandler.cpp
@@ -229,11 +229,11 @@ Ufe::Path usdPathToUfePath(
         registration->pluginSceneIndex, usdPath) : Ufe::Path();
 }
 
-#if PXR_VERSION >= 2403
+#if PXR_VERSION >= 2405
 std::vector<UsdPickHandler::HitPath> resolveGeomSubsetsPicking(
-    HdSceneIndexBaseConstRefPtr sceneIndex, 
-    const SdfPath& basePrimPath, 
-    const TfToken& geomSubsetType, 
+    HdSceneIndexBaseConstRefPtr sceneIndex,
+    const SdfPath& basePrimPath,
+    const TfToken& geomSubsetType,
     int componentIndex)
 {
     if (componentIndex < 0) {
@@ -288,7 +288,7 @@ UsdPickHandler::HitPath resolveInstancePicking(HdRenderIndex& renderIndex, const
     // (implicit USD prototype created by USD itself) and point instancing
     // (explicitly authored USD prototypes).  As per HdxInstancerContext
     // documentation:
-    // 
+    //
     // [...] "exactly one of instancePrimOrigin or instancerPrimOrigin will
     // contain data depending on whether the instancing at the current
     // level was implicit or not, respectively."
@@ -302,7 +302,7 @@ UsdPickHandler::HitPath resolveInstancePicking(HdRenderIndex& renderIndex, const
         }
         auto instanceOriginPath = instanceOriginSchema.GetOriginPath(HdPrimOriginSchemaTokens->scenePath);
 
-        // EMSUSD-1220 : Native instances picking depends on the Point Instances pick mode. 
+        // EMSUSD-1220 : Native instances picking depends on the Point Instances pick mode.
         if (GetPointInstancesPickMode() != UsdPointInstancesPickMode::Prototypes) {
             // "PointInstancer" and "Instances" pick modes : select the instanced prim
             return {instanceOriginPath, -1};
@@ -320,7 +320,7 @@ UsdPickHandler::HitPath resolveInstancePicking(HdRenderIndex& renderIndex, const
 
     // Explicit prototype instancing (i.e. USD point instancing).
     std::function<UsdPickHandler::HitPath(const HdxPrimOriginInfo& primOrigin, const HdxPickHit& hit)> pickFn[] = {pickInstancer, pickInstance, pickPrototype};
-                        
+
     // Retrieve pick mode from mayaUsd optionVar, to see if we're picking
     // instances, the instancer itself, or the prototype instanced by the
     // point instance.
@@ -353,12 +353,12 @@ bool UsdPickHandler::handlePickHit(
 
     std::vector<HitPath> hitPaths;
 
-#if PXR_VERSION >= 2403
+#if PXR_VERSION >= 2405
     if (GetGeomSubsetsPickMode() == GeomSubsetsPickModeTokens->Faces) {
         auto geomSubsetsHitPaths = resolveGeomSubsetsPicking(
-            renderIndex()->GetTerminalSceneIndex(), 
-            pickInput.pickHit.objectId, 
-            HdGeomSubsetSchemaTokens->typeFaceSet, 
+            renderIndex()->GetTerminalSceneIndex(),
+            pickInput.pickHit.objectId,
+            HdGeomSubsetSchemaTokens->typeFaceSet,
             pickInput.pickHit.elementIndex);
         if (!geomSubsetsHitPaths.empty()) {
             hitPaths.insert(hitPaths.end(), geomSubsetsHitPaths.begin(), geomSubsetsHitPaths.end());

--- a/lib/mayaHydra/mayaPlugin/renderOverride.cpp
+++ b/lib/mayaHydra/mayaPlugin/renderOverride.cpp
@@ -170,7 +170,7 @@ void replaceSelectionTask(PXR_NS::HdTaskSharedPtrVector* tasks)
     TF_AXIOM(tasks);
 
     auto isSnTask = [](const HdTaskSharedPtr& task) {
-        return std::dynamic_pointer_cast<HdxColorizeSelectionTask>(task) || 
+        return std::dynamic_pointer_cast<HdxColorizeSelectionTask>(task) ||
             std::dynamic_pointer_cast<HdxSelectionTask>(task);
     };
 
@@ -196,8 +196,8 @@ std::string getRenderingDestination(
 }
 #endif
 
-inline Fvp::LightsManagementSceneIndex::LightingMode convertFromMayaLightingModeToFlowViewportLightMode(MFrameContext::LightingMode mayaLightingMode) 
-{ 
+inline Fvp::LightsManagementSceneIndex::LightingMode convertFromMayaLightingModeToFlowViewportLightMode(MFrameContext::LightingMode mayaLightingMode)
+{
     switch (mayaLightingMode) {
         case MFrameContext::kLightDefault: return Fvp::LightsManagementSceneIndex::LightingMode::kDefaultLighting;
         case MFrameContext::kAmbientLight:
@@ -214,7 +214,7 @@ inline Fvp::LightsManagementSceneIndex::LightingMode convertFromMayaLightingMode
 
 PXR_NAMESPACE_OPEN_SCOPE
 // Bring the MayaHydra namespace into scope.
-// The following code currently lives inside the pxr namespace, but it would make more sense to 
+// The following code currently lives inside the pxr namespace, but it would make more sense to
 // have it inside the MayaHydra namespace. This using statement allows us to use MayaHydra symbols
 // from within the pxr namespace as if we were in the MayaHydra namespace.
 // Remove this once the code has been moved to the MayaHydra namespace.
@@ -273,7 +273,7 @@ public:
         : Ufe::Observer(), _renderOverride(renderOverride)
     {}
 
-    void operator()(const Ufe::Notification& notification) override 
+    void operator()(const Ufe::Notification& notification) override
     {
         // During Maya file read, each node will be selected in turn, so we get
         // notified for each node in the scene.  Prune this out.
@@ -370,7 +370,7 @@ MtohRenderOverride::~MtohRenderOverride()
     ClearHydraResources(fullReset);
 
     _operations.clear();
-    
+
     MMessage::removeCallbacks(_callbacks);
     _callbacks.clear();
     for (auto& panelAndCallbacks : _renderPanelCallbacks) {
@@ -438,13 +438,13 @@ VtValue MtohRenderOverride::_GetUsedGPUMemory() const
 }
 
 int MtohRenderOverride::GetUsedGPUMemory()
-{   
+{
     int totalGPUMemory = 0;
     std::lock_guard<std::mutex> lock(_allInstancesMutex);
     for (auto* instance : _allInstances) {
         totalGPUMemory += instance->_GetUsedGPUMemory().UncheckedGet<int>();
     }
-    return totalGPUMemory / (1024*1024); 
+    return totalGPUMemory / (1024*1024);
 }
 
 std::map<std::string, int> MtohRenderOverride::GetSceneStatistics()
@@ -513,7 +513,7 @@ std::map<std::string, int> MtohRenderOverride::GetSceneStatistics()
             stats["curve"]++;
             auto sceneIndexPrim = renderIndex->GetTerminalSceneIndex()->GetPrim(primId);
             auto curvesSchema = HdBasisCurvesSchema::GetFromParent(sceneIndexPrim.dataSource);
-            if (curvesSchema.IsDefined()) { 
+            if (curvesSchema.IsDefined()) {
                 auto curvesTopology  = curvesSchema.GetTopology();
                 if (curvesTopology.IsDefined()) {
                     auto curveIndices = curvesTopology.GetCurveIndices();
@@ -826,7 +826,7 @@ MStatus MtohRenderOverride::Render(
         if (false == manager.ModelPanelIsAlreadyRegistered(panelNameStr)){
             //Get information from viewport
             std::string cameraName;
-    
+
             M3dView view;
 	        if (M3dView::getM3dViewFromModelPanel(panelName, view)){
                 MDagPath dpath;
@@ -834,8 +834,8 @@ MStatus MtohRenderOverride::Render(
 	            MFnCamera viewCamera(dpath);
 	            cameraName = viewCamera.name().asChar();
             }
-    
-            //Create a HydraViewportInformation 
+
+            //Create a HydraViewportInformation
             const Fvp::InformationInterface::ViewportInformation hydraViewportInformation(panelNameStr, cameraName);
             const bool dataProducerSceneIndicesAdded = manager.AddViewportInformation(hydraViewportInformation, _renderIndexProxy, _lastFilteringSceneIndexBeforeCustomFiltering);
             //Update the selection since we have added data producer scene indices through manager.AddViewportInformation to the merging scene index
@@ -857,7 +857,7 @@ MStatus MtohRenderOverride::Render(
     const unsigned int currentDisplayStyle = drawContext.getDisplayStyle();
     MayaHydraParams delegateParams = _globals.delegateParams;
     delegateParams.displaySmoothMeshes = !(currentDisplayStyle & MHWRender::MFrameContext::kFlatShaded);
-    
+
     const bool currentUseDefaultMaterial = (drawContext.getDisplayStyle() & MHWRender::MFrameContext::kDefaultMaterial);
 
     if (_lightsManagementSceneIndex && _lightingMode != currentMayaLightingMode) {
@@ -871,7 +871,7 @@ MStatus MtohRenderOverride::Render(
         _mayaHydraSceneIndex->SetDefaultLight(_defaultLight);
         _mayaHydraSceneIndex->SetParams(delegateParams);
         _mayaHydraSceneIndex->PreFrame(drawContext);
-        
+
         auto& manager = Fvp::ViewportInformationAndSceneIndicesPerViewportDataManager::Get();
         if (_NeedToRecreateTheSceneIndicesChain(currentDisplayStyle)){
             _blockPrimRemovalPropagationSceneIndex->setPrimRemovalBlocked(true);//Prevent prim removal propagation to keep the current selection.
@@ -931,12 +931,12 @@ MStatus MtohRenderOverride::Render(
     {
         auto objectExclusions = framecontext->objectTypeExclusions();
 
-        static const TfTokenVector polygonFilters = { 
-            FvpPruningTokens->meshes, 
-            FvpPruningTokens->capsules, 
-            FvpPruningTokens->cones, 
-            FvpPruningTokens->cubes, 
-            FvpPruningTokens->cylinders, 
+        static const TfTokenVector polygonFilters = {
+            FvpPruningTokens->meshes,
+            FvpPruningTokens->capsules,
+            FvpPruningTokens->cones,
+            FvpPruningTokens->cubes,
+            FvpPruningTokens->cylinders,
             FvpPruningTokens->spheres
         };
         static const std::map<MUint64, TfTokenVector> mayaFiltersToFvpPruningTokens = {
@@ -955,7 +955,7 @@ MStatus MtohRenderOverride::Render(
     // Toggle textures in the material network
     const unsigned int currentDisplayMode = drawContext.getDisplayStyle();
     bool isTextured = currentDisplayMode & MHWRender::MFrameContext::kTextured;
-    if (_pruneTexturesSceneIndex && 
+    if (_pruneTexturesSceneIndex &&
         _currentlyTextured != isTextured) {
         _pruneTexturesSceneIndex->MarkTexturesDirty(isTextured);
         _currentlyTextured = isTextured;
@@ -966,37 +966,37 @@ MStatus MtohRenderOverride::Render(
         if (_mayaHydraSceneIndex && !_mayaHydraSceneIndex->DefaultMaterialCreated()) {
             _mayaHydraSceneIndex->CreateMayaDefaultMaterialData();
         }
-    
+
         _defaultMaterialSceneIndex->Enable(currentUseDefaultMaterial);
         _useDefaultMaterial = currentUseDefaultMaterial;
     }
-    
+
     // Set Required Hydra Repr (Wireframe/WireframeOnShaded/Shaded)
     // Hydra supports Wireframe and WireframeOnSurfaceRefined repr for wireframe on shaded mode.
-    // Refinement level for Hydra is set in Hydra Render Globals    
+    // Refinement level for Hydra is set in Hydra Render Globals
     const MFrameContext::WireOnShadedMode wireOnShadedMode = MFrameContext::wireOnShadedMode();//Get the user preference
     if ( (_reprSelectorSceneIndex && (currentDisplayStyle != _oldDisplayStyle) ) || (delegateParams.refineLevel != _oldRefineLevel)){
-        if( (currentDisplayStyle & MHWRender::MFrameContext::kWireFrame) && 
-            ((currentDisplayStyle & MHWRender::MFrameContext::kGouraudShaded) || 
+        if( (currentDisplayStyle & MHWRender::MFrameContext::kWireFrame) &&
+            ((currentDisplayStyle & MHWRender::MFrameContext::kGouraudShaded) ||
             (currentDisplayStyle & MHWRender::MFrameContext::kTextured)) ) {
                 // Wireframe on top of shaded
                 if (MFrameContext::WireOnShadedMode::kWireframeOnShadedFull == wireOnShadedMode) {
                     _reprSelectorSceneIndex->SetReprType(Fvp::ReprSelectorSceneIndex::RepSelectorType::WireframeOnSurfaceRefined,
                                                          /*needsReprChanged=*/true, delegateParams.refineLevel);
-                } else {              
-                    _reprSelectorSceneIndex->SetReprType(Fvp::ReprSelectorSceneIndex::RepSelectorType::WireframeOnSurface, 
+                } else {
+                    _reprSelectorSceneIndex->SetReprType(Fvp::ReprSelectorSceneIndex::RepSelectorType::WireframeOnSurface,
                                                          /*needsReprChanged=*/true, delegateParams.refineLevel);
                 }
             }
             else if( (currentDisplayStyle & MHWRender::MFrameContext::kWireFrame) ) {
                     //wireframe only, not on top of shaded
-                    _reprSelectorSceneIndex->SetReprType(Fvp::ReprSelectorSceneIndex::RepSelectorType::WireframeRefined, 
-                                                         /*needsReprChanged=*/true, delegateParams.refineLevel); 
+                    _reprSelectorSceneIndex->SetReprType(Fvp::ReprSelectorSceneIndex::RepSelectorType::WireframeRefined,
+                                                         /*needsReprChanged=*/true, delegateParams.refineLevel);
                 }
             else // Shaded mode
-                _reprSelectorSceneIndex->SetReprType(Fvp::ReprSelectorSceneIndex::RepSelectorType::Default, 
+                _reprSelectorSceneIndex->SetReprType(Fvp::ReprSelectorSceneIndex::RepSelectorType::Default,
                                                      /*needsReprChanged=*/false, delegateParams.refineLevel);
-            
+
         _oldRefineLevel = delegateParams.refineLevel;
     }
 
@@ -1027,7 +1027,7 @@ MStatus MtohRenderOverride::Render(
 
     // Set MSAA as per Maya AntiAliasing settings
     if (_isUsingHdSt)
-    {  
+    {
         // Maya's MSAA toggle settings
         bool isMultiSampled = framecontext->getPostEffectEnabled(MHWRender::MFrameContext::kAntiAliasing);
 
@@ -1038,7 +1038,7 @@ MStatus MtohRenderOverride::Render(
 
         // Set MSAA of Depth buffer
         HdAovDescriptor depthAovDesc = _taskController->GetRenderOutputSettings(HdAovTokens->depth);
-        depthAovDesc.multiSampled = isMultiSampled;        
+        depthAovDesc.multiSampled = isMultiSampled;
         _taskController->SetRenderOutputSettings(HdAovTokens->depth, depthAovDesc);
     }
 
@@ -1129,7 +1129,7 @@ MStatus MtohRenderOverride::Render(
     if (_mayaHydraSceneIndex) {
         _mayaHydraSceneIndex->PostFrame();
     }
-    
+
     //Store as old display style
     _oldDisplayStyle = currentDisplayStyle;
 
@@ -1210,7 +1210,7 @@ void MtohRenderOverride::_InitHydraResources(const MHWRender::MDrawContext& draw
     // an initializer_list cannot be used in a ternary operator.
     _fileWriterArgs = _hgi ? VtDictionary{
       {{"hgi", VtValue(_hgi.get())}, {"engine", VtValue(&_engine)}}} :
-      VtDictionary{{{"taskController", VtValue(_taskController.get())}}}; 
+      VtDictionary{{{"taskController", VtValue(_taskController.get())}}};
 
     MayaHydraInitData mhInitData(
         TfToken("MayaHydraSceneIndex"),
@@ -1231,18 +1231,18 @@ void MtohRenderOverride::_InitHydraResources(const MHWRender::MDrawContext& draw
 
     _mayaHydraSceneIndex = MayaHydraSceneIndex::New(mhInitData, !_hasDefaultLighting);
     TF_VERIFY(_mayaHydraSceneIndex, "Maya Hydra scene index not found, check mayaHydra plugin installation.");
-    
+
     VtValue fvpSelectionTrackerValue(_fvpSelectionTracker);
     _engine.SetTaskContextData(FvpTokens->fvpSelectionState, fvpSelectionTrackerValue);
 
     _mayaHydraSceneIndex->Populate();
     //Add the scene index as an input scene index of the merging scene index
     _renderIndexProxy->InsertSceneIndex(_mayaHydraSceneIndex, SdfPath::AbsoluteRootPath());
-    
+
     if (!_sceneIndexRegistry) {
         _sceneIndexRegistry.reset(new MayaHydraSceneIndexRegistry(_renderIndexProxy));
     }
-    
+
     // We provide the pick context for pick handlers, so set the pick handler
     // registry accordingly.
     PickHandlerRegistry::Instance().SetPickContext(this);
@@ -1263,7 +1263,7 @@ void MtohRenderOverride::_InitHydraResources(const MHWRender::MDrawContext& draw
     _inputSceneIndexOfFilteringSceneIndicesChain = _dirtyLeadObjectSceneIndex;
 
 #ifdef MAYA_HAS_VIEW_SELECTED_OBJECT_API
-    // _InitHydraResources() is always called from Render(), so 
+    // _InitHydraResources() is always called from Render(), so
     // getFrameContext() will be valid and non-null.
     auto viewportId = getRenderingDestination(getFrameContext());
 
@@ -1278,11 +1278,11 @@ void MtohRenderOverride::_InitHydraResources(const MHWRender::MDrawContext& draw
     _inputSceneIndexOfFilteringSceneIndicesChain = isSi;
 #endif
 
-    // Set the initial selection onto the selection scene index later. 
+    // Set the initial selection onto the selection scene index later.
     _needToReplaceSelection = true;
 
     _CreateSceneIndicesChainAfterMergingSceneIndex(drawContext);
-    
+
     if (auto* renderDelegate = _GetRenderDelegate()) {
         // Pull in any options that may have changed due file-open.
         // If the currentScene has defaultRenderGlobals we'll absorb those new settings,
@@ -1318,7 +1318,7 @@ void MtohRenderOverride::ClearHydraResources(bool fullReset)
 
     //We don't have any viewport using Hydra any more
     Fvp::ViewportInformationAndSceneIndicesPerViewportDataManager::Get().RemoveAllViewportsInformation();
-    
+
     if (fullReset){
         //Remove the data producer scene indices that apply to all viewports
         Fvp::DataProducerSceneIndexInterfaceImp::get().ClearDataProducerSceneIndicesThatApplyToAllViewports();
@@ -1385,11 +1385,11 @@ void MtohRenderOverride::_CreateSceneIndicesChainAfterMergingSceneIndex(const MH
     _displayStyleSceneIndex->addExcludedSceneRoot(MAYA_NATIVE_ROOT); // Maya native prims don't use global refinement
 
     // Add texture disabling Scene Index
-    _lastFilteringSceneIndexBeforeCustomFiltering = _pruneTexturesSceneIndex = 
+    _lastFilteringSceneIndexBeforeCustomFiltering = _pruneTexturesSceneIndex =
     Fvp::PruneTexturesSceneIndex::New(_lastFilteringSceneIndexBeforeCustomFiltering);
 
     // Add default material scene index
-    _lastFilteringSceneIndexBeforeCustomFiltering = _defaultMaterialSceneIndex = Fvp::DefaultMaterialSceneIndex::New(_lastFilteringSceneIndexBeforeCustomFiltering, 
+    _lastFilteringSceneIndexBeforeCustomFiltering = _defaultMaterialSceneIndex = Fvp::DefaultMaterialSceneIndex::New(_lastFilteringSceneIndexBeforeCustomFiltering,
                                                                                 _mayaHydraSceneIndex ? _mayaHydraSceneIndex->GetDefaultMaterialPath() : SdfPath(),
                                                                                 _mayaHydraSceneIndex ? _mayaHydraSceneIndex->GetDefaultMaterialExclusionPaths(): SdfPathVector());
 
@@ -1398,11 +1398,11 @@ void MtohRenderOverride::_CreateSceneIndicesChainAfterMergingSceneIndex(const MH
     if(! _leadObjectPathTracker){
         _leadObjectPathTracker = std::make_shared<MAYAHYDRA_NS_DEF::MhLeadObjectPathTracker>(_dirtyLeadObjectSceneIndex);
     }
-    
+
     if (! _wireframeColorInterfaceImp){
         _wireframeColorInterfaceImp = std::make_shared<MAYAHYDRA_NS_DEF::MhWireframeColorInterfaceImp>(_selection, _leadObjectPathTracker);
     }
-    
+
     //Are we using Bounding Box display style ?
     if (currentDisplayStyle & MHWRender::MFrameContext::kBoundingBox){
         //Insert the bounding box filtering scene index which converts geometries into a bounding box using the extent attribute
@@ -1410,10 +1410,10 @@ void MtohRenderOverride::_CreateSceneIndicesChainAfterMergingSceneIndex(const MH
         bboxSceneIndex->addExcludedSceneRoot(MAYA_NATIVE_ROOT); // Maya native prims are already converted by OGS
         _lastFilteringSceneIndexBeforeCustomFiltering = bboxSceneIndex;
     }
-  
+
     // Repr selector Scene Index
-    _lastFilteringSceneIndexBeforeCustomFiltering = _reprSelectorSceneIndex = 
-                                                 Fvp::ReprSelectorSceneIndex::New(_lastFilteringSceneIndexBeforeCustomFiltering, 
+    _lastFilteringSceneIndexBeforeCustomFiltering = _reprSelectorSceneIndex =
+                                                 Fvp::ReprSelectorSceneIndex::New(_lastFilteringSceneIndexBeforeCustomFiltering,
                                                  _wireframeColorInterfaceImp);
     _reprSelectorSceneIndex->addExcludedSceneRoot(MAYA_NATIVE_ROOT);
     _reprSelectorSceneIndex->SetReprType(Fvp::ReprSelectorSceneIndex::RepSelectorType::Default, false, _globals.delegateParams.refineLevel);
@@ -1423,18 +1423,18 @@ void MtohRenderOverride::_CreateSceneIndicesChainAfterMergingSceneIndex(const MH
         //// At time of writing, wireframe selection highlighting of Maya native data
         //// is done by Maya at render item creation time, so avoid double wireframe
         //// selection highlighting by excluding MAYA_NATIVE_ROOT.
-        
-#if PXR_VERSION >= 2403
+
+#if PXR_VERSION >= 2405
         _lastFilteringSceneIndexBeforeCustomFiltering = _geomSubsetWhSi = Fvp::GeomSubsetWhSi::New(_lastFilteringSceneIndexBeforeCustomFiltering, _highlightHierarchyPrefix, _wireframeColorInterfaceImp);
         _geomSubsetWhSi->AddExcludedPath(MAYA_NATIVE_ROOT);
 #endif
 
         _lastFilteringSceneIndexBeforeCustomFiltering = _meshWhSi = Fvp::MeshWhSi::New(_lastFilteringSceneIndexBeforeCustomFiltering, _highlightHierarchyPrefix, _wireframeColorInterfaceImp);
         _meshWhSi->AddExcludedPath(MAYA_NATIVE_ROOT);
-        
+
         _lastFilteringSceneIndexBeforeCustomFiltering = _niInstanceWhSi = Fvp::NiInstanceWhSi::New(_lastFilteringSceneIndexBeforeCustomFiltering, _highlightHierarchyPrefix, _wireframeColorInterfaceImp);
         _niInstanceWhSi->AddExcludedPath(MAYA_NATIVE_ROOT);
-        
+
         _lastFilteringSceneIndexBeforeCustomFiltering = _niPrototypeWhSi = Fvp::NiPrototypeWhSi::New(_lastFilteringSceneIndexBeforeCustomFiltering, _highlightHierarchyPrefix, _wireframeColorInterfaceImp);
         _niPrototypeWhSi->AddExcludedPath(MAYA_NATIVE_ROOT);
 
@@ -1444,7 +1444,7 @@ void MtohRenderOverride::_CreateSceneIndicesChainAfterMergingSceneIndex(const MH
         _lastFilteringSceneIndexBeforeCustomFiltering = _piPrototypeWhSi = Fvp::PiPrototypeWhSi::New(_lastFilteringSceneIndexBeforeCustomFiltering, _highlightHierarchyPrefix, _wireframeColorInterfaceImp);
         _piPrototypeWhSi->AddExcludedPath(MAYA_NATIVE_ROOT);
     }
-    
+
     TF_AXIOM(_mayaHydraSceneIndex);
     _lastFilteringSceneIndexBeforeCustomFiltering = _lightsManagementSceneIndex = Fvp::LightsManagementSceneIndex::New(
         _lastFilteringSceneIndexBeforeCustomFiltering, _mayaHydraSceneIndex->GetMayaDefaultLightPath());
@@ -1484,7 +1484,7 @@ void MtohRenderOverride::SelectionChanged(
 
     TF_AXIOM(_selectionSceneIndex);
 
-    // Two considerations: 
+    // Two considerations:
     // 1) Reading from the Maya active selection list only returns
     //    Maya objects, so must read from the UFE selection.
     // 2) The UFE selection does not have Maya component selections.
@@ -1513,7 +1513,7 @@ void MtohRenderOverride::SelectionChanged(
     };
     static std::function<void(const SnOp&, const SnSiPtr&)> changeSn[] = {appendSn, removeSn, insertSn, clearSn, replaceWithSn};
 
-    if (notification.opType() == 
+    if (notification.opType() ==
         Ufe::SelectionChanged::SelectionCompositeNotification) {
 
         const auto& compositeNotification = notification.staticCast<Ufe::SelectionCompositeNotification>();
@@ -1640,7 +1640,7 @@ void MtohRenderOverride::_PopulateSelectionList(
     const HdxPickHitVector&          hits,
     const MHWRender::MSelectionInfo& selectInfo,
     MSelectionList&                  selectionList,
-    MPointArray&                     worldSpaceHitPts, 
+    MPointArray&                     worldSpaceHitPts,
     bool&                            isOneMayaNodeInComponentsPickingMode)
 {
     if (hits.empty() || !_mayaHydraSceneIndex || !_ufeSn) {
@@ -1716,7 +1716,7 @@ void MtohRenderOverride::_PickByRegion(
     pickParams.collection = _renderCollection;
     pickParams.collection.SetExcludePaths({_highlightHierarchyPrefix});
     pickParams.outHits = &outHits;
-    
+
     if (geomSubsetsPickMode == GeomSubsetsPickModeTokens->Faces) {
         pickParams.pickTarget = HdxPickTokens->pickFaces;
     }
@@ -1955,7 +1955,7 @@ void MtohRenderOverride::_ViewSelectedChangedCb(
         kNbViewSelectedChangedCalls, VtValue(nbCalls));
 
     M3dView view;
-    if (!TF_VERIFY(M3dView::getM3dViewFromModelPanel(viewName, view) == MS::kSuccess, 
+    if (!TF_VERIFY(M3dView::getM3dViewFromModelPanel(viewName, view) == MS::kSuccess,
                    "No view found for view name %s.", viewName.asChar())) {
         return;
     }
@@ -1979,13 +1979,13 @@ void MtohRenderOverride::_ViewSelectedChangedCb(
     // viewSelectedObjectsChanged true or false.
     //
     // State transitions:
-    // 
+    //
     // off: message false --> go to pendingObjects, do not notify.
     // off: message true --> illegal, warn, do not notify.
-    // 
+    //
     // pendingObjects: message false --> illegal, warn, do not notify.
     // pendingObjects: message true --> notify, go to on.
-    // 
+    //
     // on: message false --> go to off, notify.
     // on: message true --> stay on, notify.
 
@@ -2001,7 +2001,7 @@ void MtohRenderOverride::_ViewSelectedChangedCb(
         }
         found->second = IsolateSelectState::IsolateSelectOn;
     }
-    
+
     TF_VERIFY(found->second == IsolateSelectState::IsolateSelectOn);
 
     // The M3dView returns the list of view selected objects as strings.
@@ -2034,7 +2034,7 @@ void MtohRenderOverride::_ViewSelectedChangedCb(
 // return true if we need to recreate the filtering scene indices chain because of a change, false otherwise.
 bool MtohRenderOverride::_NeedToRecreateTheSceneIndicesChain(unsigned int currentDisplayStyle)
 {
-    if (areDifferentForOneOfTheseBits(currentDisplayStyle, _oldDisplayStyle,  
+    if (areDifferentForOneOfTheseBits(currentDisplayStyle, _oldDisplayStyle,
                                       MHWRender::MFrameContext::kBoundingBox)){
         return true;
     }

--- a/lib/mayaHydra/mayaPlugin/renderOverride.h
+++ b/lib/mayaHydra/mayaPlugin/renderOverride.h
@@ -99,7 +99,7 @@ using HdxPickHitVector = std::vector<struct HdxPickHit>;
 /*! \brief MtohRenderOverride is a rendering override class for the viewport to use Hydra instead of
  * VP2.0.
  */
-class MtohRenderOverride : public MHWRender::MRenderOverride, 
+class MtohRenderOverride : public MHWRender::MRenderOverride,
     public MayaHydra::PickContext
 {
 public:
@@ -180,7 +180,7 @@ private:
     void              _InitHydraResources(const MHWRender::MDrawContext& drawContext);
     void              _RemovePanel(MString panelName);
     void              _DetectMayaDefaultLighting(const MHWRender::MDrawContext& drawContext);
-    HdRenderDelegate* _GetRenderDelegate();   
+    HdRenderDelegate* _GetRenderDelegate();
     void              _ClearMayaHydraSceneIndex();
     void              _SetRenderPurposeTags(const MayaHydraParams& delegateParams);
     void              _CreateSceneIndicesChainAfterMergingSceneIndex(const MHWRender::MDrawContext& drawContext);
@@ -231,7 +231,7 @@ private:
     // Callbacks
     static void _ClearHydraCallback(void* data);
     static void _TimerCallback(float, float, void* data);
-    static void _PlayblastingChanged(bool state, void*); 
+    static void _PlayblastingChanged(bool state, void*);
     static void _PanelDeletedCallback(const MString& panelName, void* data);
     static void _RendererChangedCallback(
         const MString& panelName,
@@ -291,7 +291,7 @@ private:
     Fvp::SelectionSceneIndexRefPtr            _selectionSceneIndex;
     Fvp::SelectionPtr                         _selection;
     SdfPath                                   _highlightHierarchyPrefix{"/FlowViewportSelectionHighlights"};
-#if PXR_VERSION >= 2403
+#if PXR_VERSION >= 2405
     Fvp::GeomSubsetWhSiRefPtr                 _geomSubsetWhSi;
 #endif
     Fvp::MeshWhSiRefPtr                       _meshWhSi;
@@ -330,13 +330,13 @@ private:
     std::shared_ptr<MAYAHYDRA_NS_DEF::MhLeadObjectPathTracker> _leadObjectPathTracker {nullptr};
     MAYAHYDRA_NS_DEF::MhDirtyLeadObjectSceneIndexRefPtr _dirtyLeadObjectSceneIndex{nullptr};
 
-    /** This class creates the scene index data factories and set them up into the flow viewport library to be able to create DCC 
+    /** This class creates the scene index data factories and set them up into the flow viewport library to be able to create DCC
     *   specific scene index data classes without knowing their content in Flow viewport.
     *   This is done in the constructor of this class
     */
     MAYAHYDRA_NS_DEF::SceneIndexDataFactoriesSetup  _sceneIndexDataFactoriesSetup;
 
-    SdfPath _ID; // Root path to runtime data (like task controller) 
+    SdfPath _ID; // Root path to runtime data (like task controller)
 
     GfVec4d _viewport;
 
@@ -365,7 +365,7 @@ private:
     // first false (state change), then true (objects set).  To avoid
     // double dirtying in Hydra, we track the following isolate select
     // states per viewport:
-    // 
+    //
     enum class IsolateSelectState {IsolateSelectOff, IsolateSelectPendingObjects,
 				   IsolateSelectOn};
 

--- a/scripts/mayaHydra_GeomSubsetsPickMode.mel
+++ b/scripts/mayaHydra_GeomSubsetsPickMode.mel
@@ -62,7 +62,7 @@ global proc mayaHydra_GeomSubsetsPickMode_SetMode(string $mode) {
 
 // Main entry point to create the GeomSubsets UI
 global proc mayaHydra_GeomSubsetsPickMode_SetupUI() {
-    if (`mayaHydra -usdVersion` < 2403) {
+    if (`mayaHydra -usdVersion` < 2405) {
         return;
     }
 
@@ -76,7 +76,7 @@ global proc mayaHydra_GeomSubsetsPickMode_SetupUI() {
 
 // Main entry point to delete the GeomSubsets UI
 global proc mayaHydra_GeomSubsetsPickMode_TeardownUI() {
-    if (`mayaHydra -usdVersion` < 2403) {
+    if (`mayaHydra -usdVersion` < 2405) {
         return;
     }
 
@@ -131,8 +131,8 @@ global proc mayaHydra_GeomSubsetsPickModeMenu_SelectMenuOpenedCallback() {
     // modes submenu and its menu items. So what we do in order to add our own menu items is that
     // we also add our own callback on the "Select" menu. However, we can't count on the order
     // in which callbacks will be registered and processed, and just blindly add the menu items here.
-    // To work around this, we thus create the UI elements in a method that will be called by an idle 
-    // event/scriptJob, which will be executed after the "Select" menu open callbacks have been 
+    // To work around this, we thus create the UI elements in a method that will be called by an idle
+    // event/scriptJob, which will be executed after the "Select" menu open callbacks have been
     // processed. The USD selection modes menu should then exist, and we can add our menu items then.
 
     // If MayaUSD is not loaded, the USD selection modes menu won't exist, so no need to try and add

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testGeomSubsetsPicking.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testGeomSubsetsPicking.cpp
@@ -38,7 +38,7 @@ using namespace MayaHydra;
 
 namespace {
 
-#if PXR_VERSION >= 2403
+#if PXR_VERSION >= 2405
 const std::string kStageUfePathSegment = "|GeomSubsetsPickingTestScene|GeomSubsetsPickingTestSceneShape";
 
 const std::string kCubeMeshUfePathSegment = "/Root/CubeMeshXform/CubeMesh";
@@ -133,7 +133,7 @@ void testPicking(const Ufe::Path& clickMarkerUfePath, const Ufe::Path& selectedO
 
 TEST(TestGeomSubsetsPicking, geomSubsetPicking)
 {
-#if PXR_VERSION < 2403
+#if PXR_VERSION < 2405
     GTEST_SKIP() << "Skipping test, USD version used does not support GeomSubset prims.";
 #else
     const auto cubeUpperHalfMarkerUfePath = Ufe::PathString::path(kStageUfePathSegment + "," + kCubeUpperHalfMarkerUfePathSegment);
@@ -144,7 +144,7 @@ TEST(TestGeomSubsetsPicking, geomSubsetPicking)
 
 TEST(TestGeomSubsetsPicking, fallbackPicking)
 {
-#if PXR_VERSION < 2403
+#if PXR_VERSION < 2405
     GTEST_SKIP() << "Skipping test, USD version used does not support GeomSubset prims.";
 #else
     const auto cubeLowerHalfMarkerUfePath = Ufe::PathString::path(kStageUfePathSegment + "," + kCubeLowerHalfMarkerUfePathSegment);
@@ -155,7 +155,7 @@ TEST(TestGeomSubsetsPicking, fallbackPicking)
 
 TEST(TestGeomSubsetsPicking, instanceGeomSubsetPicking)
 {
-#if PXR_VERSION < 2403
+#if PXR_VERSION < 2405
     GTEST_SKIP() << "Skipping test, USD version used does not support GeomSubset prims.";
 #else
     const auto sphereInstanceUpperHalfMarkerUfePath = Ufe::PathString::path(kStageUfePathSegment + "," + kSphereInstanceUpperHalfMarkerUfePathSegment);
@@ -166,7 +166,7 @@ TEST(TestGeomSubsetsPicking, instanceGeomSubsetPicking)
 
 TEST(TestGeomSubsetsPicking, instanceFallbackPicking)
 {
-#if PXR_VERSION < 2403
+#if PXR_VERSION < 2405
     GTEST_SKIP() << "Skipping test, USD version used does not support GeomSubset prims.";
 #else
     const auto sphereInstanceLowerHalfMarkerUfePath = Ufe::PathString::path(kStageUfePathSegment + "," + kSphereInstanceLowerHalfMarkerUfePathSegment);
@@ -177,7 +177,7 @@ TEST(TestGeomSubsetsPicking, instanceFallbackPicking)
 
 TEST(TestGeomSubsetsPicking, marqueeSelect)
 {
-#if PXR_VERSION < 2403
+#if PXR_VERSION < 2405
     GTEST_SKIP() << "Skipping test, USD version used does not support GeomSubset prims.";
 #else
     const SceneIndicesVector& sceneIndices = GetTerminalSceneIndices();
@@ -195,7 +195,7 @@ TEST(TestGeomSubsetsPicking, marqueeSelect)
     // Preconditions
     auto ufeSelection = Ufe::GlobalSelection::get();
     ASSERT_TRUE(ufeSelection->empty());
-    
+
     for (const auto& geomSubsetName : geomSubsetNamesToSelect) {
         assertUnselected(inspector, FindGeomSubsetPredicate(geomSubsetName));
     }


### PR DESCRIPTION
Code switch for geom subsets is incorrect it should be 24.05+ as described here: https://github.com/PixarAnimationStudios/OpenUSD/blob/dev/CHANGELOG.md?plain=1#L3001

One of our variants uses USD 24.03 and it cannot be built with current state.