### PR TITLE
Check CONFIGURABLE_DECIMAL_STREAMING_AVAILABLE

### DIFF
--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testCustomAttributes.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testCustomAttributes.cpp
@@ -42,7 +42,8 @@ HdDataSourceLocator primvarsLocator = HdPrimvarsSchema::GetDefaultLocator();
 // How: read aiAutobumpVisibility/aiSubdivIterations at default, then set non-default values.
 // Expect: default values yield no primvars; non-default values match reference primvar outputs.
 TEST(CustomAttributes, defaultArnoldCustomAttributes)
-{ 
+{
+#ifdef CONFIGURABLE_DECIMAL_STREAMING_AVAILABLE
     const SceneIndicesVector& sceneIndices = GetTerminalSceneIndices();
     ASSERT_GT(sceneIndices.size(), 0u);
 
@@ -107,6 +108,9 @@ TEST(CustomAttributes, defaultArnoldCustomAttributes)
         HdContainerDataSource::Get(prim.dataSource, iterLocator),
         getPathToSample("cube_primvar_aiSubdivIterations_modified.txt")))
         << " See " << getDataSourceComparisonOutputPath(getPathToSample("cube_primvar_aiSubdivIterations_modified.txt")).string() << " for actual output";
+#else
+    GTEST_SKIP() << "Skipping test, configurable decimal streaming is unavailable.";
+#endif
 }
 
 // What: camera compound attributes should not emit primvars at default values.


### PR DESCRIPTION
"defaultArnoldCustomAttributes" uses PXR_NS::TfDecimalToString but neglected to check availability.