### PR TITLE
Added null check to prevent crashes when an "instance" or "prototype" prim has no matrices.

### DIFF
--- a/lib/flowViewport/sceneIndex/wireframeHighlights/fvpNiInstanceWhSi.cpp
+++ b/lib/flowViewport/sceneIndex/wireframeHighlights/fvpNiInstanceWhSi.cpp
@@ -82,7 +82,7 @@ HdSceneIndexPrim NiInstanceWhSi::GetHighlightPrim(const SdfPath &selectionPath, 
         prototypeXform = prototypeMatrixDS->GetTypedValue(0);
     } else {
         TF_WARN(
-            "Prototype Prim %s (selection %s) has no xform matrix datasource, using identity.",
+            "Prototype Prim %s (selection %s) has no matrix, using identity.",
             originalPath.GetText(),
             selectionPath.GetText());
     }

--- a/lib/flowViewport/sceneIndex/wireframeHighlights/fvpNiInstanceWhSi.cpp
+++ b/lib/flowViewport/sceneIndex/wireframeHighlights/fvpNiInstanceWhSi.cpp
@@ -64,9 +64,29 @@ HdSceneIndexPrim NiInstanceWhSi::GetHighlightPrim(const SdfPath &selectionPath, 
 
     dsEditor.Set(HdInstancedBySchema::GetDefaultLocator(), HdBlockDataSource::New());
 
+    GfMatrix4d instanceXform(1.0);
     HdSceneIndexPrim instancePrim = GetInputSceneIndex()->GetPrim(selectionKey.first);
-    auto instanceXform = HdXformSchema::GetFromParent(instancePrim.dataSource).GetMatrix()->GetTypedValue(0);
-    auto prototypeXform = HdXformSchema::GetFromParent(prim.dataSource).GetMatrix()->GetTypedValue(0);
+    auto instanceMatrixDS = HdXformSchema::GetFromParent(instancePrim.dataSource).GetMatrix();
+    if (instanceMatrixDS) {
+        instanceXform = instanceMatrixDS->GetTypedValue(0);
+    } else {
+        TF_WARN(
+            "Instance Prim %s (selection %s) has no matrix, using identity.",
+            selectionKey.first.GetText(),
+            selectionPath.GetText());
+    }
+
+    GfMatrix4d prototypeXform(1.0);
+    auto prototypeMatrixDS = HdXformSchema::GetFromParent(prim.dataSource).GetMatrix();
+    if (prototypeMatrixDS) {
+        prototypeXform = prototypeMatrixDS->GetTypedValue(0);
+    } else {
+        TF_WARN(
+            "Prototype Prim %s (selection %s) has no xform matrix datasource, using identity.",
+            originalPath.GetText(),
+            selectionPath.GetText());
+    }
+
     dsEditor.Set(HdXformSchema::GetDefaultLocator().Append(HdXformSchemaTokens->matrix), HdRetainedTypedSampledDataSource<GfMatrix4d>::New(prototypeXform * instanceXform));
 
     prim.dataSource = dsEditor.Finish();


### PR DESCRIPTION
This PR prevent crashes caused by dereferencing null GetMatrix() on instance or prototype prims. Added safe fallbacks using identity matrice and logs warnings with prim and selection paths...

Screenshot:
<img width="1546" height="978" alt="Screenshot 2025-09-22 093424" src="https://github.com/user-attachments/assets/dc05015e-8731-47e5-9197-c887991c8576" />

CallStack:

```
>	flowViewport.dll!Fvp_v0::NiInstanceWhSi::GetHighlightPrim(const pxrInternal_v0_25_5__pxrReserved__::SdfPath & selectionPath={...}, const pxrInternal_v0_25_5__pxrReserved__::SdfPath & fullPrimPath) Line 69	C++
 	flowViewport.dll!Fvp_v0::BaseWhSi::GetPrim(const pxrInternal_v0_25_5__pxrReserved__::SdfPath & primPath={...}) Line 561	C++
 	flowViewport.dll!Fvp_v0::BaseWhSi::GetPrim(const pxrInternal_v0_25_5__pxrReserved__::SdfPath & primPath={...}) Line 564	C++
 	flowViewport.dll!Fvp_v0::BaseWhSi::GetPrim(const pxrInternal_v0_25_5__pxrReserved__::SdfPath & primPath={...}) Line 564	C++
 	flowViewport.dll!Fvp_v0::BaseWhSi::GetPrim(const pxrInternal_v0_25_5__pxrReserved__::SdfPath & primPath={...}) Line 564	C++
 	flowViewport.dll!Fvp_v0::LightsManagementSceneIndex::_DirtyAllLightsPrims() Line 140	C++
 	mayaHydra.mll!pxrInternal_v0_25_5__pxrReserved__::MtohRenderOverride::Render(const Autodesk::Maya::OpenMaya20250000::MHWRender::MDrawContext & drawContext={...}, const Autodesk::Maya::OpenMaya20250000::MHWRender::MDataServerOperation::MViewportScene & scene) Line 865	C++
 	mayaHydra.mll!pxrInternal_v0_25_5__pxrReserved__::MayaHydraRender::execute(const Autodesk::Maya::OpenMaya20250000::MHWRender::MDrawContext & drawContext, const Autodesk::Maya::OpenMaya20250000::MHWRender::MDataServerOperation::MViewportScene & scene) Line 99	C++
 	OpenMayaRender.dll!MHWRender::THogsDataserverOperation::execute() Line 1212	C++
 	OGSMayaBridge.dll!OGSMayaRenderer::performUserOperation(OGSScriptedFrameRender & scriptedRender, OGSMayaBaseRenderer & baseRenderer, OGSMayaUserOperation & userOp={...}, bool & sceneUpdated=true) Line 3859	C++
 	OGSMayaBridge.dll!OGSMayaRenderer::performOverrideRenderGraph(OGSMayaBaseRenderer & baseRenderer={...}, const Tstring & renderOverrideName) Line 3516	C++
 	OGSMayaBridge.dll!OGSMayaBaseRenderer::performOverrideRender(const Tstring & overrideName={...}, TinteractiveView * view=0x00000221e69014b0) Line 573	C++
 	OGSMayaBridge.dll!OGSViewportRenderer::performRender(const ThardwareRenderInfo & info={...}) Line 1397	C++
 	OGSMayaBridge.dll!OGSViewportRenderer::render(const ThardwareRenderInfo & info={...}) Line 1447	C++
 	DataModel.dll!TidleRefreshCmd::refreshOGSRender(T3dView * view=0x00000221e69014b0, bool presentBuffer, bool shadedActiveOnly=176, TdisplayAppearance disp=1348449808, bool reduceLOD=false, bool usingOffscreen, bool forOverlay=false) Line 1194	C++
 	DataModel.dll!TidleRefreshCmd::refresh(T3dView * myView=0x00000221e69014b0, TdisplayAppearance disp=kGouraudShaded, bool refreshBackGround, bool presentBuffer, bool shadedActiveOnly=false, bool reduceLOD, bool usingOffscreen, bool forOverlay) Line 950	C++
 	DataModel.dll!TidleRefreshCmd::doIt(const Tevent & __formal={...}) Line 427	C++
 	ExtensionLayer.dll!TeventHandler::doIdles() Line 813	C++
 	ExtensionLayer.dll!QidleTimer::timerEvent(QTimerEvent * event=0x00000221eca485b0) Line 168	C++
 	Qt6Core.dll!QObject::event(QEvent * e=0x000000c0505fc000) Line 1465	C++
 	Qt6Widgets.dll!QApplicationPrivate::notify_helper(QObject * receiver=0x00000221eca485b0, QEvent * e=0x000000c0505fc000) Line 3292	C++
 	Qt6Widgets.dll!QApplication::notify(QObject * receiver=0x00000221eca485b0, QEvent * e=0x000000c0505fc000) Line 3244	C++
 	ExtensionLayer.dll!QmayaApplication::notify(QObject * receiver=0x00000221eca485b0, QEvent * event=0x000000c0505fc000) Line 737	C++
 	Qt6Core.dll!QCoreApplication::notifyInternal2(QObject * receiver=0x00000221eca485b0, QEvent * event=0x000000c0505fc000) Line 1118	C++
 	Qt6Core.dll!QEventDispatcherWin32::event(QEvent * e=0x00000221dc2e09c0) Line 860	C++
 	Qt6Widgets.dll!QApplicationPrivate::notify_helper(QObject * receiver=0x00000221f466ca50, QEvent * e=0x00000221dc2e09c0) Line 3292	C++
 	Qt6Widgets.dll!QApplication::notify(QObject * receiver=0x00000221f466ca50, QEvent * e=0x00000221dc2e09c0) Line 3244	C++
 	ExtensionLayer.dll!QmayaApplication::notify(QObject * receiver=0x00000221f466ca50, QEvent * event=0x00000221dc2e09c0) Line 737	C++
 	Qt6Core.dll!QCoreApplication::notifyInternal2(QObject * receiver=0x00000221f466ca50, QEvent * event=0x00000221dc2e09c0) Line 1118	C++
 	[Inline Frame] Qt6Core.dll!QCoreApplication::sendEvent(QObject *) Line 1536	C++
 	Qt6Core.dll!QCoreApplicationPrivate::sendPostedEvents(QObject * receiver=0x0000000000000000, int event_type, QThreadData * data=0x00000221f0c9cd60) Line 1898	C++
 	Qt6Gui.dll!QWindowsGuiEventDispatcher::sendPostedEvents() Line 44	C++
 	Qt6Core.dll!QEventDispatcherWin32::processEvents(QFlags<enum QEventLoop::ProcessEventsFlag> flags={...}) Line 464	C++
 	Qt6Gui.dll!QWindowsGuiEventDispatcher::processEvents(QFlags<enum QEventLoop::ProcessEventsFlag> flags) Line 37	C++
 	[Inline Frame] Qt6Core.dll!QEventLoop::processEvents(QFlags<enum QEventLoop::ProcessEventsFlag>) Line 100	C++
 	Qt6Core.dll!QEventLoop::exec(QFlags<enum QEventLoop::ProcessEventsFlag> flags) Line 181	C++
 	Qt6Core.dll!QCoreApplication::exec() Line 1439	C++
 	ExtensionLayer.dll!Tapplication::start() Line 1327	C++
 	maya.exe!appmain() Line 1076	C++
 	maya.exe!qtEntryPoint() Line 50	C++
 	[External Code]	

```