### PR TITLE
Hydra-2008 - allow one aov to visualize

### DIFF
--- a/lib/mayaHydra/mayaPlugin/renderOverride.cpp
+++ b/lib/mayaHydra/mayaPlugin/renderOverride.cpp
@@ -157,6 +157,21 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 const SdfPath MAYA_NATIVE_ROOT = SdfPath("/MayaHydraViewportRenderer");
 
+TfToken _GetPurposeRenderTagFromAttrName(const TfToken& attrName)
+{
+    static const std::map<TfToken, TfToken> attrToTag {
+        { TfToken("mayaHydraRenderPurpose"),    HdRenderTagTokens->render },
+        { TfToken("mayaHydraProxyPurpose"),     HdRenderTagTokens->proxy },
+        { TfToken("mayaHydraGuidePurpose"),     HdRenderTagTokens->guide }
+    };
+    auto found = attrToTag.find(attrName);
+    if (found != attrToTag.end()) {
+        return found->second;
+    }
+    TF_CODING_ERROR("Unknown purpose attribute name '%s'", attrName.GetText());
+    return {};
+}
+
 inline bool isInComponentsPickingMode(const MHWRender::MSelectionInfo& selectInfo)
 {
     return selectInfo.selectable(MSelectionMask::kSelectMeshVerts)
@@ -460,9 +475,6 @@ void MtohRenderOverride::UpdateRenderGlobals(
     // next call to MtohRenderOverride::Render, so just force an invalidation
     // XXX: This will need to change if mayaHydra settings should ever make it to the delegate
     // itself.
-
-    // If the attribute name does not start with mayaHydra, or mayaHydra is
-    // not found.
     if (attrName.GetString().find("mayaHydra") != 0) {
         std::lock_guard<std::mutex> lock(_allInstancesMutex);
         for (auto* instance : _allInstances) {
@@ -492,7 +504,7 @@ void MtohRenderOverride::UpdateRenderGlobals(
             //One of the render purpose attributes just changed
             //Get purpose render tag from attribute name
             const PXR_NS::TfToken purposeRenderTag
-                = RenderGlobalsUtils::GetPurposeRenderTagFromAttrName(attrName);
+                = _GetPurposeRenderTagFromAttrName(attrName);
 
             if (!purposeRenderTag.IsEmpty()) {
                 std::lock_guard<std::mutex> lock(_allInstancesMutex);
@@ -989,7 +1001,7 @@ MStatus MtohRenderOverride::Render(
         const MIntArray& framePassesVisible    = 
             MayaHydraSetVisibleFramePasses::getVisibleFramePasses();
         int                 numVisibleFramePasses = framePassesVisible.length();
-        const MStringArray& visibleAOVNames = MayaHydraSetVisibleFramePasses::getAovNames();
+        const MString visibleAOVName = MayaHydraSetVisibleFramePasses::getAovName();
         const int           numFramePasses     = _GetNumFramePasses();
         if (numVisibleFramePasses > numFramePasses) {
             numVisibleFramePasses
@@ -1015,20 +1027,20 @@ MStatus MtohRenderOverride::Render(
 
             // Enable presentation for the last visible pass only
             currentPass->params().enablePresentation = isLastVisiblePass;
-            
-            // Set the AOV to visualize for the current pass if it exists
-            const TfToken aovName = TfToken(visibleAOVNames[visibleIdx].asChar());
-            // Can't rely on GetRenderBuffer(aovName) here as the AOV may not have been created yet
-            const auto renderDelegate = _GetRenderDelegate(actualPassIndex);
-            const bool aovNameExists
-                = renderDelegate ? 
-                renderDelegate->GetDefaultAovDescriptor(aovName).format != HdFormatInvalid
-                : false;
-            currentPass->params().visualizeAOV
-                = (aovNameExists) 
-                ? aovName 
-                : HdAovTokens->color;
-            
+            // Set the AOV to visualize
+            // Per HVT, the AOV to visualize must be set on the last visible pass, and HdAovTokens->color must be set on other passes
+            TfToken visualizeAOV = HdAovTokens->color;
+            if (isLastVisiblePass) {
+                const TfToken aovName = TfToken(visibleAOVName.asChar());
+                // Can't rely on GetRenderBuffer(aovName) here as the AOV may not have been created yet
+                const auto renderDelegate = _GetRenderDelegate(actualPassIndex);
+                const bool aovNameExists = renderDelegate
+                    ? renderDelegate->GetDefaultAovDescriptor(aovName).format != HdFormatInvalid
+                    : false;
+                visualizeAOV = (aovNameExists) ? aovName : HdAovTokens->color;
+            }
+            currentPass->params().visualizeAOV = visualizeAOV;
+
             if (visibleIdx > 0) {
                 currentPass->params().renderParams.depthBiasEnable = true;
                 currentPass->params().renderParams.depthBiasUseDefault = false;
@@ -1055,17 +1067,10 @@ MStatus MtohRenderOverride::Render(
                 const int previousPassIndex = (visibleIdx > 0) ?framePassesVisible[visibleIdx - 1] : 0;
                 hvt::FramePassPtr& previousPass = _GetFramePass(previousPassIndex);
                 if (previousPass) {
-                    std::vector<TfToken> inputAOVs;
-                    const auto& preVisualizedAOV = previousPass->params().visualizeAOV;
-                    // If a non-color AOV was visualized previously, HVT expects to share only that one
-                    if (preVisualizedAOV == HdAovTokens->color) {
-                        inputAOVs = { HdAovTokens->color, HdAovTokens->depth };
-                    }
-                    else {
-                        inputAOVs = { preVisualizedAOV };
-                    }
-                    const hvt::RenderBufferBindings aovBindings = previousPass->GetRenderBufferBindingsForNextPass(inputAOVs);
-                    HdTaskSharedPtrVector passTasks = currentPass->GetRenderTasks(aovBindings);
+                    const hvt::RenderBufferBindings inputAOVs = previousPass->GetRenderBufferBindingsForNextPass(
+                            { PXR_NS::HdAovTokens->color, PXR_NS::HdAovTokens->depth }
+                    );
+                    HdTaskSharedPtrVector passTasks = currentPass->GetRenderTasks(inputAOVs);
 
                     /*Debug code left here if needed later
                     hvt::FramePass& framePassToDebug = *currentPass;
@@ -1314,8 +1319,7 @@ MStatus MtohRenderOverride::Render(
     bool isTextured = currentDisplayMode & MHWRender::MFrameContext::kTextured;
     if (_pruneTexturesSceneIndex &&
         _currentlyTextured != isTextured) {
-        const bool pruneTextures = !isTextured;
-        _pruneTexturesSceneIndex->MarkTexturesDirty(pruneTextures);
+        _pruneTexturesSceneIndex->MarkTexturesDirty(isTextured);
         _currentlyTextured = isTextured;
     }
 
@@ -1792,21 +1796,12 @@ void MtohRenderOverride::_InitHydraResources(
     // registry accordingly.
     PickHandlerRegistry::Instance().SetPickContext(this);
 
-    // Create internal scene indices chain
+    //Create internal scene indices chain
     _inputSceneIndexOfFilteringSceneIndicesChain = _dataProducerMergingSceneIndexProxy->GetMergingSceneIndex();
 
     //Put BlockPrimRemovalPropagationSceneIndex first as it can block/unblock the prim removal propagation on the whole scene indices chain
     _blockPrimRemovalPropagationSceneIndex = Fvp::BlockPrimRemovalPropagationSceneIndex::New(_inputSceneIndexOfFilteringSceneIndicesChain);
-
-    // As of 13-Nov-2025, order of operations in _InitHydraResources() is such
-    // that render globals are initialized after this method is called.  Thus
-    // the included purposes attributes do not yet exist on the
-    // defaultRenderGlobals node.  Simply pass in an empty set of included
-    // purposes here.
-    _purposeFilteringSceneIndex = Fvp::PurposeFilteringSceneIndex::New(
-        _blockPrimRemovalPropagationSceneIndex, {});
-        // RenderGlobalsUtils::GetIncludedPurposes());
-    _pruningSceneIndex = Fvp::PruningSceneIndex::New(_purposeFilteringSceneIndex);
+    _pruningSceneIndex = Fvp::PruningSceneIndex::New(_blockPrimRemovalPropagationSceneIndex);
     _pruningSceneIndex->AddExcludedSceneRoot(MAYA_NATIVE_ROOT); // Maya filtering is handled by VP2/OGS.
     _selection = std::make_shared<Fvp::Selection>();
     _selectionSceneIndex = Fvp::SelectionSceneIndex::New(_pruningSceneIndex, _selection);
@@ -2008,9 +2003,8 @@ void MtohRenderOverride::_CreateSceneIndicesChainAfterMergingSceneIndex(const MH
     _displayStyleSceneIndex->addExcludedSceneRoot(MAYA_NATIVE_ROOT); // Maya native prims don't use global refinement
 
     // Add texture disabling Scene Index
-    const bool pruneTextures = !(drawContext.getDisplayStyle() & MHWRender::MFrameContext::kTextured);
     _lastFilteringSceneIndexBeforeCustomFiltering = _pruneTexturesSceneIndex =
-        Fvp::PruneTexturesSceneIndex::New(_lastFilteringSceneIndexBeforeCustomFiltering, pruneTextures);
+    Fvp::PruneTexturesSceneIndex::New(_lastFilteringSceneIndexBeforeCustomFiltering);
 
     // Add default material scene index
     _lastFilteringSceneIndexBeforeCustomFiltering = _defaultMaterialSceneIndex = Fvp::DefaultMaterialSceneIndex::New(_lastFilteringSceneIndexBeforeCustomFiltering,
@@ -2069,7 +2063,7 @@ void MtohRenderOverride::_CreateSceneIndicesChainAfterMergingSceneIndex(const MH
 
     TF_AXIOM(_mayaHydraSceneIndex);
     _lastFilteringSceneIndexBeforeCustomFiltering = _lightsManagementSceneIndex = Fvp::LightsManagementSceneIndex::New(
-        _lastFilteringSceneIndexBeforeCustomFiltering, _mayaHydraSceneIndex->MayaDefaultLightPath());
+        _lastFilteringSceneIndexBeforeCustomFiltering, _mayaHydraSceneIndex->GetMayaDefaultLightPath());
     _lightsManagementSceneIndex->SetLightingMode(convertFromMayaLightingModeToFlowViewportLightMode(_lightingMode));
     _mayaHydraSceneIndex->SetLightsManagementSceneIndex(_lightsManagementSceneIndex);
 
@@ -2863,11 +2857,11 @@ void MtohRenderOverride::_CreateFramePassesData()
     {
         auto filteringData = std::make_shared<Fvp::FramePassData>();
         filteringData->_rendererName = _rendererDesc.rendererName;//Render delegate chosen by the user
+
         filteringData->_includePaths = {};
         filteringData->_excludePaths = (shouldUseSingleFramePass) 
                                         ? SdfPathVector{}
                                         : SdfPathVector{_highlightHierarchyPrefix}; // Ignore selection highlight prims if we have multiple passes
-        filteringData->_removeLights = false; // Keep all lights in this pass
         filteringData->_supportPrimsWithNoPurposeRenderTag
             = true; // Main graphics pass supports prims with no purpose render tag
         
@@ -2901,9 +2895,8 @@ void MtohRenderOverride::_CreateFramePassesData()
     if (!shouldUseSingleFramePass) {
         auto filteringData = std::make_shared<Fvp::FramePassData>();
         filteringData->_rendererName = MtohTokens->HdStormRendererPlugin;//Storm by default
-        filteringData->_includePaths = { _highlightHierarchyPrefix, MayaHydraSceneIndex::MayaDefaultLightPath() }; // include selection highlight prims.
+        filteringData->_includePaths = { _highlightHierarchyPrefix }; // include selection highlight prims.
         filteringData->_excludePaths = { };
-        filteringData->_removeLights = true; // Remove lights from this pass except for the default light, kept through the include paths
         filteringData->_supportPrimsWithNoPurposeRenderTag
             = false; // Secondary graphics pass does not support prims with no purpose render tag
         _framePassesData.emplace_back(filteringData);
@@ -2961,8 +2954,7 @@ void MtohRenderOverride::_SetRenderPurposeTags(const MayaHydraParams& delegatePa
         }
     }
 #endif
-
-    _purposeFilteringSceneIndex->UpdatePrimsFromIncludedPurposes(RenderGlobalsUtils::GetIncludedPurposes());
 }
+
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaHydra/mayaPlugin/renderOverride.cpp
+++ b/lib/mayaHydra/mayaPlugin/renderOverride.cpp
@@ -157,21 +157,6 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 const SdfPath MAYA_NATIVE_ROOT = SdfPath("/MayaHydraViewportRenderer");
 
-TfToken _GetPurposeRenderTagFromAttrName(const TfToken& attrName)
-{
-    static const std::map<TfToken, TfToken> attrToTag {
-        { TfToken("mayaHydraRenderPurpose"),    HdRenderTagTokens->render },
-        { TfToken("mayaHydraProxyPurpose"),     HdRenderTagTokens->proxy },
-        { TfToken("mayaHydraGuidePurpose"),     HdRenderTagTokens->guide }
-    };
-    auto found = attrToTag.find(attrName);
-    if (found != attrToTag.end()) {
-        return found->second;
-    }
-    TF_CODING_ERROR("Unknown purpose attribute name '%s'", attrName.GetText());
-    return {};
-}
-
 inline bool isInComponentsPickingMode(const MHWRender::MSelectionInfo& selectInfo)
 {
     return selectInfo.selectable(MSelectionMask::kSelectMeshVerts)
@@ -475,6 +460,9 @@ void MtohRenderOverride::UpdateRenderGlobals(
     // next call to MtohRenderOverride::Render, so just force an invalidation
     // XXX: This will need to change if mayaHydra settings should ever make it to the delegate
     // itself.
+
+    // If the attribute name does not start with mayaHydra, or mayaHydra is
+    // not found.
     if (attrName.GetString().find("mayaHydra") != 0) {
         std::lock_guard<std::mutex> lock(_allInstancesMutex);
         for (auto* instance : _allInstances) {
@@ -504,7 +492,7 @@ void MtohRenderOverride::UpdateRenderGlobals(
             //One of the render purpose attributes just changed
             //Get purpose render tag from attribute name
             const PXR_NS::TfToken purposeRenderTag
-                = _GetPurposeRenderTagFromAttrName(attrName);
+                = RenderGlobalsUtils::GetPurposeRenderTagFromAttrName(attrName);
 
             if (!purposeRenderTag.IsEmpty()) {
                 std::lock_guard<std::mutex> lock(_allInstancesMutex);
@@ -1319,7 +1307,8 @@ MStatus MtohRenderOverride::Render(
     bool isTextured = currentDisplayMode & MHWRender::MFrameContext::kTextured;
     if (_pruneTexturesSceneIndex &&
         _currentlyTextured != isTextured) {
-        _pruneTexturesSceneIndex->MarkTexturesDirty(isTextured);
+        const bool pruneTextures = !isTextured;
+        _pruneTexturesSceneIndex->MarkTexturesDirty(pruneTextures);
         _currentlyTextured = isTextured;
     }
 
@@ -1796,12 +1785,21 @@ void MtohRenderOverride::_InitHydraResources(
     // registry accordingly.
     PickHandlerRegistry::Instance().SetPickContext(this);
 
-    //Create internal scene indices chain
+    // Create internal scene indices chain
     _inputSceneIndexOfFilteringSceneIndicesChain = _dataProducerMergingSceneIndexProxy->GetMergingSceneIndex();
 
     //Put BlockPrimRemovalPropagationSceneIndex first as it can block/unblock the prim removal propagation on the whole scene indices chain
     _blockPrimRemovalPropagationSceneIndex = Fvp::BlockPrimRemovalPropagationSceneIndex::New(_inputSceneIndexOfFilteringSceneIndicesChain);
-    _pruningSceneIndex = Fvp::PruningSceneIndex::New(_blockPrimRemovalPropagationSceneIndex);
+
+    // As of 13-Nov-2025, order of operations in _InitHydraResources() is such
+    // that render globals are initialized after this method is called.  Thus
+    // the included purposes attributes do not yet exist on the
+    // defaultRenderGlobals node.  Simply pass in an empty set of included
+    // purposes here.
+    _purposeFilteringSceneIndex = Fvp::PurposeFilteringSceneIndex::New(
+        _blockPrimRemovalPropagationSceneIndex, {});
+        // RenderGlobalsUtils::GetIncludedPurposes());
+    _pruningSceneIndex = Fvp::PruningSceneIndex::New(_purposeFilteringSceneIndex);
     _pruningSceneIndex->AddExcludedSceneRoot(MAYA_NATIVE_ROOT); // Maya filtering is handled by VP2/OGS.
     _selection = std::make_shared<Fvp::Selection>();
     _selectionSceneIndex = Fvp::SelectionSceneIndex::New(_pruningSceneIndex, _selection);
@@ -2003,8 +2001,9 @@ void MtohRenderOverride::_CreateSceneIndicesChainAfterMergingSceneIndex(const MH
     _displayStyleSceneIndex->addExcludedSceneRoot(MAYA_NATIVE_ROOT); // Maya native prims don't use global refinement
 
     // Add texture disabling Scene Index
+    const bool pruneTextures = !(drawContext.getDisplayStyle() & MHWRender::MFrameContext::kTextured);
     _lastFilteringSceneIndexBeforeCustomFiltering = _pruneTexturesSceneIndex =
-    Fvp::PruneTexturesSceneIndex::New(_lastFilteringSceneIndexBeforeCustomFiltering);
+        Fvp::PruneTexturesSceneIndex::New(_lastFilteringSceneIndexBeforeCustomFiltering, pruneTextures);
 
     // Add default material scene index
     _lastFilteringSceneIndexBeforeCustomFiltering = _defaultMaterialSceneIndex = Fvp::DefaultMaterialSceneIndex::New(_lastFilteringSceneIndexBeforeCustomFiltering,
@@ -2063,7 +2062,7 @@ void MtohRenderOverride::_CreateSceneIndicesChainAfterMergingSceneIndex(const MH
 
     TF_AXIOM(_mayaHydraSceneIndex);
     _lastFilteringSceneIndexBeforeCustomFiltering = _lightsManagementSceneIndex = Fvp::LightsManagementSceneIndex::New(
-        _lastFilteringSceneIndexBeforeCustomFiltering, _mayaHydraSceneIndex->GetMayaDefaultLightPath());
+        _lastFilteringSceneIndexBeforeCustomFiltering, _mayaHydraSceneIndex->MayaDefaultLightPath());
     _lightsManagementSceneIndex->SetLightingMode(convertFromMayaLightingModeToFlowViewportLightMode(_lightingMode));
     _mayaHydraSceneIndex->SetLightsManagementSceneIndex(_lightsManagementSceneIndex);
 
@@ -2857,11 +2856,11 @@ void MtohRenderOverride::_CreateFramePassesData()
     {
         auto filteringData = std::make_shared<Fvp::FramePassData>();
         filteringData->_rendererName = _rendererDesc.rendererName;//Render delegate chosen by the user
-
         filteringData->_includePaths = {};
         filteringData->_excludePaths = (shouldUseSingleFramePass) 
                                         ? SdfPathVector{}
                                         : SdfPathVector{_highlightHierarchyPrefix}; // Ignore selection highlight prims if we have multiple passes
+        filteringData->_removeLights = false; // Keep all lights in this pass
         filteringData->_supportPrimsWithNoPurposeRenderTag
             = true; // Main graphics pass supports prims with no purpose render tag
         
@@ -2895,8 +2894,9 @@ void MtohRenderOverride::_CreateFramePassesData()
     if (!shouldUseSingleFramePass) {
         auto filteringData = std::make_shared<Fvp::FramePassData>();
         filteringData->_rendererName = MtohTokens->HdStormRendererPlugin;//Storm by default
-        filteringData->_includePaths = { _highlightHierarchyPrefix }; // include selection highlight prims.
+        filteringData->_includePaths = { _highlightHierarchyPrefix, MayaHydraSceneIndex::MayaDefaultLightPath() }; // include selection highlight prims.
         filteringData->_excludePaths = { };
+        filteringData->_removeLights = true; // Remove lights from this pass except for the default light, kept through the include paths
         filteringData->_supportPrimsWithNoPurposeRenderTag
             = false; // Secondary graphics pass does not support prims with no purpose render tag
         _framePassesData.emplace_back(filteringData);
@@ -2954,7 +2954,8 @@ void MtohRenderOverride::_SetRenderPurposeTags(const MayaHydraParams& delegatePa
         }
     }
 #endif
-}
 
+    _purposeFilteringSceneIndex->UpdatePrimsFromIncludedPurposes(RenderGlobalsUtils::GetIncludedPurposes());
+}
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaHydra/mayaPlugin/setVisibleFramePassesCommand.cpp
+++ b/lib/mayaHydra/mayaPlugin/setVisibleFramePassesCommand.cpp
@@ -34,16 +34,16 @@
  * MayaHydraSetVisibleFramePasses Command
  * 
  * This command controls which render passes are visible in Maya's Hydra viewport and 
- * optionally specifies the AOV (Arbitrary Output Variable) name for each pass.
+ * optionally specifies the AOV (Arbitrary Output Variable) name.
  * 
  * Functionality:
  * - Set which render passes are visible by specifying pass indices (0, 1, 2, etc.)
- * - Optionally specify AOV names for each pass (defaults to "color" if not provided)
- * - Query currently visible render passes and their associated AOV names
+ * - Optionally specify the AOV name (defaults to "color" if not provided)
+ * - Query currently visible render passes and AOV name
  * - Supports multiple passes in a single command
  * 
- * The command manages static arrays that store the visible pass indices and their
- * corresponding AOV names, which can be accessed by other parts of the Maya-Hydra system.
+ * The command manages static arrays that store the visible pass indices and 
+ * the AOV name, which can be accessed by other parts of the Maya-Hydra system.
  */
 
 /* Examples
@@ -55,15 +55,11 @@
     MEL : mayaHydraSetVisibleFramePasses -e -v 1 -aov "depth"
     Python : maya.cmds.mayaHydraSetVisibleFramePasses(edit=True, visible=1, aovName="depth")
 
-    //Set both passes visible with default AOVs
+    //Set both passes visible with default AOV
     MEL : mayaHydraSetVisibleFramePasses -e -v 0 -v 1
     Python : //Python : cmds.mayaHydraSetVisibleFramePasses(edit=True, visible=[0, 1])
 
-    //Set both passes visible with different AOVs though the depth aov from 2nd pass with override the color aov from first pass 
-    mayaHydraSetVisibleFramePasses -e -v 0 -aov "color" -v 1 -aov "depth"
-    Python : cmds.mayaHydraSetVisibleFramePasses(edit=True, visible=[0, 1], aovName=["color", "depth"])
-
-    // Query the currently visible render passes and their AOV names
+    // Query the currently visible render passes and the AOV name
     MEL : mayaHydraSetVisibleFramePasses -q -v
     Python : result = cmds.mayaHydraSetVisibleFramePasses(query=True, visible=True)
 
@@ -71,7 +67,7 @@
     MEL : mayaHydraSetVisibleFramePasses -la 0
     Python : result = cmds.mayaHydraSetVisibleFramePasses(listAovs=0)
 
-    // Reset the displayed render passes and AOVs to defaults
+    // Reset the displayed render passes and AOV to defaults
     MEL : mayaHydraSetVisibleFramePasses -r
     Python : result = cmds.mayaHydraSetVisibleFramePasses(reset=True)
 */
@@ -82,15 +78,13 @@ namespace MAYAHYDRA_NS_DEF {
 
 const MString MayaHydraSetVisibleFramePasses::commandName("mayaHydraSetVisibleFramePasses");
 constexpr int _defaultVisibleFramePasses[] = { 0, 1 }; // Default visible passes (main and second)
-const char* _defaultAovNames[] = { "color", "color" }; // Default AOV names
+const MString _defaultAovName("color");         // Default AOV name
 
 MIntArray MayaHydraSetVisibleFramePasses::_visibleFramePasses(
     _defaultVisibleFramePasses,
     2); // Default visible passes (main and secondary)
 
-MStringArray MayaHydraSetVisibleFramePasses::_aovNames(
-    _defaultAovNames,
-    2); // Default AOV names
+MString MayaHydraSetVisibleFramePasses::_aovName(_defaultAovName); // Default AOV name
 
 namespace {
 
@@ -118,7 +112,6 @@ MSyntax MayaHydraSetVisibleFramePasses::createSyntax()
     
     // Add flag for AOV names - requires AOV name (string)
     syntax.addFlag(_aovNameId, _aovNameIdLong, MSyntax::kString);
-    syntax.makeFlagMultiUse(_aovNameId);
 
     // Add flag to list available AOVs - requires pass index (int)
     syntax.addFlag(_listAovsId, _listAovsIdLong, MSyntax::kUnsigned);
@@ -141,7 +134,7 @@ MStatus MayaHydraSetVisibleFramePasses::doIt(const MArgList& args)
 
     if (argData.isFlagSet(_resetId)) {
         _visibleFramePasses = MIntArray(_defaultVisibleFramePasses, sizeof(_defaultVisibleFramePasses) / sizeof(_defaultVisibleFramePasses[0]));
-        _aovNames = MStringArray(_defaultAovNames, sizeof(_defaultAovNames) / sizeof(_defaultAovNames[0]));
+        _aovName = _defaultAovName;
     }
 
     if (argData.isFlagSet(_listAovsId)) {
@@ -154,53 +147,43 @@ MStatus MayaHydraSetVisibleFramePasses::doIt(const MArgList& args)
 
     if (argData.isFlagSet(_visiblePassesId)) {
         if (isQuery) {
-            // Return the currently visible passes and their AOV names
+            // Return the currently visible passes and the AOV name
             for (unsigned int i = 0; i < _visibleFramePasses.length(); i++) {
                 appendToResult(_visibleFramePasses[i]);
-                appendToResult(_aovNames[i]);
             }
+            appendToResult(_aovName);
         } else if (isEdit) {
             _visibleFramePasses.clear();
-            _aovNames.clear();
 
-            // Create a map to store pass-AOV pairs for sorting and ensure uniqueness
+            // Create a set to store passes for sorting and ensure uniqueness
             // This ensures that pass indices are unique and ordered by increasing pass index
-            // If the same pass index is specified multiple times, the last AOV name will be used
-            // Example: "-v 1 -aov color -v 0 -aov depth" will result in 
-            //          passes [0,1] with AOVs ["depth","color"]
-            std::map<int, MString> passAovMap;
+            // Example: "-v 1 -aov color -v 0" will result in 
+            //          passes [0,1] with AOV "color"
+            std::set<int> passes;
 
-            // Get the pass indices and their corresponding AOV names
+            // Get the pass indices
             const unsigned int numPasses = argData.numberOfFlagUses(_visiblePassesId);
-            const unsigned int numAovs = argData.isFlagSet(_aovNameId) ? argData.numberOfFlagUses(_aovNameId) : 0;
 
             for (unsigned int i = 0; i < numPasses; ++i) {
                 MArgList flagArgs;
                 argData.getFlagArgumentList(_visiblePassesId, i, flagArgs);
                 if (flagArgs.length() >= 1) {
                     const int passIndex = flagArgs.asInt(0);
-                    
-                    // Determine the AOV name for this pass
-                    MString aovName("color"); // Default AOV
-                    if (i < numAovs) {
-                        MArgList aovFlagArgs;
-                        argData.getFlagArgumentList(_aovNameId, i, aovFlagArgs);
-                        if (aovFlagArgs.length() >= 1) {
-                            aovName = aovFlagArgs.asString(0);
-                        }
-                    }
-                    
-                    // Insert into map (automatically handles uniqueness and sorting)
-                    passAovMap[passIndex] = aovName;
+                    // Insert into set (automatically handles uniqueness and sorting)
+                    passes.insert(passIndex);
                 }
             }
 
-            // Extract sorted and unique pass indices and AOV names into member arrays
-            // The map automatically keeps entries sorted by key (pass index)
-            for (const auto& pair : passAovMap) {
-                _visibleFramePasses.append(pair.first);
-                _aovNames.append(pair.second);
+            // Get the AOV name
+            MString aovName(_defaultAovName);
+            argData.getFlagArgument(_aovNameId, 0, aovName);
+
+            // Extract sorted and unique pass indices into member arrays
+            // The set automatically keeps entries sorted by key (pass index)
+            for (const auto& pass : passes) {
+                _visibleFramePasses.append(pass);
             }
+            _aovName = aovName;
         }
     }
 

--- a/lib/mayaHydra/mayaPlugin/setVisibleFramePassesCommand.h
+++ b/lib/mayaHydra/mayaPlugin/setVisibleFramePassesCommand.h
@@ -35,11 +35,11 @@ public:
     MStatus doIt(const MArgList& args) override;
 
     static const MIntArray& getVisibleFramePasses() { return _visibleFramePasses; }
-    static const MStringArray& getAovNames() { return _aovNames; }
+    static const MString& getAovName() { return _aovName; }
 
 private:
     static MIntArray _visibleFramePasses;
-    static MStringArray _aovNames;
+    static MString _aovName;
 };
 
 } // namespace MAYAHYDRA_NS_DEF

--- a/test/lib/mayaUsd/render/mayaToHydra/testFramePasses.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/testFramePasses.py
@@ -26,6 +26,7 @@ class TestFramePasses(mtohUtils.MayaHydraBaseTestCase): #Subclassing mtohUtils.M
     _file = __file__
 
     IMAGE_DIFF_FAIL_THRESHOLD = 0.01
+    _imageVersion = None
 
     @property
     def IMAGE_DIFF_FAIL_PERCENT(self):
@@ -36,9 +37,14 @@ class TestFramePasses(mtohUtils.MayaHydraBaseTestCase): #Subclassing mtohUtils.M
     def setUp(self):
         super(TestFramePasses, self).setUp()
 
-    def run_assertion(self, filename, mode, failures):
+    def run_assertion(self, filename, mode, failures, useDynamicVersion=False):
         try:
-            self.assertSnapshotClose(filename, self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
+            # Use dynamic image version only when requested and there are 2 frame passes
+            imageVersion = None
+            if useDynamicVersion:
+                imageVersion = self._imageVersionFor2Passes
+            
+            self.assertSnapshotClose(filename, self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT, imageVersion)
         except AssertionError as e:
             failures.append(f"Failed on {filename} ({mode}): {str(e)}")
             # Still continue to the next test
@@ -51,20 +57,20 @@ class TestFramePasses(mtohUtils.MayaHydraBaseTestCase): #Subclassing mtohUtils.M
         self.setHdStormRenderer()
 
     #Enable only pass #0 then pass #1 and do snapshots using as an option the aov namre specified
-    def EnablePassesOneByOneAndDoSnapshots(self, name, failures, aovName=""):
+    def EnablePassesOneByOneAndDoSnapshots(self, name, failures, aovName="", useDynamicVersion=False):
         # Enable only pass#0
         kwargs = {"edit": True, "visible": [0]}
         if aovName:
             kwargs["aovName"] = aovName
         cmds.mayaHydraSetVisibleFramePasses(**kwargs)
-        self.run_assertion(("FirstPass"+name+".png"), ("first pass "+name), failures)
+        self.run_assertion(("FirstPass"+name+".png"), ("first pass "+name), failures, useDynamicVersion)
     
         # Enable only pass#1
         kwargs = {"edit": True, "visible": [1]}
         if aovName:
             kwargs["aovName"] = aovName
         cmds.mayaHydraSetVisibleFramePasses(**kwargs)
-        self.run_assertion(("SecondPass"+name+".png"), ("second pass "+name), failures)
+        self.run_assertion(("SecondPass"+name+".png"), ("second pass "+name), failures, useDynamicVersion)
             
     def test_FootPrintNodeForSecondPass(self):
         with PluginLoaded('mayaHydraFootPrintNode'):
@@ -88,7 +94,7 @@ class TestFramePasses(mtohUtils.MayaHydraBaseTestCase): #Subclassing mtohUtils.M
             cmds.refresh()
 
             self.setBasicCam(1)
-            self.EnablePassesOneByOneAndDoSnapshots(name="FootPrintAsScndGraphics", failures=failures)
+            self.EnablePassesOneByOneAndDoSnapshots(name="FootPrintAsScndGraphics", failures=failures, useDynamicVersion=True)#Is dependent on the number of frame passes
 
             # Enable all passes
             self.SetAllPassesVisibleToColorAOV()
@@ -112,7 +118,7 @@ class TestFramePasses(mtohUtils.MayaHydraBaseTestCase): #Subclassing mtohUtils.M
             #Render all passes
             self.EnablePassesOneByOneAndDoSnapshots(name="SceneLoaded", failures=failures)
             #Render all passes using the "depth" AOV
-            self.EnablePassesOneByOneAndDoSnapshots(name="SceneLoadedDepth", failures=failures, aovName="depth")
+            self.EnablePassesOneByOneAndDoSnapshots(name="SceneLoadedDepth", failures=failures, aovName="depth", useDynamicVersion=True)#Is dependent on the number of frame passes
             
             #Draw the foot print node as secondary graphics 
             #It should make the node be part of the secondary graphics pass if there is one, 
@@ -132,11 +138,11 @@ class TestFramePasses(mtohUtils.MayaHydraBaseTestCase): #Subclassing mtohUtils.M
             cmds.select('|transform1', add=True) #custom prim FootStep
             cmds.select('|PoolBallFlat_animated|PoolBallFlat_animatedShape', add=True)#usd prim
 
-            self.EnablePassesOneByOneAndDoSnapshots(name="SelHighlight", failures=failures)
+            self.EnablePassesOneByOneAndDoSnapshots(name="SelHighlight", failures=failures, useDynamicVersion=True)#Is dependent on the number of frame passes
             
             #Set a wrong aov Name on purpose, it should show the color aov by default
-            cmds.mayaHydraSetVisibleFramePasses(edit=True, visible=[0, 1], aovName=["wrongAovName1", "wrongAovName2"])
-            self.run_assertion("wrongAovName.png", "Wrong AOV name", failures)
+            cmds.mayaHydraSetVisibleFramePasses(edit=True, visible=[0, 1], aovName="wrongAovName1")
+            self.run_assertion("wrongAovName.png", "Wrong AOV name", failures, True)#Is dependent on the number of frame passes
 
             # Enable all passes
             self.SetAllPassesVisibleToColorAOV()
@@ -158,8 +164,8 @@ class TestFramePasses(mtohUtils.MayaHydraBaseTestCase): #Subclassing mtohUtils.M
                         "testFramePasses",
                         "framePasses.ma", useTestSettings=False)
             cmds.refresh()
-            cmds.mayaHydraSetVisibleFramePasses(edit=True, visible=[0], aovName=["depth"])
-            self.assertSnapshotClose("beforeReset.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
+            cmds.mayaHydraSetVisibleFramePasses(edit=True, visible=[0], aovName="depth")
+            self.assertSnapshotClose("beforeReset.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT, self._imageVersionFor2Passes)
             cmds.mayaHydraSetVisibleFramePasses(reset=True)
             self.assertSnapshotClose("afterReset.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
 

--- a/test/lib/mayaUsd/render/mayaToHydra/testFramePasses.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/testFramePasses.py
@@ -26,7 +26,6 @@ class TestFramePasses(mtohUtils.MayaHydraBaseTestCase): #Subclassing mtohUtils.M
     _file = __file__
 
     IMAGE_DIFF_FAIL_THRESHOLD = 0.01
-    _imageVersion = None
 
     @property
     def IMAGE_DIFF_FAIL_PERCENT(self):
@@ -37,14 +36,9 @@ class TestFramePasses(mtohUtils.MayaHydraBaseTestCase): #Subclassing mtohUtils.M
     def setUp(self):
         super(TestFramePasses, self).setUp()
 
-    def run_assertion(self, filename, mode, failures, useDynamicVersion=False):
+    def run_assertion(self, filename, mode, failures):
         try:
-            # Use dynamic image version only when requested and there are 2 frame passes
-            imageVersion = None
-            if useDynamicVersion:
-                imageVersion = self._imageVersionFor2Passes
-            
-            self.assertSnapshotClose(filename, self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT, imageVersion)
+            self.assertSnapshotClose(filename, self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
         except AssertionError as e:
             failures.append(f"Failed on {filename} ({mode}): {str(e)}")
             # Still continue to the next test
@@ -57,20 +51,20 @@ class TestFramePasses(mtohUtils.MayaHydraBaseTestCase): #Subclassing mtohUtils.M
         self.setHdStormRenderer()
 
     #Enable only pass #0 then pass #1 and do snapshots using as an option the aov namre specified
-    def EnablePassesOneByOneAndDoSnapshots(self, name, failures, aovName="", useDynamicVersion=False):
+    def EnablePassesOneByOneAndDoSnapshots(self, name, failures, aovName=""):
         # Enable only pass#0
         kwargs = {"edit": True, "visible": [0]}
         if aovName:
             kwargs["aovName"] = aovName
         cmds.mayaHydraSetVisibleFramePasses(**kwargs)
-        self.run_assertion(("FirstPass"+name+".png"), ("first pass "+name), failures, useDynamicVersion)
+        self.run_assertion(("FirstPass"+name+".png"), ("first pass "+name), failures)
     
         # Enable only pass#1
         kwargs = {"edit": True, "visible": [1]}
         if aovName:
             kwargs["aovName"] = aovName
         cmds.mayaHydraSetVisibleFramePasses(**kwargs)
-        self.run_assertion(("SecondPass"+name+".png"), ("second pass "+name), failures, useDynamicVersion)
+        self.run_assertion(("SecondPass"+name+".png"), ("second pass "+name), failures)
             
     def test_FootPrintNodeForSecondPass(self):
         with PluginLoaded('mayaHydraFootPrintNode'):
@@ -94,7 +88,7 @@ class TestFramePasses(mtohUtils.MayaHydraBaseTestCase): #Subclassing mtohUtils.M
             cmds.refresh()
 
             self.setBasicCam(1)
-            self.EnablePassesOneByOneAndDoSnapshots(name="FootPrintAsScndGraphics", failures=failures, useDynamicVersion=True)#Is dependent on the number of frame passes
+            self.EnablePassesOneByOneAndDoSnapshots(name="FootPrintAsScndGraphics", failures=failures)
 
             # Enable all passes
             self.SetAllPassesVisibleToColorAOV()
@@ -118,7 +112,7 @@ class TestFramePasses(mtohUtils.MayaHydraBaseTestCase): #Subclassing mtohUtils.M
             #Render all passes
             self.EnablePassesOneByOneAndDoSnapshots(name="SceneLoaded", failures=failures)
             #Render all passes using the "depth" AOV
-            self.EnablePassesOneByOneAndDoSnapshots(name="SceneLoadedDepth", failures=failures, aovName="depth", useDynamicVersion=True)#Is dependent on the number of frame passes
+            self.EnablePassesOneByOneAndDoSnapshots(name="SceneLoadedDepth", failures=failures, aovName="depth")
             
             #Draw the foot print node as secondary graphics 
             #It should make the node be part of the secondary graphics pass if there is one, 
@@ -138,11 +132,11 @@ class TestFramePasses(mtohUtils.MayaHydraBaseTestCase): #Subclassing mtohUtils.M
             cmds.select('|transform1', add=True) #custom prim FootStep
             cmds.select('|PoolBallFlat_animated|PoolBallFlat_animatedShape', add=True)#usd prim
 
-            self.EnablePassesOneByOneAndDoSnapshots(name="SelHighlight", failures=failures, useDynamicVersion=True)#Is dependent on the number of frame passes
+            self.EnablePassesOneByOneAndDoSnapshots(name="SelHighlight", failures=failures)
             
             #Set a wrong aov Name on purpose, it should show the color aov by default
             cmds.mayaHydraSetVisibleFramePasses(edit=True, visible=[0, 1], aovName="wrongAovName1")
-            self.run_assertion("wrongAovName.png", "Wrong AOV name", failures, True)#Is dependent on the number of frame passes
+            self.run_assertion("wrongAovName.png", "Wrong AOV name", failures)
 
             # Enable all passes
             self.SetAllPassesVisibleToColorAOV()
@@ -165,7 +159,7 @@ class TestFramePasses(mtohUtils.MayaHydraBaseTestCase): #Subclassing mtohUtils.M
                         "framePasses.ma", useTestSettings=False)
             cmds.refresh()
             cmds.mayaHydraSetVisibleFramePasses(edit=True, visible=[0], aovName="depth")
-            self.assertSnapshotClose("beforeReset.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT, self._imageVersionFor2Passes)
+            self.assertSnapshotClose("beforeReset.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
             cmds.mayaHydraSetVisibleFramePasses(reset=True)
             self.assertSnapshotClose("afterReset.png", self.IMAGE_DIFF_FAIL_THRESHOLD, self.IMAGE_DIFF_FAIL_PERCENT)
 


### PR DESCRIPTION
1.Sync to latest HVT which contains AOV sharing change. Now, the way to visualize AOV in multi-pass rendering is to always transport all the information (all AOVs) and let the last frame pass dictates the VisualizeAOV.
2.Change mayaHydraSetVisibleFramePasses command to only allow one aov to be visualized.


E.g., 
mayaHydraSetVisibleFramePasses -e -v 0 -v 1 -aov "color"; //visualize color from 2 passes(default case)
mayaHydraSetVisibleFramePasses -e -v 0 -v 1 -aov "depth"; //visualize depth from 2 passes
mayaHydraSetVisibleFramePasses -e -v 0 -aov "color"; //only visualize color from 1st pass
mayaHydraSetVisibleFramePasses -e -v 1 -aov "depth"; //only visualize depth from 2nd pass