### PR TITLE
HYDRA-2005 : Fix depth peeling

### DIFF
--- a/lib/mayaHydra/mayaPlugin/renderOverride.cpp
+++ b/lib/mayaHydra/mayaPlugin/renderOverride.cpp
@@ -2207,6 +2207,8 @@ MStatus MtohRenderOverride::setup(const MString& destination)
         // Clear and draw pre scene elements (grid not pushed into hydra)
         _operations.push_back(std::make_unique<MayaHydraPreRender>("HydraRenderOverride_PreScene"));
 
+        _operations.push_back(std::make_unique<MayaHydraDataUpdatePass>("HydraRenderOverride_DataUpdatePass"));
+
         // The main hydra render
         // For the data server, This also invokes scene update then sync scene delegate after scene update
         _operations.push_back(std::make_unique<MayaHydraRender>("HydraRenderOverride_DataServer", this));

--- a/lib/mayaHydra/mayaPlugin/renderOverrideUtils.h
+++ b/lib/mayaHydra/mayaPlugin/renderOverrideUtils.h
@@ -18,6 +18,8 @@
 #ifndef MTOH_VIEW_OVERRIDE_UTILS_H
 #define MTOH_VIEW_OVERRIDE_UTILS_H
 
+#include <maya/MViewport2Renderer.h>
+
 #include <pxr/pxr.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -35,9 +37,15 @@ public:
 
     MUint64 getObjectTypeExclusions() override
     {
-        /// To skip the generation of some unwanted render lists even the kRenderPreSceneUIItems
+        /// To skip the generation of some unwanted render lists even if the kRenderPreSceneUIItems
         /// filter is specified.
-        return MFrameContext::kExcludeManipulators | MFrameContext::kExcludeHUD;
+        static MUint64 sObjectTypeExclusions = []() -> MUint64 {
+            /// Exclude everything as a baseline. Restore grid.
+            MUint64 flags = MFrameContext::kExcludeAll;
+            flags &= ~MFrameContext::kExcludeGrid;
+            return flags;
+        }();
+        return sObjectTypeExclusions;
     }
 
     MSceneFilterOption renderFilterOverride() override { return kRenderPreSceneUIItems; }

--- a/lib/mayaHydra/mayaPlugin/renderOverrideUtils.h
+++ b/lib/mayaHydra/mayaPlugin/renderOverrideUtils.h
@@ -18,6 +18,7 @@
 #ifndef MTOH_VIEW_OVERRIDE_UTILS_H
 #define MTOH_VIEW_OVERRIDE_UTILS_H
 
+#include <maya/MSelectionList.h>
 #include <maya/MViewport2Renderer.h>
 
 #include <pxr/pxr.h>
@@ -43,10 +44,29 @@ public:
             /// Exclude everything as a baseline. Restore grid.
             MUint64 flags = MFrameContext::kExcludeAll;
             flags &= ~MFrameContext::kExcludeGrid;
+            //flags &= ~MFrameContext::kExcludeMeshes;				
+            //flags &= ~MFrameContext::kExcludePluginShapes;		
+            //flags &= ~MFrameContext::kExcludeNurbsCurves;		
+            //flags &= ~MFrameContext::kExcludeNurbsSurfaces;		
+            //flags &= ~MFrameContext::kExcludePlanes;				
+            //flags &= ~MFrameContext::kExcludeLights;				
+            flags &= ~MFrameContext::kExcludeCameras;			
+            //flags &= ~MFrameContext::kExcludeJoints;				
+            //flags &= ~MFrameContext::kExcludeIkHandles;			
+            //flags &= ~MFrameContext::kExcludeSubdivSurfaces;		
+            //flags &= ~MFrameContext::kExcludeHairSystems;		
+            //flags &= ~MFrameContext::kExcludeGreasePencils;		
             return flags;
         }();
         return sObjectTypeExclusions;
+        //return MFrameContext::kExcludeManipulators | MFrameContext::kExcludeHUD;
     }
+
+    //const MSelectionList * objectSetOverride() override
+    //{
+    //    static MSelectionList emptyList;
+    //    return &emptyList;
+    //}
 
     MSceneFilterOption renderFilterOverride() override { return kRenderPreSceneUIItems; }
 
@@ -80,6 +100,35 @@ public:
     {
         return MSceneFilterOption(kRenderPostSceneUIItems);
     }
+
+    MHWRender::MClearOperation& clearOperation() override { return mClearOperation; }
+};
+
+class MayaHydraDataUpdatePass : public MHWRender::MSceneRender
+{
+public:
+    explicit MayaHydraDataUpdatePass(const MString& name)
+        : MHWRender::MSceneRender(name)
+    {
+        mClearOperation.setMask(MHWRender::MClearOperation::kClearNone);
+    }
+
+    MUint64 getObjectTypeExclusions() override
+    {
+        return MFrameContext::kExcludeGrid 
+            | MFrameContext::kExcludeGreasePencils 
+            | MFrameContext::kExcludeHUD
+            | MFrameContext::kExcludeDimensions 
+            | MFrameContext::kExcludeManipulators;
+    }
+
+    const MSelectionList * objectSetOverride() override
+    {
+        static MSelectionList emptyList;
+        return &emptyList;
+    }
+
+    MSceneFilterOption renderFilterOverride() override { return kNoSceneFilterOverride; }
 
     MHWRender::MClearOperation& clearOperation() override { return mClearOperation; }
 };


### PR DESCRIPTION
Fix depth peeling artifacts.

I tried to add a unit test, but I could not get it to repro in our test environment, even if I tried removing some of our test-specific options. I did find out that the artifacts are only present when MSAA is off, but that still doesn't make the bug work in testing. There is likely some other element needed to repro, possibly an idle event, that is needed for the issue to occur.

Nonetheless, I've tested multiple times and with and without the change and it always fixed the issue when present, and the issue was back without it.