### PR TITLE
HYDRA-2235 : Fix or suppress certain warnings on Linux

### DIFF
--- a/cmake/compiler_config.cmake
+++ b/cmake/compiler_config.cmake
@@ -20,6 +20,12 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         )
 endif()
 
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    list(APPEND GNU_CLANG_FLAGS
+        -Wno-error=maybe-uninitialized # GCC false-positive workaround
+    )
+endif()
+
 set(CLANG_FLAGS
     -MP
     -frtti

--- a/cmake/compiler_config.cmake
+++ b/cmake/compiler_config.cmake
@@ -22,7 +22,10 @@ endif()
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     list(APPEND GNU_CLANG_FLAGS
-        -Wno-error=maybe-uninitialized # GCC false-positive workaround
+        # GCC can emit false-positives for this warning.
+        # We hit this with a combination of inlined calls + a std::swap
+        # in USD's VtValue::UncheckedGet.
+        -Wno-error=maybe-uninitialized
     )
 endif()
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -9,3 +9,13 @@ set(ENABLE_DRAW_ORDER OFF)
 # Disable tests for HVT.
 set(ENABLE_TESTS OFF)
 add_subdirectory(hydra-viewport-toolbox)
+
+# FIXME HYDRA-2275 : Demote -Wmaybe-uninitialized from error to warning for HVT targets.
+# Some Linux machines/compilers are stricter than others about this.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    foreach(_hvt_target hvt hvt_engine hvt_dataSource hvt_geometry hvt_sceneIndex hvt_shadow hvt_tasks hvt_utils)
+        if(TARGET ${_hvt_target})
+            target_compile_options(${_hvt_target} PRIVATE -Wno-error=maybe-uninitialized)
+        endif()
+    endforeach()
+endif()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -12,7 +12,7 @@ add_subdirectory(hydra-viewport-toolbox)
 
 # FIXME HYDRA-2275 : Demote -Wmaybe-uninitialized from error to warning for HVT targets.
 # Some Linux machines/compilers are stricter than others about this.
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     foreach(_hvt_target hvt hvt_engine hvt_dataSource hvt_geometry hvt_sceneIndex hvt_shadow hvt_tasks hvt_utils)
         if(TARGET ${_hvt_target})
             target_compile_options(${_hvt_target} PRIVATE -Wno-error=maybe-uninitialized)

--- a/lib/mayaHydra/mayaPlugin/viewCommand.cpp
+++ b/lib/mayaHydra/mayaPlugin/viewCommand.cpp
@@ -227,8 +227,8 @@ MStatus MtohViewCmd::doIt(const MArgList& args)
         if (db.getFlagArgument(_updateRenderGlobals, 0, attrFlag) == MS::kSuccess) {
             bool          userDefaults = db.isFlagSet(_userDefaultsId);
             const TfToken attrName(attrFlag.asChar());
-            auto&         inst = MtohRenderGlobals::GlobalChanged(
-                { attrName, false, userDefaults }, storeUserSettings);
+            MtohRenderGlobals::GlobalParams params = { attrName, false, userDefaults };
+            auto&         inst = MtohRenderGlobals::GlobalChanged(params, storeUserSettings);
             MtohRenderOverride::UpdateRenderGlobals(inst, attrName);
             return MS::kSuccess;
         }


### PR DESCRIPTION
Some Linux machines and compilers are stricter or have false positives. Handle these.