### PR TITLE
HYDRA-1909 - Fix picking crash on instance with guide purpose

### DIFF
--- a/lib/mayaHydra/flowViewportAPIExamples/flowViewportAPILocator/mhFlowViewportAPILocator.cpp
+++ b/lib/mayaHydra/flowViewportAPIExamples/flowViewportAPILocator/mhFlowViewportAPILocator.cpp
@@ -30,6 +30,7 @@
 #include <mayaHydraLib/mayaUtils.h>
 #include <mayaHydraLib/mayaHydraLibInterface.h>
 #include <mayaHydraLib/pick/mhPickHandler.h>
+#include <mayaHydraLib/pick/mhPickHit.h>
 #include <mayaHydraLib/pick/mhPickHandlerRegistry.h>
 #include <ufeExtensions/Global.h>
 #include <ufeExtensions/cvtTypeUtils.h>
@@ -211,7 +212,7 @@ public:
     ) const override
     {
         auto cubeUfePath = MhFlowViewportAPILocator::getCubeUfePath(
-            _locatorObj, pickInput.pickHit.objectId.GetName());
+            _locatorObj, pickInput.pickHit.hdxPickHit.objectId.GetName());
 
         // Append the picked object to the UFE selection.
         auto si = Ufe::Hierarchy::createItem(cubeUfePath);

--- a/lib/mayaHydra/flowViewportAPIExamples/footPrintNode/mhFootPrintNode.cpp
+++ b/lib/mayaHydra/flowViewportAPIExamples/footPrintNode/mhFootPrintNode.cpp
@@ -48,6 +48,7 @@
 
 // MayaHydra headers.
 #include <mayaHydraLib/pick/mhPickHandler.h>
+#include <mayaHydraLib/pick/mhPickHit.h>
 #include <mayaHydraLib/pick/mhPickHandlerRegistry.h>
 #include <ufeExtensions/Global.h>
 
@@ -99,7 +100,7 @@ public:
         MDagPath dagPath;
         TF_AXIOM(MDagPath::getAPathTo(_footPrintObj, dagPath) == MS::kSuccess);
         pickOutput.mayaSelection.add(dagPath);
-        const auto& wsPt = pickInput.pickHit.worldSpaceHitPoint;
+        const auto& wsPt = pickInput.pickHit.hdxPickHit.worldSpaceHitPoint;
         pickOutput.mayaWorldSpaceHitPts.append(wsPt[0], wsPt[1], wsPt[2]);
 
         return true;

--- a/lib/mayaHydra/hydraExtensions/pick/CMakeLists.txt
+++ b/lib/mayaHydra/hydraExtensions/pick/CMakeLists.txt
@@ -9,6 +9,8 @@ target_sources(${TARGET_NAME}
     mhPickHandlerFwd.cpp
     mhPickHandlerRegistry.cpp
     mhUsdPickHandler.cpp
+    mhPickHit.cpp
+    mhPickHitFwd.cpp
 )
 
 set(HEADERS
@@ -18,6 +20,8 @@ set(HEADERS
     mhPickHandlerFwd.h
     mhPickHandlerRegistry.h
     mhUsdPickHandler.h
+    mhPickHit.h
+    mhPickHitFwd.h
 )
 
 # -----------------------------------------------------------------------------

--- a/lib/mayaHydra/hydraExtensions/pick/mhPickHandler.h
+++ b/lib/mayaHydra/hydraExtensions/pick/mhPickHandler.h
@@ -18,16 +18,13 @@
 
 #include <mayaHydraLib/api.h>
 #include <mayaHydraLib/pick/mhPickHandlerFwd.h>
+#include <mayaHydraLib/pick/mhPickHitFwd.h>
 
 #include <pxr/pxr.h>
 
 #include <maya/MApiNamespace.h>
 
 #include <ufe/namedSelection.h>
-
-PXR_NAMESPACE_OPEN_SCOPE
-struct HdxPickHit;
-PXR_NAMESPACE_CLOSE_SCOPE
 
 PXR_NAMESPACE_USING_DIRECTIVE
 
@@ -56,7 +53,7 @@ public:
     ) const = 0;
 
     MAYAHYDRALIB_API
-    virtual bool inSingleNodeComponentsPick(const HdxPickHit&) const {
+    virtual bool inSingleNodeComponentsPick(const PickHit&) const {
         return false;
     }
 };
@@ -66,12 +63,12 @@ public:
 /// Picking input consists of the Hydra pick hit and the Maya selection state.
 struct PickHandler::Input {
     Input(
-        const HdxPickHit&                pickHitArg, 
+        const PickHit&                   pickHitArg, 
         const MHWRender::MSelectionInfo& pickInfoArg,
         const bool                       isSolePickHitArg
     ) : pickHit(pickHitArg), pickInfo(pickInfoArg), isSolePickHit(isSolePickHitArg) {}
 
-    const HdxPickHit&                pickHit;
+    const PickHit&                   pickHit;
     const MHWRender::MSelectionInfo& pickInfo;
     const bool                       isSolePickHit;
 };

--- a/lib/mayaHydra/hydraExtensions/pick/mhPickHit.cpp
+++ b/lib/mayaHydra/hydraExtensions/pick/mhPickHit.cpp
@@ -1,0 +1,18 @@
+//
+// Copyright 2025 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Trivial inclusion to ensure header compiles on its own.
+#include <mayaHydraLib/pick/mhPickHit.h>

--- a/lib/mayaHydra/hydraExtensions/pick/mhPickHit.h
+++ b/lib/mayaHydra/hydraExtensions/pick/mhPickHit.h
@@ -36,8 +36,8 @@ struct PickHit
         : passIndex(passIdx)
         , hdxPickHit(pickHit) {}
 
-    int        passIndex; // FramePass index.
-    HdxPickHit hdxPickHit;
+    const int        passIndex; // FramePass index.
+    const HdxPickHit hdxPickHit;
 };
 
 }

--- a/lib/mayaHydra/hydraExtensions/pick/mhPickHit.h
+++ b/lib/mayaHydra/hydraExtensions/pick/mhPickHit.h
@@ -1,0 +1,45 @@
+//
+// Copyright 2025 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef MH_PICK_HIT_H
+#define MH_PICK_HIT_H
+
+#include <mayaHydraLib/api.h>
+#include <mayaHydraLib/mayaHydra.h>
+
+#include <pxr/imaging/hdx/pickTask.h>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+namespace MAYAHYDRA_NS_DEF {
+
+/// \class PickContext
+///
+/// Provides an interface that pick handlers can call to obtain information
+/// needed to implement picking.
+///
+struct PickHit
+{
+    PickHit(int passIdx, HdxPickHit pickHit)
+        : passIndex(passIdx)
+        , hdxPickHit(pickHit) {}
+
+    int        passIndex; // FramePass index.
+    HdxPickHit hdxPickHit;
+};
+
+}
+
+#endif

--- a/lib/mayaHydra/hydraExtensions/pick/mhPickHitFwd.cpp
+++ b/lib/mayaHydra/hydraExtensions/pick/mhPickHitFwd.cpp
@@ -1,0 +1,18 @@
+//
+// Copyright 2025 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Trivial inclusion to ensure header compiles on its own.
+#include <mayaHydraLib/pick/mhPickHitFwd.h>

--- a/lib/mayaHydra/hydraExtensions/pick/mhPickHitFwd.h
+++ b/lib/mayaHydra/hydraExtensions/pick/mhPickHitFwd.h
@@ -1,0 +1,31 @@
+//
+// Copyright 2025 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef MH_PICK_HIT_FWD_H
+#define MH_PICK_HIT_FWD_H
+
+#include <mayaHydraLib/api.h>
+
+#include <vector>
+
+namespace MAYAHYDRA_NS_DEF {
+
+class PickHit;
+
+using PickHitVector = std::vector<struct PickHit>;
+
+} // namespace MAYAHYDRA_NS_DEF
+
+#endif

--- a/lib/mayaHydra/hydraExtensions/pick/mhUsdPickHandler.cpp
+++ b/lib/mayaHydra/hydraExtensions/pick/mhUsdPickHandler.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+#include <mayaHydraLib/pick/mhPickHit.h>
 #include <mayaHydraLib/pick/mhUsdPickHandler.h>
 #include <mayaHydraLib/pick/mhPickContext.h>
 #include <mayaHydraLib/pick/mhPickHandlerRegistry.h>
@@ -280,7 +281,7 @@ UsdPickHandler::HitPath resolveInstancePicking(HdRenderIndex& renderIndex, const
 {
     auto primOrigin = HdxPrimOriginInfo::FromPickHit(&renderIndex, pickHit);
 
-    if (pickHit.instancerId.IsEmpty()) {
+    if (pickHit.instancerId.IsEmpty() || primOrigin.instancerContexts.empty()) {
         return {primOrigin.GetFullPath(), -1};
     }
 
@@ -345,7 +346,7 @@ bool UsdPickHandler::handlePickHit(
         return false;
     }
 
-    auto registration = sceneIndexRegistry()->GetSceneIndexRegistrationForRprim(pickInput.pickHit.objectId);
+    auto registration = sceneIndexRegistry()->GetSceneIndexRegistrationForRprim(pickInput.pickHit.hdxPickHit.objectId);
 
     if (!registration) {
         return false;
@@ -356,23 +357,23 @@ bool UsdPickHandler::handlePickHit(
 #if PXR_VERSION >= 2405
     if (GetGeomSubsetsPickMode() == GeomSubsetsPickModeTokens->Faces) {
         auto geomSubsetsHitPaths = resolveGeomSubsetsPicking(
-            renderIndex()->GetTerminalSceneIndex(),
-            pickInput.pickHit.objectId,
+            renderIndex(pickInput.pickHit.passIndex)->GetTerminalSceneIndex(),
+            pickInput.pickHit.hdxPickHit.objectId,
             HdGeomSubsetSchemaTokens->typeFaceSet,
-            pickInput.pickHit.elementIndex);
+            pickInput.pickHit.hdxPickHit.elementIndex);
         if (!geomSubsetsHitPaths.empty()) {
             hitPaths.insert(hitPaths.end(), geomSubsetsHitPaths.begin(), geomSubsetsHitPaths.end());
         }
 
         // If we did not find any geomSubset and this is the only pick hit, then fallback to selecting the base prim/instance.
         if (hitPaths.empty() && pickInput.isSolePickHit) {
-            hitPaths.push_back(resolveInstancePicking(*renderIndex(), pickInput.pickHit));
+            hitPaths.push_back(resolveInstancePicking(*renderIndex(pickInput.pickHit.passIndex), pickInput.pickHit.hdxPickHit));
         }
     } else {
-        hitPaths.push_back(resolveInstancePicking(*renderIndex(), pickInput.pickHit));
+        hitPaths.push_back(resolveInstancePicking(*renderIndex(pickInput.pickHit.passIndex), pickInput.pickHit.hdxPickHit));
     }
 #else
-    hitPaths.push_back(resolveInstancePicking(*renderIndex(), pickInput.pickHit));
+    hitPaths.push_back(resolveInstancePicking(*renderIndex(pickInput.pickHit.passIndex), pickInput.pickHit.hdxPickHit));
 #endif
 
     size_t nbSelectedUfeItems = 0;
@@ -429,9 +430,9 @@ bool UsdPickHandler::handlePickHit(
     return nbSelectedUfeItems > 0;
 }
 
-HdRenderIndex* UsdPickHandler::renderIndex() const
+HdRenderIndex* UsdPickHandler::renderIndex(int passIndex) const
 {
-    return PickHandlerRegistry::Instance().GetPickContext()->renderIndex();
+    return PickHandlerRegistry::Instance().GetPickContext()->renderIndex(passIndex);
 }
 
 std::shared_ptr<const MayaHydraSceneIndexRegistry>

--- a/lib/mayaHydra/hydraExtensions/pick/mhUsdPickHandler.h
+++ b/lib/mayaHydra/hydraExtensions/pick/mhUsdPickHandler.h
@@ -53,7 +53,7 @@ public:
 
 private:
 
-    PXR_NS::HdRenderIndex* renderIndex() const;
+    PXR_NS::HdRenderIndex* renderIndex(int passIndex = 0) const;
     std::shared_ptr<const MayaHydraSceneIndexRegistry>
     sceneIndexRegistry() const;
 };

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
@@ -44,6 +44,7 @@
 #include <mayaHydraLib/mixedUtils.h>
 #include <mayaHydraLib/sceneIndex/mayaHydraDataSource.h>
 #include <mayaHydraLib/pick/mhPickHandler.h>
+#include <mayaHydraLib/pick/mhPickHit.h>
 #include <mayaHydraLib/pick/mhPickHandlerRegistry.h>
 #include <flowViewport/selection/fvpDataProducersNodeHashCodeToSdfPathRegistry.h>
 
@@ -85,7 +86,7 @@ public:
     {
         // Maya does not create Hydra instances, so if the pick hit instancer
         // ID isn't empty, it's not a Maya pick hit.
-        if (!pickInput.pickHit.instancerId.IsEmpty()) {
+        if (!pickInput.pickHit.hdxPickHit.instancerId.IsEmpty()) {
             return false;
         }
 
@@ -95,7 +96,7 @@ public:
         );
     }
 
-    bool inSingleNodeComponentsPick(const HdxPickHit& hit) const override {
+    bool inSingleNodeComponentsPick(const MayaHydra::PickHit& hit) const override {
         // Is the picked node in components selection mode?  If so it is in the
         // hilite list.
         MSelectionList hiliteList;
@@ -866,7 +867,7 @@ SdfPath MayaHydraSceneIndex::SetCameraViewport(const MDagPath& camPath, const Gf
     return {};
 }
 
-bool MayaHydraSceneIndex::IsPickedNodeInComponentsPickingMode(const HdxPickHit& hit)const
+bool MayaHydraSceneIndex::IsPickedNodeInComponentsPickingMode(const MayaHydra::PickHit& hit) const
 {
     // Is the picked node in components selection mode ? If so it is in the hilite list
     MSelectionList hiliteList;
@@ -877,7 +878,7 @@ bool MayaHydraSceneIndex::IsPickedNodeInComponentsPickingMode(const HdxPickHit& 
 
     bool isOneMayaNodeInComponentsPickingMode = false;
             
-    SdfPath hitId = hit.objectId;
+    SdfPath hitId = hit.hdxPickHit.objectId;
     if (hitId.HasPrefix(GetRprimPath())) {
         _FindAdapter<MayaHydraRenderItemAdapter>(
             hitId,
@@ -906,12 +907,12 @@ bool MayaHydraSceneIndex::IsPickedNodeInComponentsPickingMode(const HdxPickHit& 
 }
 
 bool MayaHydraSceneIndex::AddPickHitToSelectionList(
-    const HdxPickHit& hit,
+    const MayaHydra::PickHit& hit,
     const MHWRender::MSelectionInfo& /* selectInfo */,
     MSelectionList& selectionList,
     MPointArray& worldSpaceHitPts)
 {
-    SdfPath hitId = hit.objectId;
+    SdfPath hitId = hit.hdxPickHit.objectId;
     // validate that hit is indeed a maya item. Alternatively, the rprim hit could be an rprim
     // defined by a scene index such as maya usd.
     if (hitId.HasPrefix(GetRprimPath())) {
@@ -927,9 +928,9 @@ bool MayaHydraSceneIndex::AddPickHitToSelectionList(
                 }
                 selectionList.add(selectPath);
                 worldSpaceHitPts.append(
-                    hit.worldSpaceHitPoint[0],
-                    hit.worldSpaceHitPoint[1],
-                    hit.worldSpaceHitPoint[2]);
+                    hit.hdxPickHit.worldSpaceHitPoint[0],
+                    hit.hdxPickHit.worldSpaceHitPoint[1],
+                    hit.hdxPickHit.worldSpaceHitPoint[2]);
             },
             _renderItemsAdapters);
         return true;

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.h
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.h
@@ -32,6 +32,7 @@
 #include <mayaHydraLib/adapters/cameraAdapter.h>
 #include <mayaHydraLib/sceneIndex/mayaHydraDefaultLightDataSource.h>
 #include <mayaHydraLib/sceneIndex/mayaHydraMaterialDataSource.h>
+#include <mayaHydraLib/pick/mhPickHitFwd.h>
 
 #include <flowViewport/selection/fvpPathMapperFwd.h>
 #include <flowViewport/selection/fvpSelectionTypes.h>
@@ -113,12 +114,12 @@ public:
 
     // Add hydra pick points and items to Maya's selection list
     bool AddPickHitToSelectionList(
-        const HdxPickHit& hit,
+        const MayaHydra::PickHit&        hit,
         const MHWRender::MSelectionInfo& selectInfo,
         MSelectionList& selectionList,
         MPointArray& worldSpaceHitPts);
 
-    bool IsPickedNodeInComponentsPickingMode(const HdxPickHit& hit)const;
+    bool IsPickedNodeInComponentsPickingMode(const MayaHydra::PickHit& hit) const;
     
 
     // Insert a primitive to hydra scene

--- a/lib/mayaHydra/mayaPlugin/renderOverride.cpp
+++ b/lib/mayaHydra/mayaPlugin/renderOverride.cpp
@@ -30,6 +30,7 @@
 
 #include <mayaHydraLib/mayaHydraLibInterface.h>
 #include <mayaHydraLib/sceneIndex/registration.h>
+#include <mayaHydraLib/pick/mhPickHit.h>
 #include <mayaHydraLib/pick/mhPickHandler.h>
 #include <mayaHydraLib/pick/mhPickHandlerRegistry.h>
 #include <mayaHydraLib/hydraUtils.h>
@@ -258,7 +259,7 @@ std::vector<MtohRenderOverride*> _allInstances;
 //! \brief  Get the index of the hit nearest to a given cursor point.
 int GetNearestHitIndex(
     const MHWRender::MFrameContext& frameContext,
-    const HdxPickHitVector&         hits,
+    const PickHitVector&            hits,
     int                             cursor_x,
     int                             cursor_y)
 {
@@ -268,9 +269,9 @@ int GetNearestHitIndex(
     float  depth_min = std::numeric_limits<float>::max();
 
     for (unsigned int i = 0; i < hits.size(); i++) {
-        const HdxPickHit& hit = hits[i];
+        const PickHit& hit = hits[i];
         const MPoint      worldSpaceHitPoint(
-            hit.worldSpaceHitPoint[0], hit.worldSpaceHitPoint[1], hit.worldSpaceHitPoint[2]);
+            hit.hdxPickHit.worldSpaceHitPoint[0], hit.hdxPickHit.worldSpaceHitPoint[1], hit.hdxPickHit.worldSpaceHitPoint[2]);
 
         // Calculate the (x, y) coordinate relative to the lower left corner of the viewport.
         double hit_x, hit_y;
@@ -282,9 +283,9 @@ int GetNearestHitIndex(
         double dist2 = dist_x * dist_x + dist_y * dist_y;
 
         // Find the hit nearest to the cursor.
-        if ((dist2 < dist2_min) || (dist2 == dist2_min && hit.normalizedDepth < depth_min)) {
+        if ((dist2 < dist2_min) || (dist2 == dist2_min && hit.hdxPickHit.normalizedDepth < depth_min)) {
             dist2_min = dist2;
-            depth_min = hit.normalizedDepth;
+            depth_min = hit.hdxPickHit.normalizedDepth;
             nearestHitIndex = (int)i;
         }
     }
@@ -2244,7 +2245,7 @@ bool MtohRenderOverride::nextRenderOperation()
 }
 
 void MtohRenderOverride::_PopulateSelectionList(
-    const HdxPickHitVector&          hits,
+    const PickHitVector&             hits,
     const MHWRender::MSelectionInfo& selectInfo,
     MSelectionList&                  selectionList,
     MPointArray&                     worldSpaceHitPts,
@@ -2257,11 +2258,11 @@ void MtohRenderOverride::_PopulateSelectionList(
     PickHandler::Output pickOutput(selectionList, worldSpaceHitPts, _ufeSn);
 
     MStatus status;
-    for (const HdxPickHit& hit : hits) {
+    for (const PickHit& hit : hits) {
         PickHandler::Input pickInput(hit, selectInfo, hits.size() == 1u);
 
         auto pickHandler = _PickHandler(hit);
-        if (TF_VERIFY(pickHandler, "No pick handler found for pick hit %s!", hit.objectId.GetText())) {
+        if (TF_VERIFY(pickHandler, "No pick handler found for pick hit %s!", hit.hdxPickHit.objectId.GetText())) {
 
             if (pickHandler->inSingleNodeComponentsPick(hit)) {
                 isOneMayaNodeInComponentsPickingMode = true;
@@ -2274,13 +2275,13 @@ void MtohRenderOverride::_PopulateSelectionList(
 }
 
 PickHandlerConstPtr
-MtohRenderOverride::_PickHandler(const HdxPickHit& pickHit) const
+MtohRenderOverride::_PickHandler(const PickHit& pickHit) const
 {
-    return PickHandlerRegistry::Instance().GetHandler(pickHit.objectId);
+    return PickHandlerRegistry::Instance().GetHandler(pickHit.hdxPickHit.objectId);
 }
 
 void MtohRenderOverride::_PickByRegion(
-    HdxPickHitVector& outHits,
+    PickHitVector& outHits,
     const MMatrix& viewMatrix,
     const MMatrix& projMatrix,
     bool singlePick,
@@ -2322,7 +2323,6 @@ void MtohRenderOverride::_PickByRegion(
     pickParams.projectionMatrix.Set(adjustedProjMatrix.matrix);
     pickParams.collection = _renderCollection;
     pickParams.collection.SetExcludePaths({_highlightHierarchyPrefix});
-    pickParams.outHits = &outHits;
 
     if (geomSubsetsPickMode == GeomSubsetsPickModeTokens->Faces) {
         pickParams.pickTarget = HdxPickTokens->pickFaces;
@@ -2358,14 +2358,27 @@ void MtohRenderOverride::_PickByRegion(
             // Reserve memory for efficiency
             outHits.reserve(outHits.size() + tempHits.size());
             // Insert all hits from tempHits into outHits
-            outHits.insert(outHits.end(), tempHits.begin(), tempHits.end());
+            for (const auto& hit : tempHits) {
+                outHits.emplace_back(i, hit);
+            }
         }
     }
 #else
+    HdxPickHitVector tempHits;
+    pickParams.outHits = &tempHits;
     HdTaskSharedPtrVector pickingTasks = _taskController->GetPickingTasks();
     VtValue               pickParamsValue(pickParams);
     _engine.SetTaskContextData(HdxPickTokens->pickParams, pickParamsValue);
     _engine.Execute(_taskController->GetRenderIndex(), &pickingTasks);
+    // Build the PickHitVector
+    if (!tempHits.empty()) {
+        // Reserve memory for efficiency
+        outHits.reserve(outHits.size() + tempHits.size());
+        // Insert all hits from tempHits into outHits
+        for (const auto& hit : tempHits) {
+            outHits.emplace_back((0, hit);
+        }
+    }
 #endif
 }
 
@@ -2413,7 +2426,7 @@ bool MtohRenderOverride::select(
     if (status != MStatus::kSuccess)
         return false;
 
-    HdxPickHitVector outHits;
+    PickHitVector outHits;
     const bool singlePick = selectInfo.singleSelection();
     const TfToken geomSubsetsPickMode = GetGeomSubsetsPickMode();
     const bool pointSnappingActive = selectInfo.pointSnapping();
@@ -2460,7 +2473,7 @@ bool MtohRenderOverride::select(
         }
 
         if (nearestHitIndex >= 0) {
-            const HdxPickHit hit = outHits[nearestHitIndex];
+            const auto hit = outHits[nearestHitIndex];
             outHits.clear();
             outHits.push_back(hit);
         } else {

--- a/lib/mayaHydra/mayaPlugin/renderOverride.h
+++ b/lib/mayaHydra/mayaPlugin/renderOverride.h
@@ -41,6 +41,7 @@
 #include <mayaHydraLib/sceneIndex/mhDirtyLeadObjectSceneIndex.h>
 #include <mayaHydraLib/pick/mhPickHandlerFwd.h>
 #include <mayaHydraLib/pick/mhPickContext.h>
+#include <mayaHydraLib/pick/mhPickHitFwd.h>
 
 #include <flowViewport/fvpFramePassData.h>
 #include <flowViewport/sceneIndex/fvpDataProducerMergingSceneIndexProxy.h>
@@ -96,7 +97,6 @@ using MtohRendererDescription = MayaHydra::MtohRendererDescription;
 using HgiUniquePtr = std::unique_ptr<class Hgi>;
 class MayaHydraSceneIndexRegistry;
 class MayaHydraSceneDelegate;
-using HdxPickHitVector = std::vector<struct HdxPickHit>;
 
 /*! \brief MtohRenderOverride is a rendering override class for the viewport to use Hydra instead of
  * VP2.0.
@@ -220,7 +220,7 @@ private:
     VtValue _GetUsedGPUMemory() const;
 
     void _PickByRegion(
-        HdxPickHitVector& outHits,
+        MayaHydra::PickHitVector& outHits,
         const MMatrix&    viewMatrix,
         const MMatrix&    projMatrix,
         bool              singlePick,
@@ -247,7 +247,7 @@ private:
     }
 
     void _PopulateSelectionList(
-        const HdxPickHitVector&          hits,
+        const MayaHydra::PickHitVector&    hits,
         const MHWRender::MSelectionInfo& selectInfo,
         MSelectionList&                  selectionList,
         MPointArray&                     worldSpaceHitPts,
@@ -259,7 +259,7 @@ private:
 
     // Determine the pick handler which should handle a pick hit, to transform
     // the pick hit into a selection.
-    MayaHydra::PickHandlerConstPtr _PickHandler(const HdxPickHit& hit) const;
+    MayaHydra::PickHandlerConstPtr _PickHandler(const MayaHydra::PickHit& hit) const;
 
     // Callbacks
     static void _ClearHydraCallback(void* data);

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testUsdNativeInstancePicking.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testUsdNativeInstancePicking.py
@@ -65,5 +65,35 @@ class TestUsdNativeInstancePicking(mtohUtils.MayaHydraBaseTestCase):
                     self.PICK_PATH + marker,
                     f="TestUsdPicking.pickInstanceWithMarker")
 
+
+class TestUsdNativeInstancePicking_Guide(mtohUtils.MayaHydraBaseTestCase):
+    # MayaHydraBaseTestCase.setUpClass requirement.
+    _file = __file__
+
+    PICK_PATH = "|instancedCubeHierarchies_Guide|instancedCubeHierarchies_GuideShape,/cubeHierarchies"
+
+    def loadUsdScene(self):
+        usdScenePath = testUtils.getTestScene('testUsdNativeInstances', 'instancedCubeHierarchies_Guide.usda')
+        usdUtils.createStageFromFile(usdScenePath)
+
+    def setUp(self):
+        super(TestUsdNativeInstancePicking_Guide, self).setUp()
+        self.loadUsdScene()
+        cmds.select(clear=True)
+        cmds.setAttr('persp.translate', 0, 0, 15, type='float3')
+        cmds.setAttr('persp.rotate', 0, 0, 0, type='float3')
+        cmds.refresh()
+
+    def test_NativeInstances(self):
+        with PluginLoaded('mayaHydraCppTests'):
+            cmds.optionVar(
+                    sv=('mayaUsd_PointInstancesPickMode', 'Instances'))
+            
+            instances = ["/cubes_1", "/cubes_2"]
+            for instance in instances:
+                cmds.mayaHydraCppTest(
+                    self.PICK_PATH + instance,
+                    f="TestUsdPicking.pickPrim")
+
 if __name__ == '__main__':
     fixturesUtils.runTests(globals())

--- a/test/testSamples/testUsdNativeInstances/instancedCubeHierarchies_Guide.usda
+++ b/test/testSamples/testUsdNativeInstances/instancedCubeHierarchies_Guide.usda
@@ -1,0 +1,36 @@
+#usda 1.0
+ 
+def "cubeHierarchies"
+{
+    def Xform "cubes_1" (
+        instanceable = true
+        references = @./cubesHierarchy.usda@
+    )
+    {
+        uniform token purpose = "guide"
+        double3 xformOp:translate = (-1.0, 0, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+    }
+ 
+    def Xform "cubes_2" (
+        instanceable = true
+        references = @./cubesHierarchy.usda@
+    )
+    {
+        uniform token purpose = "guide"
+        double3 xformOp:translate = (1.0, 0, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+    }
+
+    def Xform "marker_cubes_1_baseCube"
+    {
+        double3 xformOp:translate = (-1, 0.5, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+    }
+
+    def Xform "marker_cubes_2_topCube"
+    {
+        double3 xformOp:translate = (1, 1.25, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+    }
+}


### PR DESCRIPTION
With multi FramePass enabled, when resolving HdxPickHit data returned from Hydra renderers, we need to know which FramePass (RenderIndex) the hit prim belongs to. To archieve that, we add a _passIndex_ data on top of HdxPickHit data structure.