### PR TITLE
Fix compiler error when building against usd v25.11

### DIFF
--- a/lib/mayaHydra/mayaPlugin/renderOverride.cpp
+++ b/lib/mayaHydra/mayaPlugin/renderOverride.cpp
@@ -1362,7 +1362,9 @@ MStatus MtohRenderOverride::Render(
 #else
     HdxRenderTaskParams params;
     params.enableLighting       = true;
+#if PXR_VERSION <= 2508
     params.enableSceneMaterials = true;
+#endif
     params.cullStyle            = HdCullStyleBackUnlessDoubleSided;
     _taskController->SetSelectionColor(_globals.colorSelectionHighlightColor);// Default color in usdview.
     _taskController->SetEnableSelection(_globals.colorSelectionHighlight);


### PR DESCRIPTION
Fix additional compiler error when building against usd v25.11 after https://github.com/Autodesk/maya-hydra/pull/361 