### PR TITLE
Configure render delegate to use scene render settings.

### DIFF
--- a/lib/mayaHydra/mayaPlugin/CMakeLists.txt
+++ b/lib/mayaHydra/mayaPlugin/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(${TARGET_NAME}
         batchRendering/hydraRenderCmdHydraV2RenderSettings.cpp
         batchRendering/hydraRenderCmdMayaRenderSettings.cpp
         batchRendering/renderVarUtils.cpp
+        batchRendering/tokens.cpp
         colorNotFoundException.cpp
         envSettings.cpp
         mayaColorPreferencesTranslator.cpp

--- a/lib/mayaHydra/mayaPlugin/batchRendering/batchRenderer.cpp
+++ b/lib/mayaHydra/mayaPlugin/batchRendering/batchRenderer.cpp
@@ -18,6 +18,7 @@
 #include "batchRendererHydraV1RenderSettings.h"
 #include "batchRendererHydraV2RenderSettings.h"
 #include "batchRendererMayaRenderSettings.h"
+#include "tokens.h"
 
 #include "pluginDebugCodes.h"
 #include "renderSettingsUtils.h"
@@ -396,6 +397,13 @@ void BatchRenderer::_InitHydraResources()
     _taskController->SetEnablePresentation(false);
     _renderDelegate->SetRenderSetting(
         HdRenderSettingsTokens->enableInteractive, VtValue(false));
+
+    // Tell render delegate to read render settings from the Hydra
+    // scene (Hydra v2 render settings), rather than from the render
+    // settings map (Hydra v1 render settings).  This is an
+    // Autodesk-specific convention which render delegate providers
+    // can use.
+    _renderDelegate->SetRenderSetting(BatchRenderTokens->renderSettingsSrc, VtValue(BatchRenderTokens->hydraSceneRenderSettingsSrc));
 
     // Support a USD stage providing the render settings through prims in the
     // Hydra scene.  Hydra Prman supports this when the

--- a/lib/mayaHydra/mayaPlugin/batchRendering/tokens.cpp
+++ b/lib/mayaHydra/mayaPlugin/batchRendering/tokens.cpp
@@ -1,0 +1,50 @@
+//
+// Copyright 2016 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+// Copyright 2026 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "tokens.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+// clang-format off
+TF_DEFINE_PUBLIC_TOKENS(
+    BatchRenderTokens,
+
+    BATCH_RENDER_TOKENS
+);
+// clang-format on
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaHydra/mayaPlugin/batchRendering/tokens.h
+++ b/lib/mayaHydra/mayaPlugin/batchRendering/tokens.h
@@ -1,0 +1,57 @@
+//
+// Copyright 2016 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+// Copyright 2026 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef BATCH_RENDER_TOKENS_H
+#define BATCH_RENDER_TOKENS_H
+
+#include <pxr/base/tf/staticTokens.h>
+#include <pxr/pxr.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+// clang-format off
+#define BATCH_RENDER_TOKENS \
+    (renderSettingsSrc) \
+    (settingsMapRenderSettingsSrc) \
+    (hydraSceneRenderSettingsSrc)
+// clang-format on
+
+TF_DECLARE_PUBLIC_TOKENS(BatchRenderTokens, , BATCH_RENDER_TOKENS);
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // BATCH_RENDER_TOKENS_H


### PR DESCRIPTION
After discussion with the Arnold team, we will use a Hydra v1 render setting to determine whether the render delegate should read render settings from the Hydra v1 HdRenderSettingsMap or from the Hydra scene (Hydra v2).
