### PR TITLE
Support of external cameras through scene index filters.

### DIFF
--- a/lib/flowViewport/API/renderViewData/fvpDataProducerSceneIndexDataBase.cpp
+++ b/lib/flowViewport/API/renderViewData/fvpDataProducerSceneIndexDataBase.cpp
@@ -108,6 +108,8 @@ void DataProducerSceneIndexDataBase::_CreateSceneIndexChainForUsdStageSceneIndex
         //Set the overridesSceneIndexCallback to insert our scene indices chain after the stage scene index and before the flatten scene index
         //If we don't do so, we cannot modify the transform or visibility to the children because of the flatten scene index in the usd stage chain.
         auto clientCallback = params._createInfo.overridesSceneIndexCallback;
+        // Allow additional chaining of scene indices through an input
+        // clientCallback.
         params._createInfo.overridesSceneIndexCallback =
             [this, clientCallback](HdSceneIndexBaseRefPtr const& input) {
                 auto si = input;

--- a/lib/flowViewport/API/renderViewData/fvpDataProducerSceneIndexDataBase.cpp
+++ b/lib/flowViewport/API/renderViewData/fvpDataProducerSceneIndexDataBase.cpp
@@ -107,7 +107,15 @@ void DataProducerSceneIndexDataBase::_CreateSceneIndexChainForUsdStageSceneIndex
     if (params._dccNode){
         //Set the overridesSceneIndexCallback to insert our scene indices chain after the stage scene index and before the flatten scene index
         //If we don't do so, we cannot modify the transform or visibility to the children because of the flatten scene index in the usd stage chain.
-        params._createInfo.overridesSceneIndexCallback = std::bind(&DataProducerSceneIndexDataBase::_CreateUsdStageSceneIndexChain, this, std::placeholders::_1);
+        auto clientCallback = params._createInfo.overridesSceneIndexCallback;
+        params._createInfo.overridesSceneIndexCallback =
+            [this, clientCallback](HdSceneIndexBaseRefPtr const& input) {
+                auto si = input;
+                if (clientCallback) {
+                    si = clientCallback(si);
+                }
+                return _CreateUsdStageSceneIndexChain(si);
+            };
     }
 
     //Create the scene indices chain

--- a/lib/mayaHydra/hydraExtensions/mayaUtils.cpp
+++ b/lib/mayaHydra/hydraExtensions/mayaUtils.cpp
@@ -146,6 +146,15 @@ bool IsDagPathALight(const MDagPath& dagPath)
     return (typeName.indexW(_lightString) != -1); // Does the typename contains "Light"
 }
 
+bool IsDagPathACamera(const MDagPath& dagPath)
+{
+    if (!dagPath.isValid())
+        return false;
+    auto shapeDagPath = dagPath;
+    shapeDagPath.extendToShape();
+    return shapeDagPath.hasFn(MFn::kCamera);
+}
+
 std::string GetDomeLightTexture(const MFnDependencyNode& lightNode)
 {
     // Be aware that dome lights in HdStorm always need a texture to work correctly,

--- a/lib/mayaHydra/hydraExtensions/mayaUtils.h
+++ b/lib/mayaHydra/hydraExtensions/mayaUtils.h
@@ -181,6 +181,9 @@ bool IsDagPathALight(const MDagPath& dagPath);
  *
  * Works whether dagPath points to the camera shape or its parent transform.
  *
+ * Checks support for MFn::kCamera, which is more general than the exact
+ * type match requirement of IsDagPathOfGivenType().
+ *
  * @param[in] dagPath is a MDagPath
  *
  * @return true if the object is a camera, false otherwise

--- a/lib/mayaHydra/hydraExtensions/mayaUtils.h
+++ b/lib/mayaHydra/hydraExtensions/mayaUtils.h
@@ -177,6 +177,17 @@ bool IsDagPathAnArnoldAreaLight(const MDagPath& dagPath);
 bool IsDagPathALight(const MDagPath& dagPath);
 
 /**
+ * @brief Get if this MDagPath is a camera.
+ *
+ * Works whether dagPath points to the camera shape or its parent transform.
+ *
+ * @param[in] dagPath is a MDagPath
+ *
+ * @return true if the object is a camera, false otherwise
+ */
+bool IsDagPathACamera(const MDagPath& dagPath);
+
+/**
  * @brief Retrieves the texture file path from a dome light node.
  *
  * This function extracts the texture file path from a Maya dome light node,

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/CMakeLists.txt
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/CMakeLists.txt
@@ -22,6 +22,8 @@ target_sources(${TARGET_NAME}
     mhMayaUsdProxyShapeSceneIndexBase.cpp
     mhMayaUsdProxyShapeSceneIndex.cpp
     mhDirtyLeadObjectSceneIndex.cpp
+    mhExternalCameraOverrideSceneIndex.cpp
+    mhExternalCameraResolvingSceneIndex.cpp
     mhGenerativeProceduralResolvingSceneIndex.cpp
 )
 
@@ -46,6 +48,8 @@ set(HEADERS
     mhMayaUsdProxyShapeSceneIndexBase.h
     mhMayaUsdProxyShapeSceneIndex.h
     mhDirtyLeadObjectSceneIndex.h
+    mhExternalCameraOverrideSceneIndex.h
+    mhExternalCameraResolvingSceneIndex.h
     mhGenerativeProceduralResolvingSceneIndex.h
 )
 

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
@@ -62,7 +62,8 @@ bool _UseTheShapeDagPath(const MDagPath& dagpath)
         || MayaHydra::IsDagPathACamera(dagpath);
 }
 
-// Check if this dag path is registered in Sprims (such as the Arnold sky dome light)
+// Check if this dag path is registered in Sprims, which includes lights
+// (such as the Arnold sky dome light) and cameras.
 bool _IsDagPathRegisteredInHydraSPrims(const MDagPath& dagpath)
 {
     return MayaHydra::IsDagPathALight(dagpath)

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
@@ -58,14 +58,15 @@ namespace {
 // For some dag paths we use the shape to translate it to an Hydra path
 bool _UseTheShapeDagPath(const MDagPath& dagpath)
 {
-    // Only for the Arnold skydome light
-    return MAYAHYDRA_NS_DEF::IsDagPathAnArnoldSkyDomeLight(dagpath);
+    return MayaHydra::IsDagPathAnArnoldSkyDomeLight(dagpath)
+        || MayaHydra::IsDagPathACamera(dagpath);
 }
 
 // Check if this dag path is registered in Sprims (such as the Arnold sky dome light)
 bool _IsDagPathRegisteredInHydraSPrims(const MDagPath& dagpath)
 {
-    return MAYAHYDRA_NS_DEF::IsDagPathALight(dagpath);
+    return MayaHydra::IsDagPathALight(dagpath)
+        || MayaHydra::IsDagPathACamera(dagpath);
 }
 
 } // namespace
@@ -653,36 +654,6 @@ Fvp::PrimSelections MayaHydraSceneIndex::UfePathToPrimSelections(const Ufe::Path
 
     const SdfPath primPath = GetPrimPath((extendToShape) ? shapeDagPath : dagPath, isSprim);
 
-    TF_DEBUG(MAYAHYDRALIB_SCENE_INDEX)
-        .Msg("    mapped to scene index path %s.\n", primPath.GetText());
-
-    return Fvp::PrimSelections({ Fvp::PrimSelection { primPath } });
-}
-
-Fvp::PrimSelections MayaHydraSceneIndex::UfePathToPrimSelectionsLit(const Ufe::Path& appPath) const
-{
-    TF_DEBUG(MAYAHYDRALIB_SCENE_INDEX)
-        .Msg(
-            "MayaHydraSceneIndex::UfePathToPrimSelectionsLit(const Ufe::Path& %s) called.\n",
-            Ufe::PathString::string(appPath).c_str());
-
-    // Same as UfePathToPrimSelections(), except returns the "Lighted"
-    // hierarchy.  Should not be required.  Having the path mapper call
-    // UfePathToPrimSelections() would allow factoring out into a single path
-    // mapper for Usd and Maya (see registration.cpp).
-    if (appPath.runTimeId() != UfeExtensions::getMayaRunTimeId()) {
-        return {};
-    }
-
-    // If the Maya node described by the appPath is in fact a path mapper
-    // registry entry, nothing to do, the path mapper for that entry will
-    // handle things.
-    if (Fvp::PathMapperRegistry::Instance().HasMapper(appPath)) {
-        return {};
-    }
-
-    SdfPath primPath = _rprimPath.AppendPath(toSdfPath(UfeExtensions::ufeToDagPath(appPath))
-                                                 .MakeRelativePath(SdfPath::AbsoluteRootPath()));
     TF_DEBUG(MAYAHYDRALIB_SCENE_INDEX)
         .Msg("    mapped to scene index path %s.\n", primPath.GetText());
 

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.h
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.h
@@ -203,7 +203,6 @@ public:
     bool IsHdSt() const { return _isHdSt; }
 
     Fvp::PrimSelections UfePathToPrimSelections(const Ufe::Path& appPath) const;
-    Fvp::PrimSelections UfePathToPrimSelectionsLit(const Ufe::Path& appPath) const;
 
     // Common function to return templated sample types
     template <typename T, typename Getter>

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mhExternalCameraOverrideSceneIndex.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mhExternalCameraOverrideSceneIndex.cpp
@@ -38,6 +38,9 @@ const TfToken kExternalCameraToken("adskUsd:externalCamera");
 // ExternalCameraResolvingSceneIndex.
 const SdfPath kExternalCameraPrefix("/__adskUsd__externalCamera");
 
+// External camera paths are either through USD (already uses '/' as a
+// separator), or through Maya (uses '|' as a separator, converted to '/' for
+// SdfPath representation).  We also erase the UFE path segment ',' separator.
 SdfPath SanitizeExternalPath(const std::string& rawValue)
 {
     std::string pathStr = rawValue;
@@ -76,6 +79,8 @@ MhExternalCameraOverrideSceneIndex::GetPrim(const SdfPath& primPath) const
         return prim;
     }
 
+    // Do special external camera override processing only if the prim is a
+    // render product or a render setting prim.
     TfToken schemaToken;
     if (prim.primType == HdPrimTypeTokens->renderSettings) {
         schemaToken = UsdImagingUsdRenderSettingsSchemaTokens->__usdRenderSettings;
@@ -97,6 +102,8 @@ MhExternalCameraOverrideSceneIndex::GetPrim(const SdfPath& primPath) const
         return prim;
     }
 
+    // If we don't have an external camera data source, nothing to do, return
+    // the prim unchanged.
     auto externalCameraDs =
         HdTypedSampledDataSource<std::string>::Cast(
             namespacedSettingsDs->Get(kExternalCameraToken));
@@ -110,6 +117,8 @@ MhExternalCameraOverrideSceneIndex::GetPrim(const SdfPath& primPath) const
     HdDataSourceLocator cameraLocator(
         schemaToken, UsdImagingUsdRenderSettingsSchemaTokens->camera);
 
+    // Overwrite or add the internal camera data source with the SdfPath
+    // representation of the external camera path, with its sentinel prefix.
     prim.dataSource = HdContainerDataSourceEditor(prim.dataSource)
         .Set(cameraLocator,
              HdRetainedTypedSampledDataSource<SdfPath>::New(sanitizedPath))

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mhExternalCameraOverrideSceneIndex.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mhExternalCameraOverrideSceneIndex.cpp
@@ -32,6 +32,10 @@ PXR_NAMESPACE_USING_DIRECTIVE
 namespace {
 
 const TfToken kExternalCameraToken("adskUsd:externalCamera");
+
+// Special Hydra SdfPath sentinel value used when setting the path to the
+// external camera. This will be detected and resolved later, by the
+// ExternalCameraResolvingSceneIndex.
 const SdfPath kExternalCameraPrefix("/__adskUsd__externalCamera");
 
 SdfPath SanitizeExternalPath(const std::string& rawValue)

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mhExternalCameraOverrideSceneIndex.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mhExternalCameraOverrideSceneIndex.cpp
@@ -1,0 +1,141 @@
+//
+// Copyright 2026 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "mhExternalCameraOverrideSceneIndex.h"
+
+#include <pxr/imaging/hd/containerDataSourceEditor.h>
+#include <pxr/imaging/hd/retainedDataSource.h>
+#include <pxr/imaging/hd/renderProductSchema.h>
+#include <pxr/imaging/hd/tokens.h>
+#include <pxr/usd/sdf/path.h>
+#include <pxr/usdImaging/usdImaging/usdRenderProductSchema.h>
+#include <pxr/usdImaging/usdImaging/usdRenderSettingsSchema.h>
+
+#include <algorithm>
+#include <string>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+namespace {
+
+const TfToken kExternalCameraToken("adskUsd:externalCamera");
+const SdfPath kExternalCameraPrefix("/__adskUsd__externalCamera");
+
+SdfPath SanitizeExternalPath(const std::string& rawValue)
+{
+    std::string pathStr = rawValue;
+
+    std::replace(pathStr.begin(), pathStr.end(), '|', '/');
+    pathStr.erase(std::remove(pathStr.begin(), pathStr.end(), ','), pathStr.end());
+
+    return kExternalCameraPrefix.AppendPath(SdfPath(pathStr).MakeRelativePath(SdfPath::AbsoluteRootPath()));
+}
+
+} // anonymous namespace
+
+namespace MAYAHYDRA_NS_DEF {
+
+MhExternalCameraOverrideSceneIndexRefPtr
+MhExternalCameraOverrideSceneIndex::New(
+    const HdSceneIndexBaseRefPtr& inputSceneIndex)
+{
+    return TfCreateRefPtr(
+        new MhExternalCameraOverrideSceneIndex(inputSceneIndex));
+}
+
+MhExternalCameraOverrideSceneIndex::MhExternalCameraOverrideSceneIndex(
+    const HdSceneIndexBaseRefPtr& inputSceneIndex)
+    : HdSingleInputFilteringSceneIndexBase(inputSceneIndex)
+    , InputSceneIndexUtils(inputSceneIndex)
+{
+}
+
+HdSceneIndexPrim
+MhExternalCameraOverrideSceneIndex::GetPrim(const SdfPath& primPath) const
+{
+    HdSceneIndexPrim prim = GetInputSceneIndex()->GetPrim(primPath);
+
+    if (!prim.dataSource) {
+        return prim;
+    }
+
+    TfToken schemaToken;
+    if (prim.primType == HdPrimTypeTokens->renderSettings) {
+        schemaToken = UsdImagingUsdRenderSettingsSchemaTokens->__usdRenderSettings;
+    } else if (prim.primType == HdRenderProductSchemaTokens->renderProduct) {
+        schemaToken = UsdImagingUsdRenderProductSchemaTokens->__usdRenderProduct;
+    } else {
+        return prim;
+    }
+
+    auto schemaDs = HdContainerDataSource::Cast(prim.dataSource->Get(schemaToken));
+    if (!schemaDs) {
+        return prim;
+    }
+
+    auto namespacedSettingsDs =
+        HdContainerDataSource::Cast(schemaDs->Get(
+            UsdImagingUsdRenderSettingsSchemaTokens->namespacedSettings));
+    if (!namespacedSettingsDs) {
+        return prim;
+    }
+
+    auto externalCameraDs =
+        HdTypedSampledDataSource<std::string>::Cast(
+            namespacedSettingsDs->Get(kExternalCameraToken));
+    if (!externalCameraDs) {
+        return prim;
+    }
+
+    const std::string rawValue = externalCameraDs->GetTypedValue(0);
+    const SdfPath sanitizedPath = SanitizeExternalPath(rawValue);
+
+    HdDataSourceLocator cameraLocator(
+        schemaToken, UsdImagingUsdRenderSettingsSchemaTokens->camera);
+
+    prim.dataSource = HdContainerDataSourceEditor(prim.dataSource)
+        .Set(cameraLocator,
+             HdRetainedTypedSampledDataSource<SdfPath>::New(sanitizedPath))
+        .Finish();
+
+    return prim;
+}
+
+void MhExternalCameraOverrideSceneIndex::_PrimsAdded(
+    const HdSceneIndexBase&                       sender,
+    const HdSceneIndexObserver::AddedPrimEntries& entries)
+{
+    if (!_IsObserved()) return;
+    _SendPrimsAdded(entries);
+}
+
+void MhExternalCameraOverrideSceneIndex::_PrimsRemoved(
+    const HdSceneIndexBase&                         sender,
+    const HdSceneIndexObserver::RemovedPrimEntries& entries)
+{
+    if (!_IsObserved()) return;
+    _SendPrimsRemoved(entries);
+}
+
+void MhExternalCameraOverrideSceneIndex::_PrimsDirtied(
+    const HdSceneIndexBase&                         sender,
+    const HdSceneIndexObserver::DirtiedPrimEntries& entries)
+{
+    if (!_IsObserved()) return;
+    _SendPrimsDirtied(entries);
+}
+
+} // namespace MAYAHYDRA_NS_DEF

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mhExternalCameraOverrideSceneIndex.h
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mhExternalCameraOverrideSceneIndex.h
@@ -1,0 +1,85 @@
+//
+// Copyright 2026 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef MAYA_HYDRA_EXTERNAL_CAMERA_OVERRIDE_SCENE_INDEX_H
+#define MAYA_HYDRA_EXTERNAL_CAMERA_OVERRIDE_SCENE_INDEX_H
+
+// MayaHydra headers
+#include "mayaHydraLib/api.h"
+
+// Flow viewport toolkit headers
+#include <flowViewport/sceneIndex/fvpSceneIndexUtils.h>
+
+// Usd/Hydra headers
+#include <pxr/imaging/hd/filteringSceneIndex.h>
+
+namespace MAYAHYDRA_NS_DEF {
+
+class MhExternalCameraOverrideSceneIndex;
+typedef PXR_NS::TfRefPtr<MhExternalCameraOverrideSceneIndex>
+    MhExternalCameraOverrideSceneIndexRefPtr;
+typedef PXR_NS::TfRefPtr<const MhExternalCameraOverrideSceneIndex>
+    MhExternalCameraOverrideSceneIndexConstRefPtr;
+
+/// \class MhExternalCameraOverrideSceneIndex
+///
+/// A filtering scene index that overrides the camera data source on
+/// renderSettings and renderProduct prims when an adskUsd:externalCamera key
+/// is present in their namespacedSettings.  The external camera path is
+/// sanitized ('|' -> '/', ',' stripped) and prefixed with
+/// "/__adskUsd__externalCamera" before being written into the camera field.
+///
+class MhExternalCameraOverrideSceneIndex
+    : public PXR_NS::HdSingleInputFilteringSceneIndexBase
+    , public Fvp::InputSceneIndexUtils<MhExternalCameraOverrideSceneIndex>
+{
+public:
+    using PXR_NS::HdSingleInputFilteringSceneIndexBase::_GetInputSceneIndex;
+
+    MAYAHYDRALIB_API
+    static MhExternalCameraOverrideSceneIndexRefPtr
+    New(const PXR_NS::HdSceneIndexBaseRefPtr& inputSceneIndex);
+
+    MAYAHYDRALIB_API
+    PXR_NS::HdSceneIndexPrim GetPrim(const PXR_NS::SdfPath& primPath) const override;
+
+    PXR_NS::SdfPathVector GetChildPrimPaths(const PXR_NS::SdfPath& primPath) const override
+    {
+        return GetInputSceneIndex()->GetChildPrimPaths(primPath);
+    }
+
+    ~MhExternalCameraOverrideSceneIndex() override = default;
+
+protected:
+    MhExternalCameraOverrideSceneIndex(
+        const PXR_NS::HdSceneIndexBaseRefPtr& inputSceneIndex);
+
+    void _PrimsAdded(
+        const PXR_NS::HdSceneIndexBase&                       sender,
+        const PXR_NS::HdSceneIndexObserver::AddedPrimEntries& entries) override;
+
+    void _PrimsRemoved(
+        const PXR_NS::HdSceneIndexBase&                         sender,
+        const PXR_NS::HdSceneIndexObserver::RemovedPrimEntries& entries) override;
+
+    void _PrimsDirtied(
+        const PXR_NS::HdSceneIndexBase&                         sender,
+        const PXR_NS::HdSceneIndexObserver::DirtiedPrimEntries& entries) override;
+};
+
+} // namespace MAYAHYDRA_NS_DEF
+
+#endif // MAYA_HYDRA_EXTERNAL_CAMERA_OVERRIDE_SCENE_INDEX_H

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mhExternalCameraResolvingSceneIndex.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mhExternalCameraResolvingSceneIndex.cpp
@@ -40,6 +40,10 @@ const TfToken kExternalCameraComponent("__adskUsd__externalCamera");
 SdfPath ResolveExternalCameraPath(const SdfPath& inputPath)
 {
     SdfPath appPath; // Application path to the external camera, in SdfPath form.
+
+    // Strip away all components up to and including the sentinel
+    // component. The output of this process is an application Ufe::Path,
+    // represented in SdfPath form.
     for (const SdfPath& prefix : inputPath.GetPrefixes()) {
         if (prefix.GetNameToken() == kExternalCameraComponent) {
             appPath = inputPath.ReplacePrefix(prefix, SdfPath::AbsoluteRootPath());
@@ -96,7 +100,7 @@ SdfPath ResolveExternalCameraPath(const SdfPath& inputPath)
     auto hydraPath = Fvp::ufePathToPrimSelections(appUfePath);
 
     // Camera is non-instanced, so there will be a single PrimSelection.
-    if (hydraPath.size() != 1) {
+    if (!TF_VERIFY(hydraPath.size() == 1)) {
         return inputPath;
     }
     return hydraPath[0].primPath;
@@ -195,6 +199,7 @@ ExternalCameraResolvingSceneIndex::GetPrim(const SdfPath& primPath) const
 {
     HdSceneIndexPrim prim = GetInputSceneIndex()->GetPrim(primPath);
 
+    // If prim isn't a Hydra render settings prim, return it unchanged.
     if (!prim.dataSource
         || prim.primType != HdPrimTypeTokens->renderSettings) {
         return prim;
@@ -206,6 +211,8 @@ ExternalCameraResolvingSceneIndex::GetPrim(const SdfPath& primPath) const
         return prim;
     }
 
+    // If the render settings prim doesn't have render products, return it
+    // unchanged.
     auto renderProductsDs = HdVectorDataSource::Cast(
         renderSettingsDs->Get(HdRenderSettingsSchemaTokens->renderProducts));
     if (!renderProductsDs) {

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mhExternalCameraResolvingSceneIndex.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mhExternalCameraResolvingSceneIndex.cpp
@@ -223,6 +223,7 @@ ExternalCameraResolvingSceneIndex::GetPrim(const SdfPath& primPath) const
         HdRenderSettingsSchemaTokens->renderSettings,
         HdRenderSettingsSchemaTokens->renderProducts);
 
+    // Resolve external cameras for all render products.
     prim.dataSource = HdContainerDataSourceEditor(prim.dataSource)
         .Set(productsLocator,
              _ResolvedRenderProductsDataSource::New(renderProductsDs))

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mhExternalCameraResolvingSceneIndex.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mhExternalCameraResolvingSceneIndex.cpp
@@ -1,0 +1,251 @@
+//
+// Copyright 2026 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "mhExternalCameraResolvingSceneIndex.h"
+
+#include <ufeExtensions/Global.h>
+
+#include <flowViewport/selection/fvpPathMapperRegistry.h>
+
+#include <pxr/imaging/hd/containerDataSourceEditor.h>
+#include <pxr/imaging/hd/dataSource.h>
+#include <pxr/imaging/hd/retainedDataSource.h>
+#include <pxr/imaging/hd/renderProductSchema.h>
+#include <pxr/imaging/hd/renderSettingsSchema.h>
+#include <pxr/imaging/hd/tokens.h>
+#include <pxr/usd/sdf/path.h>
+
+#include <ufe/path.h>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+using namespace UfeExtensions;
+
+namespace {
+
+const TfToken kExternalCameraComponent("__adskUsd__externalCamera");
+
+SdfPath ResolveExternalCameraPath(const SdfPath& inputPath)
+{
+    SdfPath appPath; // Application path to the external camera, in SdfPath form.
+    for (const SdfPath& prefix : inputPath.GetPrefixes()) {
+        if (prefix.GetNameToken() == kExternalCameraComponent) {
+            appPath = inputPath.ReplacePrefix(prefix, SdfPath::AbsoluteRootPath());
+            break;
+        }
+    }
+    if (appPath.IsEmpty()) {
+        return inputPath;
+    }
+
+    // We are within a call to GetPrim(), which must be thread safe.
+    //
+    // Use the path mapper to map the app path to the actual Hydra camera path.
+    // At this point the camera app path is represented as an SdfPath, with each
+    // SdfPath component corresponding to a Ufe::PathComponent.
+    // 
+    // Convert the SdfPath to a Ufe::Path, for path mapper lookup.  Ufe::Path
+    // construction is NOT thread safe, because Ufe::PathComponent creation is
+    // not thread safe (insertion into the Ufe::PathComponent StringTable is
+    // not thread safe).  However, because data access through the Maya API is
+    // not thread safe, we already restrict Hydra batch rendering to be single
+    // threaded (HYDRA-1919), and no Ufe::Path creation occurs in the batch
+    // rendering main thread, so thread safety during batch rendering is not a
+    // concern at time of writing (2026-05-06).
+    //
+    // If we remove the Hydra batch rendering single threaded restriction, a
+    // way to guarantee thread safety in the following code is to create the
+    // Ufe::PathComponent's for each camera Ufe::Path's ahead of time, so that
+    // at GetPrim() call time, no Ufe::PathComponent creation occurs.  This
+    // would be done in the following way, and only for the chosen USD render
+    // settings prim, as cameras in render settings that are not used do not
+    // need to be resolved.
+    //
+    // Before rendering (i.e. in a single threaded execution context), we
+    // inspect the render settings prim and all render product prims for the
+    // presence of an external camera, described as a UFE path string.  For any
+    // such camera, simply convert the UFE path string to a Ufe::Path, which
+    // will insert any missing Ufe::PathComponent into the Ufe::PathComponent
+    // StringTable.  As no entry can be removed from the StringTable, this will
+    // guarantee the existence of all Ufe::PathComponent's for the chosen
+    // external cameras.
+    //
+    // An obvious other alternative is to make the Ufe::PathComponent
+    // StringTable thread safe in a future UFE version (with single writer,
+    // multiple reader behavior), which has been considered in the past, but
+    // this requires UFE versus Maya TBB configuration management.
+
+    Ufe::PathSegment::Components components;
+    components.push_back(Ufe::PathComponent("world"));
+    for (const SdfPath& prefix : appPath.GetPrefixes()) {
+        components.push_back(prefix.GetNameToken().GetString());
+    }
+    Ufe::Path appUfePath(Ufe::PathSegment(components, getMayaRunTimeId(), '|'));
+    auto hydraPath = Fvp::ufePathToPrimSelections(appUfePath);
+
+    // Camera is non-instanced, so there will be a single PrimSelection.
+    if (hydraPath.size() != 1) {
+        return inputPath;
+    }
+    return hydraPath[0].primPath;
+}
+
+/// Wraps a single render product container, overriding cameraPrim when it
+/// contains the __adskUsd__externalCamera sentinel component.
+class _ResolvedRenderProductDataSource : public HdContainerDataSource
+{
+public:
+    HD_DECLARE_DATASOURCE(_ResolvedRenderProductDataSource);
+
+    TfTokenVector GetNames() override
+    {
+        return _input->GetNames();
+    }
+
+    HdDataSourceBaseHandle Get(const TfToken& name) override
+    {
+        if (name == HdRenderProductSchemaTokens->cameraPrim) {
+            auto cameraPrimDs = HdTypedSampledDataSource<SdfPath>::Cast(
+                _input->Get(HdRenderProductSchemaTokens->cameraPrim));
+            if (cameraPrimDs) {
+                const SdfPath resolved =
+                    ResolveExternalCameraPath(cameraPrimDs->GetTypedValue(0));
+                if (resolved != cameraPrimDs->GetTypedValue(0)) {
+                    return HdRetainedTypedSampledDataSource<SdfPath>::New(resolved);
+                }
+            }
+        }
+        return _input->Get(name);
+    }
+
+private:
+    _ResolvedRenderProductDataSource(
+        const HdContainerDataSourceHandle& input)
+        : _input(input)
+    {
+    }
+
+    HdContainerDataSourceHandle _input;
+};
+
+/// Wraps the renderProducts vector, returning resolved wrappers for each
+/// element.
+class _ResolvedRenderProductsDataSource : public HdVectorDataSource
+{
+public:
+    HD_DECLARE_DATASOURCE(_ResolvedRenderProductsDataSource);
+
+    size_t GetNumElements() override
+    {
+        return _input->GetNumElements();
+    }
+
+    HdDataSourceBaseHandle GetElement(size_t element) override
+    {
+        auto child = _input->GetElement(element);
+        if (auto childContainer = HdContainerDataSource::Cast(child)) {
+            return _ResolvedRenderProductDataSource::New(childContainer);
+        }
+        return child;
+    }
+
+private:
+    _ResolvedRenderProductsDataSource(
+        const HdVectorDataSourceHandle& input)
+        : _input(input)
+    {
+    }
+
+    HdVectorDataSourceHandle _input;
+};
+
+} // anonymous namespace
+
+namespace MAYAHYDRA_NS_DEF {
+
+ExternalCameraResolvingSceneIndexRefPtr
+ExternalCameraResolvingSceneIndex::New(
+    const HdSceneIndexBaseRefPtr& inputSceneIndex)
+{
+    return TfCreateRefPtr(
+        new ExternalCameraResolvingSceneIndex(inputSceneIndex));
+}
+
+ExternalCameraResolvingSceneIndex::ExternalCameraResolvingSceneIndex(
+    const HdSceneIndexBaseRefPtr& inputSceneIndex)
+    : HdSingleInputFilteringSceneIndexBase(inputSceneIndex)
+    , InputSceneIndexUtils(inputSceneIndex)
+{
+}
+
+HdSceneIndexPrim
+ExternalCameraResolvingSceneIndex::GetPrim(const SdfPath& primPath) const
+{
+    HdSceneIndexPrim prim = GetInputSceneIndex()->GetPrim(primPath);
+
+    if (!prim.dataSource
+        || prim.primType != HdPrimTypeTokens->renderSettings) {
+        return prim;
+    }
+
+    auto renderSettingsDs = HdContainerDataSource::Cast(
+        prim.dataSource->Get(HdRenderSettingsSchemaTokens->renderSettings));
+    if (!renderSettingsDs) {
+        return prim;
+    }
+
+    auto renderProductsDs = HdVectorDataSource::Cast(
+        renderSettingsDs->Get(HdRenderSettingsSchemaTokens->renderProducts));
+    if (!renderProductsDs) {
+        return prim;
+    }
+
+    HdDataSourceLocator productsLocator(
+        HdRenderSettingsSchemaTokens->renderSettings,
+        HdRenderSettingsSchemaTokens->renderProducts);
+
+    prim.dataSource = HdContainerDataSourceEditor(prim.dataSource)
+        .Set(productsLocator,
+             _ResolvedRenderProductsDataSource::New(renderProductsDs))
+        .Finish();
+
+    return prim;
+}
+
+void ExternalCameraResolvingSceneIndex::_PrimsAdded(
+    const HdSceneIndexBase&                       sender,
+    const HdSceneIndexObserver::AddedPrimEntries& entries)
+{
+    if (!_IsObserved()) return;
+    _SendPrimsAdded(entries);
+}
+
+void ExternalCameraResolvingSceneIndex::_PrimsRemoved(
+    const HdSceneIndexBase&                         sender,
+    const HdSceneIndexObserver::RemovedPrimEntries& entries)
+{
+    if (!_IsObserved()) return;
+    _SendPrimsRemoved(entries);
+}
+
+void ExternalCameraResolvingSceneIndex::_PrimsDirtied(
+    const HdSceneIndexBase&                         sender,
+    const HdSceneIndexObserver::DirtiedPrimEntries& entries)
+{
+    if (!_IsObserved()) return;
+    _SendPrimsDirtied(entries);
+}
+
+} // namespace MAYAHYDRA_NS_DEF

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mhExternalCameraResolvingSceneIndex.h
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mhExternalCameraResolvingSceneIndex.h
@@ -1,0 +1,85 @@
+//
+// Copyright 2026 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef MAYA_HYDRA_EXTERNAL_CAMERA_RESOLVING_SCENE_INDEX_H
+#define MAYA_HYDRA_EXTERNAL_CAMERA_RESOLVING_SCENE_INDEX_H
+
+// MayaHydra headers
+#include "mayaHydraLib/api.h"
+
+// Flow viewport toolkit headers
+#include <flowViewport/sceneIndex/fvpSceneIndexUtils.h>
+
+// Usd/Hydra headers
+#include <pxr/imaging/hd/filteringSceneIndex.h>
+
+namespace MAYAHYDRA_NS_DEF {
+
+class ExternalCameraResolvingSceneIndex;
+typedef PXR_NS::TfRefPtr<ExternalCameraResolvingSceneIndex>
+    ExternalCameraResolvingSceneIndexRefPtr;
+typedef PXR_NS::TfRefPtr<const ExternalCameraResolvingSceneIndex>
+    ExternalCameraResolvingSceneIndexConstRefPtr;
+
+/// \class ExternalCameraResolvingSceneIndex
+///
+/// A filtering scene index that resolves external camera paths in
+/// renderSettings prims.  For each render product under
+/// renderSettings.renderProducts, if the cameraPrim SdfPath contains
+/// a "__adskUsd__externalCamera" component, the path prefix up to and
+/// including that component is stripped, leaving the actual camera path.
+///
+class ExternalCameraResolvingSceneIndex
+    : public PXR_NS::HdSingleInputFilteringSceneIndexBase
+    , public Fvp::InputSceneIndexUtils<ExternalCameraResolvingSceneIndex>
+{
+public:
+    using PXR_NS::HdSingleInputFilteringSceneIndexBase::_GetInputSceneIndex;
+
+    MAYAHYDRALIB_API
+    static ExternalCameraResolvingSceneIndexRefPtr
+    New(const PXR_NS::HdSceneIndexBaseRefPtr& inputSceneIndex);
+
+    MAYAHYDRALIB_API
+    PXR_NS::HdSceneIndexPrim GetPrim(const PXR_NS::SdfPath& primPath) const override;
+
+    PXR_NS::SdfPathVector GetChildPrimPaths(const PXR_NS::SdfPath& primPath) const override
+    {
+        return GetInputSceneIndex()->GetChildPrimPaths(primPath);
+    }
+
+    ~ExternalCameraResolvingSceneIndex() override = default;
+
+protected:
+    ExternalCameraResolvingSceneIndex(
+        const PXR_NS::HdSceneIndexBaseRefPtr& inputSceneIndex);
+
+    void _PrimsAdded(
+        const PXR_NS::HdSceneIndexBase&                       sender,
+        const PXR_NS::HdSceneIndexObserver::AddedPrimEntries& entries) override;
+
+    void _PrimsRemoved(
+        const PXR_NS::HdSceneIndexBase&                         sender,
+        const PXR_NS::HdSceneIndexObserver::RemovedPrimEntries& entries) override;
+
+    void _PrimsDirtied(
+        const PXR_NS::HdSceneIndexBase&                         sender,
+        const PXR_NS::HdSceneIndexObserver::DirtiedPrimEntries& entries) override;
+};
+
+} // namespace MAYAHYDRA_NS_DEF
+
+#endif // MAYA_HYDRA_EXTERNAL_CAMERA_RESOLVING_SCENE_INDEX_H

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mhExternalCameraResolvingSceneIndex.h
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mhExternalCameraResolvingSceneIndex.h
@@ -36,12 +36,18 @@ typedef PXR_NS::TfRefPtr<const ExternalCameraResolvingSceneIndex>
 
 /// \class ExternalCameraResolvingSceneIndex
 ///
-/// A filtering scene index that resolves external camera paths in
-/// renderSettings prims.  For each render product under
-/// renderSettings.renderProducts, if the cameraPrim SdfPath contains
-/// a "__adskUsd__externalCamera" component, the path prefix up to and
-/// including that component is stripped, leaving the actual camera path.
-///
+/// The ExternalCameraResolvingSceneIndex is a filtering scene index that does
+/// the final external camera path resolution in renderSettings prims. For a
+/// flattened Hydra render settings prim, it will look at the camera path for
+/// all render products. If the special external camera path component
+/// "__adskUsd__externalCamera" sentinel value is present in the camera path,
+/// the path components following the sentinel value represent an application
+/// Ufe::Path to the camera, represented in SdfPath form.  The path prefix up
+/// to and including the sentinel component is stripped, leaving the actual
+/// application camera path.  It will then invoke the path mapper on that
+/// external camera application path to convert it to a Hydra scene SdfPath,
+/// which completes the external camera support.
+
 class ExternalCameraResolvingSceneIndex
     : public PXR_NS::HdSingleInputFilteringSceneIndexBase
     , public Fvp::InputSceneIndexUtils<ExternalCameraResolvingSceneIndex>

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/registration.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/registration.cpp
@@ -16,6 +16,8 @@
 
 #include "mayaHydraLib/mixedUtils.h"
 #include "mayaHydraLib/sceneIndex/registration.h"
+#include "mayaHydraLib/sceneIndex/mhExternalCameraOverrideSceneIndex.h"
+#include "mayaHydraLib/sceneIndex/mhExternalCameraResolvingSceneIndex.h"
 #include "mayaHydraLib/sceneIndex/mhMayaUsdProxyShapeSceneIndex.h"
 
 #include <flowViewport/sceneIndex/fvpSceneIndexUtils.h>
@@ -206,7 +208,10 @@ void MayaHydraSceneIndexRegistry::_AddSceneIndexForNode(MObject& dagNode)
     //With this callback you can insert some scene indices which will be applied before the prototype scene indices.
     //This will be done inside Fvp::DataProducerSceneIndexInterfaceImp::get().addUsdStageSceneIndex later
     UsdImagingCreateSceneIndicesInfo createInfo;
-        
+    createInfo.overridesSceneIndexCallback = [](HdSceneIndexBaseRefPtr const& inputSi) {
+        return MayaHydra::MhExternalCameraOverrideSceneIndex::New(inputSi);
+    };
+
     auto stage = proxyStage.getUsdStage();
     // Check whether the pseudo-root has children
     if (stage && (!stage->GetPseudoRoot().GetChildren().empty())) {
@@ -246,6 +251,8 @@ void MayaHydraSceneIndexRegistry::_AddSceneIndexForNode(MObject& dagNode)
         registration->pluginSceneIndex,
         registration->sceneIndexPathPrefix);
 
+    auto externalCameraResolvingSi = MayaHydra::ExternalCameraResolvingSceneIndex::New(pfsi);
+
     // Add a scene index that enforces a coherent prim removal + prim retrieval behavior.
     // This is to work around a bug in OpenUSD with the UsdImagingDrawModeSceneIndex where 
     // it can send PrimsRemoved notifications, but still return valid prims and prim paths 
@@ -254,7 +261,7 @@ void MayaHydraSceneIndexRegistry::_AddSceneIndexForNode(MObject& dagNode)
     // change in HdMergingSceneIndex : 
     // https://github.com/PixarAnimationStudios/OpenUSD/blob/v25.08/pxr/imaging/hd/mergingSceneIndex.cpp#L507-L533
     // See fvpPrimRemovalEnforcingSceneIndex.h for a more detailed breakdown of the issue.
-    auto primRemovalSi = Fvp::PrimRemovalEnforcingSceneIndex::New(pfsi);
+    auto primRemovalSi = Fvp::PrimRemovalEnforcingSceneIndex::New(externalCameraResolvingSi);
 
     registration->rootSceneIndex = primRemovalSi;
 

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/registration.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/registration.cpp
@@ -208,6 +208,9 @@ void MayaHydraSceneIndexRegistry::_AddSceneIndexForNode(MObject& dagNode)
     //With this callback you can insert some scene indices which will be applied before the prototype scene indices.
     //This will be done inside Fvp::DataProducerSceneIndexInterfaceImp::get().addUsdStageSceneIndex later
     UsdImagingCreateSceneIndicesInfo createInfo;
+    // Insert the ExternalCameraOverrideSceneIndex into the scene index
+    // chain. This callback will be applied by the
+    // Fvp::DataProducerSceneIndexDataBase.
     createInfo.overridesSceneIndexCallback = [](HdSceneIndexBaseRefPtr const& inputSi) {
         return MayaHydra::MhExternalCameraOverrideSceneIndex::New(inputSi);
     };


### PR DESCRIPTION
Maya Hydra supports USD render settings.  In a Maya scene the USD render settings can come from a default render settings node, or any MayaUsdProxyShape stage.

To support cameras in USD render prims and USD render products that come from outside the USD stage where the render prim and render products are defined, a special adskUsd:externalCamera attribute can be defined.  This holds the UFE path to the chosen camera, which can therefore come from the Maya data model, or any MayaUsdProxyShape.

This external camera follows the USD render settings behavior, where a render prim camera is propagated (flattened) to all render products, except those that already have a camera.

If a render prim (or render product) has both an internal and an external camera, the external camera is chosen for that prim, and the internal camera is ignored.  Normal USD render settings flattening behavior is then invoked.

Architecturally, the support is done through two filtering scene indices.

The first is the ExternalCameraOverrideSceneIndex, which detects the presence of an external camera, and sets / replaces the camera on that Hydra render setting or render product prim.  The camera path is given a special sentinel value prefix, for later resolution, and the rest of the camera SdfPath is actually the application Ufe::Path to the external camera.  The prim then goes through the standard UsdImagingRenderSettingsFlatteningSceneIndex, which creates the Hydra render settings data source, and propagates the camera from the render settings prim to the render products, if required.

After the UsdImagingRenderSettingsFlatteningSceneIndex, the standard HdPrefixingSceneIndex filter is run, which places prims in their final location in the Hydra scene hierarchy.

Then, the second external camera filtering scene index runs, which is the ExternalCameraResolvingSceneIndex.  This filtering scene index detects the special sentinel value, and calls the Fvp::PathMapper service to map the application Ufe::Path to the properly resolved Hydra SdfPath for the camera.

