### PR TITLE
HYDRA-2235 : Skip some tests on OSX

### DIFF
--- a/test/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
+++ b/test/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
@@ -23,7 +23,7 @@ set(INTERACTIVE_TEST_SCRIPT_FILES
     testTransforms.py
     testRefinement.py
 	testNewSceneWithStage.py
-    testMayaShadingModes.py
+    testMayaShadingModes.py|skipOnPlatform:osx # HYDRA-1127 : refinedWire not working on OSX
     testMayaDisplayLayers.py
     testMayaIsolateSelect.py
 	#HYDRA-1940 temporarily disable this test which doesn't pass on Maya 2026
@@ -46,9 +46,9 @@ set(INTERACTIVE_TEST_SCRIPT_FILES
     testOpenPBRSurface.py
     testFlowViewportAPI.py
     testStagePayloadsReferences.py
-    testNurbsPrimitives.py
+    testNurbsPrimitives.py|skipOnPlatform:osx # HYDRA-1127 : refinedWire not working on OSX
     testCurveTools.py
-    testPolygonPrimitives.py
+    testPolygonPrimitives.py|skipOnPlatform:osx # HYDRA-1127 : refinedWire not working on OSX
     testFootPrintNode.py
     testBackgroundColor.py
     testGrid.py

--- a/test/lib/mayaUsd/render/mayaToHydra/testBasicRender.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/testBasicRender.py
@@ -19,6 +19,8 @@ import maya.mel
 
 import fixturesUtils
 import mtohUtils
+import platform
+import unittest
 
 from string import digits
 
@@ -66,6 +68,7 @@ class TestSnapshot(BasicRenderBaseTestCase):
 class TestMayaHydraRender(BasicRenderBaseTestCase):
     _file = __file__
 
+    @unittest.skipIf(platform.system() == "Darwin", 'HYDRA-1127 : wireframes are unstable on OSX.')
     def test_cube(self):
         imageVersion = maya.mel.eval("defaultShaderName").rstrip(digits)
 


### PR DESCRIPTION
Some OSX machines are having issues with these tests, which are using wireframes. Wireframes are not yet expected to fully work in OSX, so disable them for now.