### PR TITLE
HYDRA-2070 : Add HDGP_INCLUDE_DEFAULT_RESOLVER by default 

### DIFF
--- a/lib/mayaHydra/mayaPlugin/plugin.cpp
+++ b/lib/mayaHydra/mayaPlugin/plugin.cpp
@@ -191,6 +191,8 @@ PLUGIN_EXPORT MStatus initializePlugin(MObject obj)
 
     // For now this is required for the HdSt backend to use lights.
     setEnv("USDIMAGING_ENABLE_SCENE_LIGHTS", "1");
+    // This is required to see Hydra Generative Procedurals in the viewport
+    setEnv("HDGP_INCLUDE_DEFAULT_RESOLVER", "1");
 
     // Set dome light textures maximum resolution default to 1024.  A proper
     // solution with a Hydra preferences category in the Maya


### PR DESCRIPTION
This environment variable is needed to see Hydra Generative Procedurals in the Viewport. We will add it by default if it doesn't negatively affect the performance. Looking at the code, I don't think this environment variable will worsen the performance, but I haven't been able to test it in a concrete way. If we see that merging this PR worsens the performance, we can revert it. 