### PR TITLE
HYDRA-2140 : Add MayaHydra profiling utilities

### DIFF
--- a/lib/mayaHydra/hydraExtensions/CMakeLists.txt
+++ b/lib/mayaHydra/hydraExtensions/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(${TARGET_NAME}
         mixedUtils.cpp
         mhWireframeColorInterfaceImp.cpp
         mhLeadObjectPathTracker.cpp
+        profilingUtils.cpp
         tokens.cpp
 )
 
@@ -29,6 +30,7 @@ set(HEADERS
     mixedUtils.h
     mhWireframeColorInterfaceImp.h
     mhLeadObjectPathTracker.h
+    profilingUtils.h
     tokens.h
 )
 

--- a/lib/mayaHydra/hydraExtensions/profilingUtils.cpp
+++ b/lib/mayaHydra/hydraExtensions/profilingUtils.cpp
@@ -1,0 +1,70 @@
+//
+// Copyright 2026 Autodesk, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "profilingUtils.h"
+
+#include <pxr/base/tf/diagnostic.h>
+#include <pxr/base/trace/collector.h>
+#include <pxr/base/trace/reporter.h>
+
+#include <maya/MProfiler.h>
+
+#include <fstream>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+namespace MAYAHYDRA_NS_DEF {
+
+int ProfilingCategory()
+{
+    static int category = MProfiler::addCategory("MayaHydra", "Events from MayaHydra profiling utilities");
+    return category;
+}
+
+void StartProfiling()
+{
+    TraceCollector::GetInstance().SetEnabled(true);
+    MProfiler::setRecordingActive(true);
+}
+
+void StopProfiling(const std::string& chromeTraceFile)
+{
+    TraceCollector::GetInstance().SetEnabled(false);
+    MProfiler::setRecordingActive(false);
+
+    if (!chromeTraceFile.empty()) {
+        std::ofstream out(chromeTraceFile);
+        if (out.is_open()) {
+            TraceReporter::GetGlobalReporter()->ReportChromeTracing(out);
+        }
+    }
+}
+
+bool IsProfilingActive()
+{
+    bool isMayaProfilerActive = MProfiler::recordingActive();
+    bool isUsdProfilerEnabled = TraceCollector::IsEnabled();
+    if (isMayaProfilerActive != isUsdProfilerEnabled) {
+        if (isMayaProfilerActive) {
+            TF_WARN("Maya profiler is active but USD tracing is disabled");
+        } else {
+            TF_WARN("USD tracing is enabled but Maya profiler is inactive");
+        }
+    }
+    return isMayaProfilerActive || isUsdProfilerEnabled;
+}
+
+} // namespace MAYAHYDRA_NS_DEF

--- a/lib/mayaHydra/hydraExtensions/profilingUtils.h
+++ b/lib/mayaHydra/hydraExtensions/profilingUtils.h
@@ -27,6 +27,13 @@
 
 #include <string>
 
+/// Utilities for managing both the Maya profiler and USD tracing system simultaneously.
+/// After profiling is done, profiling results for Maya can be viewed by opening the profiling
+/// window under Window > General Editors > Profiler.
+/// The USD tracing system produces .json files following the Chrome tracing format, which
+/// can be viewed and analyzed through a tool like https://ui.perfetto.dev/
+/// More info can be found in the official docs : https://openusd.org/release/api/trace_page_front.html
+
 namespace MAYAHYDRA_NS_DEF {
 
 /// Returns the MProfiler category ID registered for MayaHydra.
@@ -41,6 +48,7 @@ void StartProfiling();
 /// Disables both the Maya profiler and USD trace collector, then writes
 /// the collected USD trace data to \p chromeTraceFile in Chrome tracing format.
 /// If \p chromeTraceFile is empty, the trace data is not written out.
+/// The trace file can be visualized and analyzed with a tool like https://ui.perfetto.dev/
 MAYAHYDRALIB_API
 void StopProfiling(const std::string& chromeTraceFile);
 

--- a/lib/mayaHydra/hydraExtensions/profilingUtils.h
+++ b/lib/mayaHydra/hydraExtensions/profilingUtils.h
@@ -1,0 +1,85 @@
+//
+// Copyright 2026 Autodesk, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef MAYAHYDRALIB_PROFILING_UTILS_H
+#define MAYAHYDRALIB_PROFILING_UTILS_H
+
+#include <mayaHydraLib/api.h>
+
+#include <pxr/base/trace/trace.h>
+#include <pxr/base/arch/functionLite.h>
+#include <pxr/base/tf/preprocessorUtilsLite.h>
+
+#include <maya/MProfiler.h>
+
+#include <string>
+
+namespace MAYAHYDRA_NS_DEF {
+
+/// Returns the MProfiler category ID registered for MayaHydra.
+/// The category is lazily created on first call.
+MAYAHYDRALIB_API
+int ProfilingCategory();
+
+/// Enables both the Maya profiler (MProfiler) and USD trace collector.
+MAYAHYDRALIB_API
+void StartProfiling();
+
+/// Disables both the Maya profiler and USD trace collector, then writes
+/// the collected USD trace data to \p chromeTraceFile in Chrome tracing format.
+/// If \p chromeTraceFile is empty, the trace data is not written out.
+MAYAHYDRALIB_API
+void StopProfiling(const std::string& chromeTraceFile);
+
+/// Returns true if either the Maya profiler is active or the USD trace collector
+/// is enabled.
+MAYAHYDRALIB_API
+bool IsProfilingActive();
+
+} // namespace MAYAHYDRA_NS_DEF
+
+#if !defined(MH_PROFILING_ENABLED)
+    #define MH_PROFILING_ENABLED 1
+#endif
+
+#if MH_PROFILING_ENABLED
+
+/// Profiles the enclosing function in both Maya MProfiler and USD Trace,
+/// using the function name as the event/scope key.
+#define MH_PROFILE_FUNCTION() \
+    TRACE_FUNCTION(); \
+    MProfilingScope TF_PP_CAT(_mayaHydraProfiling_, __LINE__)( \
+        MAYAHYDRA_NS::ProfilingCategory(), \
+        MProfiler::kColorC_L1, \
+        __ARCH_PRETTY_FUNCTION__)
+
+/// Profiles the enclosing scope in both Maya MProfiler and USD Trace,
+/// using \p name (a string literal) as the event/scope key.
+#define MH_PROFILE_SCOPE(name) \
+    TRACE_SCOPE(name); \
+    MProfilingScope TF_PP_CAT(_mayaHydraProfiling_, __LINE__)( \
+        MAYAHYDRA_NS::ProfilingCategory(), \
+        MProfiler::kColorB_L3, \
+        name)
+
+#else
+
+#define MH_PROFILE_FUNCTION()
+#define MH_PROFILE_SCOPE(name)
+
+#endif // MH_PROFILING_ENABLED
+
+#endif // MAYAHYDRALIB_PROFILING_UTILS_H

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
@@ -24,6 +24,7 @@
 #include <mayaHydraLib/hydraUtils.h>
 #include <mayaHydraLib/mayaUtils.h>
 #include <mayaHydraLib/mixedUtils.h>
+#include <mayaHydraLib/profilingUtils.h>
 #include <mayaHydraLib/sceneIndex/mayaHydraDataSource.h>
 
 #include <pxr/base/tf/envSetting.h>
@@ -441,6 +442,8 @@ void MayaHydraSceneIndex::_Destroy()
 
 void MayaHydraSceneIndex::UpdateRenderItems(const MDataServerOperation::MViewportScene& scene)
 {
+    MH_PROFILE_FUNCTION();
+
     // First loop to get rid of removed items
     constexpr int kInvalidId = 0;
     for (size_t i = 0; i < scene.mRemovalCount; i++) {
@@ -538,6 +541,8 @@ void MayaHydraSceneIndex::UpdateRenderItems(const MDataServerOperation::MViewpor
 
 void MayaHydraSceneIndex::Populate()
 {
+    MH_PROFILE_FUNCTION();
+
     MayaHydraAdapterRegistry::LoadAllPlugin();
 
     MStatus status;

--- a/lib/mayaHydra/mayaPlugin/CMakeLists.txt
+++ b/lib/mayaHydra/mayaPlugin/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources(${TARGET_NAME}
         pluginBuildInfoCommand.cpp
         getFramePassesCountCommand.cpp
         testingCommand.cpp
+        profilingCommand.cpp
         renderRegionCommand.cpp
         setVisibleFramePassesCommand.cpp
 )

--- a/lib/mayaHydra/mayaPlugin/plugin.cpp
+++ b/lib/mayaHydra/mayaPlugin/plugin.cpp
@@ -24,6 +24,7 @@
 #include "getFramePassesCountCommand.h"
 #include "testingCommand.h"
 #include "renderRegionCommand.h"
+#include "profilingCommand.h"
 #include "setVisibleFramePassesCommand.h"
 
 #include <mayaHydraLib/adapters/adapter.h>
@@ -249,6 +250,15 @@ PLUGIN_EXPORT MStatus initializePlugin(MObject obj)
         return ret;
     }
 
+    if (!plugin.registerCommand(
+            MayaHydraProfilingCommand::commandName,
+            MayaHydraProfilingCommand::creator,
+            MayaHydraProfilingCommand::createSyntax)) {
+        ret = MS::kFailure;
+        ret.perror("Error registering mayaHydraProfiling command!");
+        return ret;
+    }
+
     // Set the path where maya hydra is loaded to be used later
     //This must be called before the renderoverride is created
     MtohSetMayaHydraPluginLocation(std::filesystem::path(plugin.loadPath().asChar())); 
@@ -363,6 +373,11 @@ PLUGIN_EXPORT MStatus uninitializePlugin(MObject obj)
     if (!plugin.deregisterCommand(MayaHydraGetFramePassesCount::commandName)) {
         ret = MS::kFailure;
         ret.perror("Error deregistering MayaHydraGetFramePassesCount command!");
+    }
+
+    if (!plugin.deregisterCommand(MayaHydraProfilingCommand::commandName)) {
+        ret = MS::kFailure;
+        ret.perror("Error deregistering mayaHydraProfiling command!");
     }
 
     return ret;

--- a/lib/mayaHydra/mayaPlugin/profilingCommand.cpp
+++ b/lib/mayaHydra/mayaPlugin/profilingCommand.cpp
@@ -1,0 +1,84 @@
+//
+// Copyright 2026 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "profilingCommand.h"
+
+#include <mayaHydraLib/profilingUtils.h>
+
+#include <maya/MArgDatabase.h>
+#include <maya/MSyntax.h>
+
+namespace MAYAHYDRA_NS_DEF {
+
+const MString MayaHydraProfilingCommand::commandName("mayaHydraProfiling");
+
+namespace {
+
+constexpr auto kEnabled = "-e";
+constexpr auto kEnabledLong = "-enabled";
+
+constexpr auto kUsdTraceFile = "-utf";
+constexpr auto kUsdTraceFileLong = "-usdTraceFile";
+
+constexpr auto kIsEnabled = "-ie";
+constexpr auto kIsEnabledLong = "-isEnabled";
+
+} // namespace
+
+MSyntax MayaHydraProfilingCommand::createSyntax()
+{
+    MSyntax syntax;
+
+    syntax.addFlag(kEnabled, kEnabledLong, MSyntax::kBoolean);
+    syntax.addFlag(kUsdTraceFile, kUsdTraceFileLong, MSyntax::kString);
+    syntax.addFlag(kIsEnabled, kIsEnabledLong);
+
+    return syntax;
+}
+
+MStatus MayaHydraProfilingCommand::doIt(const MArgList& args)
+{
+    MStatus status;
+
+    MArgDatabase db(syntax(), args, &status);
+    if (!status) {
+        return status;
+    }
+
+    if (db.isFlagSet(kEnabled)) {
+        bool enabled = false;
+        CHECK_MSTATUS_AND_RETURN_IT(db.getFlagArgument(kEnabled, 0, enabled));
+        if (enabled) {
+            StartProfiling();
+        } else {
+            MString filePath;
+            if (db.isFlagSet(kUsdTraceFile)) {
+                CHECK_MSTATUS_AND_RETURN_IT(db.getFlagArgument(kUsdTraceFile, 0, filePath));
+            }
+            StopProfiling(filePath.asChar());
+        }
+        return MS::kSuccess;
+    }
+
+    if (db.isFlagSet(kIsEnabled)) {
+        setResult(IsProfilingActive());
+        return MS::kSuccess;
+    }
+
+    return MS::kSuccess;
+}
+
+} // namespace MAYAHYDRA_NS_DEF

--- a/lib/mayaHydra/mayaPlugin/profilingCommand.cpp
+++ b/lib/mayaHydra/mayaPlugin/profilingCommand.cpp
@@ -25,8 +25,10 @@
  * mayaHydraProfiling command
  * 
  * This command allows the user to start/stop both the Maya profiler and USD tracing system at the same time.
- * When stopping profiling, a file path for where to store the USD tracing results can optionally be passed. 
+ * When stopping profiling, a .json file path for where to store the USD tracing results can optionally be passed. 
  * The command also allows for querying whether profiling is currently active or not.
+ * Information on the USD tracing system can be found at https://openusd.org/release/api/trace_page_front.html
+ * USD traces can be visualized and analyzed with a tool like https://ui.perfetto.dev/
  * 
  * Functionality:
  * - Start/Stop Maya and USD profiling

--- a/lib/mayaHydra/mayaPlugin/profilingCommand.cpp
+++ b/lib/mayaHydra/mayaPlugin/profilingCommand.cpp
@@ -21,20 +21,47 @@
 #include <maya/MArgDatabase.h>
 #include <maya/MSyntax.h>
 
+/**
+ * mayaHydraProfiling command
+ * 
+ * This command allows the user to start/stop both the Maya profiler and USD tracing system at the same time.
+ * When stopping profiling, a file path for where to store the USD tracing results can optionally be passed. 
+ * The command also allows for querying whether profiling is currently active or not.
+ * 
+ * Functionality:
+ * - Start/Stop Maya and USD profiling
+ * - Set where to store USD tracing results
+ * - Query if profiling is active
+ */
+
+/* Examples
+    // Start profiling
+    MEL : mayaHydraProfiling -a 1
+    Python : maya.cmds.mayaHydraProfiling(active=True)
+
+    // Stop profiling
+    MEL : mayaHydraProfiling -a 0 -utf "D:/dev/traces/mayaHydraUsdTrace.json"
+    Python : maya.cmds.mayaHydraProfiling(active=False, usdTraceFile="D:/dev/traces/mayaHydraUsdTrace.json")
+
+    // Query if profiling is active
+    MEL : mayaHydraProfiling -ia
+    Python : maya.cmds.mayaHydraProfiling(isActive=True)
+*/
+
 namespace MAYAHYDRA_NS_DEF {
 
 const MString MayaHydraProfilingCommand::commandName("mayaHydraProfiling");
 
 namespace {
 
-constexpr auto kEnabled = "-e";
-constexpr auto kEnabledLong = "-enabled";
+constexpr auto kActive = "-a";
+constexpr auto kActiveLong = "-active";
 
 constexpr auto kUsdTraceFile = "-utf";
 constexpr auto kUsdTraceFileLong = "-usdTraceFile";
 
-constexpr auto kIsEnabled = "-ie";
-constexpr auto kIsEnabledLong = "-isEnabled";
+constexpr auto kIsActive = "-ia";
+constexpr auto kIsActiveLong = "-isActive";
 
 } // namespace
 
@@ -42,9 +69,9 @@ MSyntax MayaHydraProfilingCommand::createSyntax()
 {
     MSyntax syntax;
 
-    syntax.addFlag(kEnabled, kEnabledLong, MSyntax::kBoolean);
+    syntax.addFlag(kActive, kActiveLong, MSyntax::kBoolean);
     syntax.addFlag(kUsdTraceFile, kUsdTraceFileLong, MSyntax::kString);
-    syntax.addFlag(kIsEnabled, kIsEnabledLong);
+    syntax.addFlag(kIsActive, kIsActiveLong);
 
     return syntax;
 }
@@ -58,10 +85,10 @@ MStatus MayaHydraProfilingCommand::doIt(const MArgList& args)
         return status;
     }
 
-    if (db.isFlagSet(kEnabled)) {
-        bool enabled = false;
-        CHECK_MSTATUS_AND_RETURN_IT(db.getFlagArgument(kEnabled, 0, enabled));
-        if (enabled) {
+    if (db.isFlagSet(kActive)) {
+        bool active = false;
+        CHECK_MSTATUS_AND_RETURN_IT(db.getFlagArgument(kActive, 0, active));
+        if (active) {
             StartProfiling();
         } else {
             MString filePath;
@@ -73,7 +100,7 @@ MStatus MayaHydraProfilingCommand::doIt(const MArgList& args)
         return MS::kSuccess;
     }
 
-    if (db.isFlagSet(kIsEnabled)) {
+    if (db.isFlagSet(kIsActive)) {
         setResult(IsProfilingActive());
         return MS::kSuccess;
     }

--- a/lib/mayaHydra/mayaPlugin/profilingCommand.cpp
+++ b/lib/mayaHydra/mayaPlugin/profilingCommand.cpp
@@ -25,10 +25,11 @@
  * mayaHydraProfiling command
  * 
  * This command allows the user to start/stop both the Maya profiler and USD tracing system at the same time.
- * When stopping profiling, a .json file path for where to store the USD tracing results can optionally be passed. 
+ * When stopping profiling, a file path for where to store the USD tracing results can optionally be passed.
+ * These tracing results are stored as .json following the Chrome tracing format.
+ * They can be visualized and analyzed with a tool like https://ui.perfetto.dev/
  * The command also allows for querying whether profiling is currently active or not.
  * Information on the USD tracing system can be found at https://openusd.org/release/api/trace_page_front.html
- * USD traces can be visualized and analyzed with a tool like https://ui.perfetto.dev/
  * 
  * Functionality:
  * - Start/Stop Maya and USD profiling

--- a/lib/mayaHydra/mayaPlugin/profilingCommand.h
+++ b/lib/mayaHydra/mayaPlugin/profilingCommand.h
@@ -1,0 +1,39 @@
+//
+// Copyright 2026 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef MAYAHYDRA_PROFILING_COMMAND_H
+#define MAYAHYDRA_PROFILING_COMMAND_H
+
+#include <mayaHydraLib/mayaHydra.h>
+
+#include <maya/MPxCommand.h>
+
+namespace MAYAHYDRA_NS_DEF {
+
+class MayaHydraProfilingCommand : public MPxCommand
+{
+public:
+    static void*   creator() { return new MayaHydraProfilingCommand(); }
+    static MSyntax createSyntax();
+
+    static const MString commandName;
+
+    MStatus doIt(const MArgList& args) override;
+};
+
+} // namespace MAYAHYDRA_NS_DEF
+
+#endif // MAYAHYDRA_PROFILING_COMMAND_H

--- a/lib/mayaHydra/mayaPlugin/renderOverride.cpp
+++ b/lib/mayaHydra/mayaPlugin/renderOverride.cpp
@@ -33,6 +33,8 @@
 #include <mayaHydraLib/pick/mhPickHit.h>
 #include <mayaHydraLib/pick/mhPickHandler.h>
 #include <mayaHydraLib/pick/mhPickHandlerRegistry.h>
+
+#include <mayaHydraLib/profilingUtils.h>
 #include <mayaHydraLib/hydraUtils.h>
 #include <mayaHydraLib/mixedUtils.h>
 #include <mayaHydraLib/tokens.h>
@@ -126,7 +128,6 @@
 #include <maya/MNodeMessage.h>
 #include <maya/MAnimControl.h>
 #include <maya/MObjectHandle.h>
-#include <maya/MProfiler.h>
 #include <maya/MSceneMessage.h>
 #include <maya/MSelectionList.h>
 #include <maya/MTimerMessage.h>
@@ -143,10 +144,6 @@
 #include <pxr/base/tf/getenv.h>
 #include <pxr/base/tf/envSetting.h>
 #include "envSettings.h"
-
-int _profilerCategory = MProfiler::addCategory(
-    "MtohRenderOverride (mayaHydra)",
-    "Events from mayaHydra render override");
 
 using namespace MayaHydra;
 
@@ -831,10 +828,12 @@ MStatus MtohRenderOverride::Render(
     //         override->ClearHydraResources();
     //     }
     // }
+    MH_PROFILE_FUNCTION();
     TF_DEBUG(MAYAHYDRALIB_RENDEROVERRIDE_RENDER).Msg("MtohRenderOverride::Render()\n");
     // We can use the mayaHydraSetVisibleFramePasses command to set the visible passes
 
     auto renderFrame = [&](bool markTime = false) {
+        MH_PROFILE_SCOPE("MtohRenderOverride::Render renderFrame lambda");
         if (scene.changed()) {
             if (_mayaHydraSceneIndex) {
                 _mayaHydraSceneIndex->UpdateRenderItems(scene);
@@ -895,7 +894,7 @@ MStatus MtohRenderOverride::Render(
 
         // Iterate over visible passes
         for (int visibleIdx = 0; visibleIdx < numVisibleFramePasses; ++visibleIdx) {
-
+            MH_PROFILE_SCOPE("MayaHydra frame pass");
             const int actualPassIndex = framePassesVisible[visibleIdx]; // Get the actual pass index
             const hvt::FramePassPtr& currentPass = _GetFramePass(actualPassIndex);
             if (!currentPass) {
@@ -1375,6 +1374,7 @@ void MtohRenderOverride::_InitHydraResources(
     const MHWRender::MDrawContext& drawContext,
     const MayaHydraParams& delegateParams)
 {
+    MH_PROFILE_FUNCTION();
     TF_DEBUG(MAYAHYDRALIB_RENDEROVERRIDE_RESOURCES)
         .Msg("MtohRenderOverride::_InitHydraResources(%s)\n", _rendererDesc.rendererName.GetText());
 
@@ -1605,6 +1605,7 @@ void MtohRenderOverride::_InitHydraResources(
 //Use fullReset = false when you still want to see the previously registered data producer scene indices when using an hydra viewport.
 void MtohRenderOverride::ClearHydraResources(bool fullReset)
 {
+    MH_PROFILE_FUNCTION();
     if (!_initializationAttempted) {
         return;
     }
@@ -1829,6 +1830,7 @@ void MtohRenderOverride::SelectionChanged(
     const Ufe::SelectionChanged& notification
 )
 {
+    MH_PROFILE_FUNCTION();
     TF_DEBUG(FVP_APP_SELECTION_CHANGE)
         .Msg("MtohRenderOverride::SelectionChanged(Ufe::SelectionChanged) called.\n");
 
@@ -2117,13 +2119,7 @@ bool MtohRenderOverride::select(
     MSelectionList& selectionList,
     MPointArray&    worldSpaceHitPts)
 {
-#ifdef MAYAHYDRA_PROFILERS_ENABLED
-    MProfilingScope profilingScopeForEval(
-        _profilerCategory,
-        MProfiler::kColorD_L1,
-        "MtohRenderOverride::select",
-        "MtohRenderOverride::select");
-#endif
+    MH_PROFILE_FUNCTION();
     /*
     * There are 2 modes of selection picking for components in maya :
     * 1) You can be in components picking mode, this setting is global.This is detected in the function "isInComponentsPickingMode(selectInfo)"


### PR DESCRIPTION
Adds some basic profiling utilities to bridge the gap between Maya and USD profiling.

- mayaHydraProfiling command to start/stop both Maya and USD profiling simultaneously
- MH_PROFILING macros to trace MayaHydra code in both profilers