### PR TITLE
Handle duplicate fastIds in render item removal list

### DIFF
--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
@@ -458,7 +458,12 @@ void MayaHydraSceneIndex::UpdateRenderItems(const MDataServerOperation::MViewpor
         if (_GetRenderItem(fastId, ria)) {
             _RemoveRenderItem(ria);
         }
-        assert(ria != nullptr);
+        // The removal list can contain duplicate fastIds.  After the first
+        // removal succeeds, subsequent duplicates will not be found — skip
+        // them.
+        if (ria == nullptr) {
+            continue;
+        }
     }
 
     // My version, does minimal update


### PR DESCRIPTION
The removal list passed to UpdateRenderItems can contain duplicate fastIds.  After the first _RemoveRenderItem succeeds, subsequent lookups for the same id return nullptr.  The previous assert(ria != nullptr) fires in debug/non-NDEBUG builds when this happens.

Replace the assert with a nullptr check and continue, since a duplicate removal is benign — the item was already removed.