### PR TITLE
HYDRA-1760 Fixed custom attributes creation followed by undo/redo

### DIFF
--- a/lib/mayaHydra/hydraExtensions/adapters/adapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/adapter.cpp
@@ -180,6 +180,14 @@ bool MayaHydraAdapter::IsExtensionOrDynamicAttribute(const MPlug& plug)
     return fnAttr.isExtension() || fnAttr.isDynamic();
 }
 
+bool MayaHydraAdapter::AttributeMessageAffectsExtensionPrimvars(MNodeMessage::AttributeMessage msg)
+{
+    const MNodeMessage::AttributeMessage mask = static_cast<MNodeMessage::AttributeMessage>(
+        MNodeMessage::kAttributeSet | MNodeMessage::kAttributeRemoved | MNodeMessage::kAttributeAdded
+        | MNodeMessage::kAttributeRenamed);
+    return (msg & mask) != 0;
+}
+
 // Normalize the plug, filter non extension/dynamic attrs, then mark primvars dirty if allowed.
 void MayaHydraAdapter::MaybeMarkPrimvarDirtyForAttributeChange(const MPlug& plug)
 {
@@ -188,6 +196,13 @@ void MayaHydraAdapter::MaybeMarkPrimvarDirtyForAttributeChange(const MPlug& plug
     // still mark primvars dirty so the scene browser refreshes when resetting
     // to default (primvar removal). Duplicate MarkDirty calls are idempotent.
     MPlug topPlug = MayaHydra::GetTopPlug(plug);
+    MStatus attrStatus;
+    topPlug.attribute(&attrStatus);
+    if (!attrStatus) {
+        // During kAttributeRemoved the plug may no longer resolve; still invalidate primvar cache.
+        MarkPrimvarDirtyForAttributeChange(topPlug);
+        return;
+    }
     if (!IsExtensionOrDynamicAttribute(topPlug)) {
         return;
     }
@@ -203,16 +218,23 @@ void MayaHydraAdapter::MarkPrimvarDirtyForAttributeChange(const MPlug& plug)
 {
     MStatus status;
     MObject attrObj = plug.attribute(&status);
-    if (status) {
-        MFnAttribute fnAttr(attrObj);
-        if (fnAttr.isExtension() || fnAttr.isDynamic()) {
-            _extAttrMapNeedUpdate = true;
-            // Notify the change tracker. Include extra bits from subclass (e.g. light param attrs
-            // need DirtyParams|DirtyShadowParams) to consolidate into one MarkDirty and avoid
-            // redundant scene index notifications.
-            MarkDirty(
-                HdChangeTracker::DirtyPrimvar | GetConsolidatedDirtyBitsForPrimvarAttributeChange(plug));
-        }
+    if (!status) {
+        // Plug may be invalid during kAttributeRemoved; still refresh cached extension/dynamic map.
+        _extAttrMapNeedUpdate = true;
+        MPlug emptyPlug;
+        MarkDirty(
+            HdChangeTracker::DirtyPrimvar
+            | GetConsolidatedDirtyBitsForPrimvarAttributeChange(emptyPlug));
+        return;
+    }
+    MFnAttribute fnAttr(attrObj);
+    if (fnAttr.isExtension() || fnAttr.isDynamic()) {
+        _extAttrMapNeedUpdate = true;
+        // Notify the change tracker. Include extra bits from subclass (e.g. light param attrs
+        // need DirtyParams|DirtyShadowParams) to consolidate into one MarkDirty and avoid
+        // redundant scene index notifications.
+        MarkDirty(
+            HdChangeTracker::DirtyPrimvar | GetConsolidatedDirtyBitsForPrimvarAttributeChange(plug));
     }
 }
 

--- a/lib/mayaHydra/hydraExtensions/adapters/adapter.h
+++ b/lib/mayaHydra/hydraExtensions/adapters/adapter.h
@@ -38,6 +38,7 @@
 #include <maya/MDrawContext.h>
 #include <maya/MPointArray.h>
 #include <maya/MSelectionContext.h>
+#include <maya/MNodeMessage.h>
 #include <maya/MPlug.h>
 #include <maya/MSelectionList.h>
 
@@ -169,6 +170,10 @@ public:
 
     /// Return true if \p plug is an extension or dynamic attribute.
     static bool IsExtensionOrDynamicAttribute(const MPlug& plug);
+
+    /// True for attribute-changed messages that should refresh extension/dynamic primvars: value
+    /// changes (kAttributeSet) and DG structure (add/remove/rename).
+    static bool AttributeMessageAffectsExtensionPrimvars(MNodeMessage::AttributeMessage msg);
 
     MAYAHYDRALIB_API
     /// Return the mesh topology for this prim (if applicable).

--- a/lib/mayaHydra/hydraExtensions/adapters/cameraAdapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/cameraAdapter.cpp
@@ -67,18 +67,17 @@ static void _cameraPlugDirty(MObject& node, MPlug& plug, void* clientData)
     }
 }
 
-// Fires when any attribute value changes (including reset to default). Ensures extension
-// attrs like aiUScale trigger primvar dirty so the scene browser updates when resetting.
+// Fires on attribute value changes and DG structure changes (add/remove/rename). Ensures
+// extension attrs like aiUScale trigger primvar dirty, and undo/redo of addAttr refreshes primvars.
 static void _cameraAttributeChanged(
     MNodeMessage::AttributeMessage msg,
     MPlug&                        plug,
     MPlug&                        otherPlug,
     void*                         clientData)
 {
-    TF_UNUSED(msg);
     TF_UNUSED(otherPlug);
     auto* adapter = reinterpret_cast<MayaHydraCameraAdapter*>(clientData);
-    if (!(msg & MNodeMessage::kAttributeSet)) {
+    if (!MayaHydraAdapter::AttributeMessageAffectsExtensionPrimvars(msg)) {
         return;
     }
     MPlug topPlug = MayaHydra::GetTopPlug(plug);

--- a/lib/mayaHydra/hydraExtensions/adapters/lightAdapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/lightAdapter.cpp
@@ -165,8 +165,8 @@ void MayaHydraLightAdapter::_LightShapeAttributeChanged(
     // For param attributes, rely on attribute-changed notifications to avoid duplicate
     // dirtying from NodeDirtyPlugCallback.
     if (_IsLightParamAttribute(topPlug)) {
-        // Reduce duplicate notifications: only react to kAttributeSet.
-        if (msg & MNodeMessage::kAttributeSet) {
+        // Reduce duplicate notifications: value changes and structural attr changes (undo addAttr).
+        if (MayaHydraAdapter::AttributeMessageAffectsExtensionPrimvars(msg)) {
             if (MayaHydraAdapter::IsExtensionOrDynamicAttribute(topPlug)) {
                 adapter->MarkPrimvarDirtyForAttributeChange(topPlug);
             } else {
@@ -176,7 +176,7 @@ void MayaHydraLightAdapter::_LightShapeAttributeChanged(
         return;
     }
 
-    if (!(msg & MNodeMessage::kAttributeSet)) {
+    if (!MayaHydraAdapter::AttributeMessageAffectsExtensionPrimvars(msg)) {
         return;
     }
 

--- a/lib/mayaHydra/hydraExtensions/adapters/meshAdapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/meshAdapter.cpp
@@ -570,12 +570,19 @@ private:
     }
 
     /// Handle attribute changes used for material assignments and primvar dirtying.
+    // Extension and dynamic (user addAttr) attributes are exposed as constant primvars via
+    // MayaHydraAdapter (see GetPrimvarDescriptors / GetExtensionAndDynamicAttributesFromNode).
+    // We do not filter on msg here: kAttributeRemoved / kAttributeAdded (e.g. undo/redo of
+    // addAttr) must reach MaybeMarkPrimvarDirtyForAttributeChange; invalid plugs during removal
+    // are handled in MayaHydraAdapter::MaybeMarkPrimvarDirtyForAttributeChange.
     static void AttributeChangedCallback(
         MNodeMessage::AttributeMessage msg,
         MPlug&                         plug,
         MPlug&                         otherPlug,
         void*                          clientData)
     {
+        TF_UNUSED(msg);
+        TF_UNUSED(otherPlug);
         auto* adapter = reinterpret_cast<MayaHydraMeshAdapter*>(clientData);
         if (plug == MayaAttrs::mesh::instObjGroups) {
             adapter->MarkDirty(HdChangeTracker::DirtyMaterialId);

--- a/lib/mayaHydra/hydraExtensions/adapters/renderItemAdapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/renderItemAdapter.cpp
@@ -626,7 +626,7 @@ void MayaHydraRenderItemAdapter::CreateCallbacks()
         +[](MNodeMessage::AttributeMessage msg, MPlug& plug, MPlug& otherPlug, void* clientData) {
             auto* adapter = reinterpret_cast<MayaHydraRenderItemAdapter*>(clientData);
             TF_UNUSED(otherPlug);
-            if (!(msg & MNodeMessage::kAttributeSet)) {
+            if (!MayaHydraAdapter::AttributeMessageAffectsExtensionPrimvars(msg)) {
                 return;
             }
             MObject node = adapter->GetNode();

--- a/lib/mayaHydra/hydraExtensions/mixedUtils.cpp
+++ b/lib/mayaHydra/hydraExtensions/mixedUtils.cpp
@@ -1259,7 +1259,8 @@ static bool ExtensionAttrValueEqualsDefault(const MPlug& attrPlug, const MObject
 }
 
 // Populate a dictionary with extension/dynamic attribute values for translation to Hydra primvars.
-// Only non-default values are included (dynamic attrs skip default checks).
+// Extension attributes: omit when still at default (isDefaultValue / manual default compare).
+// Dynamic attributes (e.g. Add Attribute UI): always included; default suppression is not applied.
 void GetExtensionAndDynamicAttributesFromNode(
     const MObject& node, PXR_NS::VtDictionary& attrs)
 {

--- a/lib/mayaHydra/hydraExtensions/mixedUtils.h
+++ b/lib/mayaHydra/hydraExtensions/mixedUtils.h
@@ -259,6 +259,9 @@ PXR_NS::TfToken GetGeomSubsetsPickMode();
 /**
  * @brief Get extension/dynamic attributes from a Maya node for translation to Hydra primvars.
  *
+ * Extension attributes are skipped while at their default. Dynamic attributes (user addAttr) are
+ * always collected regardless of default value.
+ *
  * @param[in] node is the node in the Maya scene graph.
  * @param[out] attrs is a map that will contain the attribute names and their corresponding values.
  */

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testCustomAttributeTypes.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testCustomAttributeTypes.cpp
@@ -72,7 +72,7 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 using namespace MayaHydra;
 
-// Unit test: verifies custom Maya extension attributes are translated into Hydra primvars.
+// Unit test: verifies Maya extension attributes (plugin-defined) are translated into Hydra primvars.
 namespace {
 
 // OptionVar to emit enum primvars as label tokens.

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testCustomAttributes.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testCustomAttributes.cpp
@@ -21,11 +21,13 @@
 #include <pxr/imaging/hd/tokens.h>
 #include <pxr/imaging/hd/primvarsSchema.h>
 
+#include <maya/MDGModifier.h>
 #include <maya/MGlobal.h>
 #include <maya/MFnDependencyNode.h>
 #include <maya/MFnNumericAttribute.h>
 #include <maya/MFnNumericData.h>
 #include <maya/MPlug.h>
+#include <maya/MStatus.h>
 #include <maya/MString.h>
 
 #include <gtest/gtest.h>
@@ -34,11 +36,13 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 using namespace MayaHydra;
 
-// Unit test: validates that only non-default extension/custom attributes are exposed as Hydra primvars.
+// Unit test: extension attributes (e.g. Arnold ai*): primvars appear for non-default values and
+// are omitted at default. User-added dynamic attrs skip default suppression in
+// GetExtensionAndDynamicAttributesFromNode; dynamicAttributeUndoRedoRefreshesPrimvars covers undo/redo.
 namespace {
 HdDataSourceLocator primvarsLocator = HdPrimvarsSchema::GetDefaultLocator();
 
-// What: default-valued extension/custom attributes should not emit primvars.
+// What: default-valued extension attributes should not emit primvars.
 // How: read aiAutobumpVisibility/aiSubdivIterations at default, then set non-default values.
 // Expect: default values yield no primvars; non-default values match reference primvar outputs.
 TEST(CustomAttributes, defaultArnoldCustomAttributes)
@@ -330,6 +334,81 @@ TEST(CustomAttributes, aiPrimvarsAppearAndRemovedWhenReset)
             absentReference))
             << "Light aiColorTemperature primvar should be removed when reset";
     }
+#else
+    GTEST_SKIP() << "Skipping test, configurable decimal streaming is unavailable.";
+#endif
+}
+
+// What: undo/redo of addAttr must refresh Hydra primvars (kAttributeRemoved / kAttributeAdded).
+// How: add a dynamic long on pCubeShape1 via MDGModifier; undo; redo; compare primvar data sources.
+// Expect: primvar present after add and redo; matches absent reference after undo.
+TEST(CustomAttributes, dynamicAttributeUndoRedoRefreshesPrimvars)
+{
+#ifdef CONFIGURABLE_DECIMAL_STREAMING_AVAILABLE
+    DecimalStreamingOverride decimalStreamingOverride(
+        { PXR_NS::TfDecimalToStringMode::FIXED, 5, false });
+
+    MGlobal::executeCommand("catchQuiet(`deleteAttr -at mhUndoRedoPrimvarTest pCubeShape1`);");
+
+    const SceneIndicesVector& sceneIndices = GetTerminalSceneIndices();
+    ASSERT_GT(sceneIndices.size(), 0u);
+
+    auto mayaSceneIndex = FindMayaHydraSceneIndex(sceneIndices.front());
+    ASSERT_TRUE(mayaSceneIndex) << "MayaHydraSceneIndex not found in scene index tree";
+
+    SceneIndexInspector sceneInspector(mayaSceneIndex);
+
+    PrimEntriesVector meshPrims
+        = sceneInspector.FindPrims(CreatePrimPredicate("pCube1", HdPrimTypeTokens->mesh));
+    ASSERT_EQ(meshPrims.size(), 1u) << "Mesh prim (pCube1) not found";
+    const SdfPath primPath = meshPrims.front().primPath;
+
+    MObject cubeNode;
+    ASSERT_TRUE(GetDependNodeFromNodeName("pCubeShape1", cubeNode));
+
+    MStatus             status;
+    MFnNumericAttribute nAttr;
+    MObject attrObj = nAttr.create(
+        "mhUndoRedoPrimvarTest", "mhURPT", MFnNumericData::kLong, 0.0, &status);
+    ASSERT_TRUE(status) << "Failed to create numeric attribute";
+    MDGModifier mod;
+    status = mod.addAttribute(cubeNode, attrObj);
+    ASSERT_TRUE(status) << "MDGModifier::addAttribute failed";
+    status = mod.doIt();
+    ASSERT_TRUE(status) << "MDGModifier::doIt failed";
+
+    const std::filesystem::path absentReference = getPathToSample("cube_primvar_absent.txt");
+    const std::filesystem::path presentRef
+        = getPathToSample("cube_primvar_mhUndoRedoPrimvarTest_present.txt");
+
+    MGlobal::executeCommand("refresh");
+    HdSceneIndexPrim prim = mayaSceneIndex->GetPrim(primPath);
+    EXPECT_TRUE(dataSourceMatchesReference(
+        HdContainerDataSource::Get(
+            prim.dataSource, primvarsLocator.Append(TfToken("mhUndoRedoPrimvarTest"))),
+        presentRef))
+        << "Dynamic attr should expose primvar after add. See "
+        << getDataSourceComparisonOutputPath(presentRef).string() << " for actual";
+
+    MGlobal::executeCommand("undo");
+    MGlobal::executeCommand("refresh");
+    prim = mayaSceneIndex->GetPrim(primPath);
+    EXPECT_TRUE(dataSourceMatchesReference(
+        HdContainerDataSource::Get(
+            prim.dataSource, primvarsLocator.Append(TfToken("mhUndoRedoPrimvarTest"))),
+        absentReference))
+        << "Primvar should disappear after undo of addAttr";
+
+    MGlobal::executeCommand("redo");
+    MGlobal::executeCommand("refresh");
+    prim = mayaSceneIndex->GetPrim(primPath);
+    EXPECT_TRUE(dataSourceMatchesReference(
+        HdContainerDataSource::Get(
+            prim.dataSource, primvarsLocator.Append(TfToken("mhUndoRedoPrimvarTest"))),
+        presentRef))
+        << "Primvar should return after redo";
+
+    MGlobal::executeCommand("catchQuiet(`deleteAttr -at mhUndoRedoPrimvarTest pCubeShape1`);");
 #else
     GTEST_SKIP() << "Skipping test, configurable decimal streaming is unavailable.";
 #endif

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testCustomAttributes.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testCustomAttributes.cpp
@@ -369,7 +369,7 @@ TEST(CustomAttributes, dynamicAttributeUndoRedoRefreshesPrimvars)
     MStatus             status;
     MFnNumericAttribute nAttr;
     MObject attrObj = nAttr.create(
-        "mhUndoRedoPrimvarTest", "mhURPT", MFnNumericData::kLong, 0.0, &status);
+        "mhUndoRedoPrimvarTest", "mhURPT", MFnNumericData::kLong, 0, &status);
     ASSERT_TRUE(status) << "Failed to create numeric attribute";
     MDGModifier mod;
     status = mod.addAttribute(cubeNode, attrObj);

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testCustomAttributes.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testCustomAttributes.cpp
@@ -339,8 +339,10 @@ TEST(CustomAttributes, aiPrimvarsAppearAndRemovedWhenReset)
 #endif
 }
 
-// What: undo/redo of addAttr must refresh Hydra primvars (kAttributeRemoved / kAttributeAdded).
-// How: add a dynamic long on pCubeShape1 via MDGModifier; undo; redo; compare primvar data sources.
+// What: undo/redo after adding a dynamic attr must refresh Hydra primvars (kAttributeRemoved /
+// kAttributeAdded).
+// How: add a dynamic long on pCubeShape1 via MDGModifier; undo/redo with the same MDGModifier
+// (global undo does not record bare MDGModifier::doIt()).
 // Expect: primvar present after add and redo; matches absent reference after undo.
 TEST(CustomAttributes, dynamicAttributeUndoRedoRefreshesPrimvars)
 {
@@ -390,23 +392,25 @@ TEST(CustomAttributes, dynamicAttributeUndoRedoRefreshesPrimvars)
         << "Dynamic attr should expose primvar after add. See "
         << getDataSourceComparisonOutputPath(presentRef).string() << " for actual";
 
-    MGlobal::executeCommand("undo");
+    status = mod.undoIt();
+    ASSERT_TRUE(status) << "MDGModifier::undoIt failed";
     MGlobal::executeCommand("refresh");
     prim = mayaSceneIndex->GetPrim(primPath);
     EXPECT_TRUE(dataSourceMatchesReference(
         HdContainerDataSource::Get(
             prim.dataSource, primvarsLocator.Append(TfToken("mhUndoRedoPrimvarTest"))),
         absentReference))
-        << "Primvar should disappear after undo of addAttr";
+        << "Primvar should disappear after MDGModifier::undoIt (addAttribute)";
 
-    MGlobal::executeCommand("redo");
+    status = mod.doIt();
+    ASSERT_TRUE(status) << "MDGModifier::doIt failed (redo addAttribute)";
     MGlobal::executeCommand("refresh");
     prim = mayaSceneIndex->GetPrim(primPath);
     EXPECT_TRUE(dataSourceMatchesReference(
         HdContainerDataSource::Get(
             prim.dataSource, primvarsLocator.Append(TfToken("mhUndoRedoPrimvarTest"))),
         presentRef))
-        << "Primvar should return after redo";
+        << "Primvar should return after MDGModifier::doIt redo";
 
     MGlobal::executeCommand("catchQuiet(`deleteAttr -at mhUndoRedoPrimvarTest pCubeShape1`);");
 #else


### PR DESCRIPTION
Fix: Attribute-changed callbacks now treat structural DG changes (kAttributeRemoved / kAttributeAdded / kAttributeRenamed, plus kAttributeSet) as primvar-relevant in render-item, camera, and light adapters, and invalidate the extension/dynamic primvar cache when plugs are invalid during removal.
Test: Added CustomAttributes.dynamicAttributeUndoRedoRefreshesPrimvars with a reference file to cover add → undo → redo on a dynamic mesh attribute.
Docs: Clarified extension vs dynamic default behavior in mixedUtils / tests and documented mesh adapter’s unfiltered attribute callback (delegates to shared base-adapter logic).