### PR TITLE
HYDRA-2003 : Fix env vars for LookdevX unit test

### DIFF
--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -278,6 +278,7 @@ finally:
         XBMLANGPATH
         ${PXR_OVERRIDE_PLUGINPATH_NAME}
         PXR_MTLX_STDLIB_SEARCH_PATHS
+        MATERIALX_SEARCH_PATH
     )
 
     if(IS_WINDOWS)
@@ -408,6 +409,12 @@ finally:
              "${LOOKDEVX_LOCATION}/python")
         list(APPEND MAYAUSD_VARNAME_MAYA_PLUG_IN_PATH
              "${LOOKDEVX_LOCATION}/plug-ins")
+        list(APPEND MAYAUSD_VARNAME_PXR_MTLX_STDLIB_SEARCH_PATHS
+             "${LOOKDEVX_LOCATION}/libraries-lookdevx")
+        list(APPEND MAYAUSD_VARNAME_MATERIALX_SEARCH_PATH
+             "${LOOKDEVX_LOCATION}/libraries")
+        list(APPEND MAYAUSD_VARNAME_MATERIALX_SEARCH_PATH
+             "${LOOKDEVX_LOCATION}/libraries-lookdevx")
     endif()
 
     if(DEFINED BIFROST_LOCATION)


### PR DESCRIPTION
Some env vars setup was missing in our unit test compared to the LookdevX mod files. Fix the missing MaterialX search paths.