### PR TITLE
HYDRA-1919 : Disable Hydra parallel RPrim sync and remove dg_access_mutex

### DIFF
--- a/lib/mayaHydra/hydraExtensions/adapters/adapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/adapter.cpp
@@ -44,9 +44,6 @@ TF_REGISTRY_FUNCTION(TfType) { TfType::Define<MayaHydraAdapter>(); }
 
 namespace {
 
-using LockType = std::recursive_mutex;
-LockType dg_access_mutex;
-
 void _preRemoval(MObject& node, void* clientData)
 {
     TF_UNUSED(node);
@@ -151,8 +148,6 @@ HdPrimvarDescriptorVector MayaHydraAdapter::GetPrimvarDescriptors(HdInterpolatio
     // All extension/dynamic attributes as custom primvars.
     if (interpolation == HdInterpolationConstant) {
         if (_extAttrMapNeedUpdate) {
-            // Apply a global lock to avoid race condition while doing parallel DG node evaluation.
-            std::lock_guard<LockType> lock(dg_access_mutex);
             MAYAHYDRA_NS::GetExtensionAndDynamicAttributesFromNode(
                 GetNode(),
                 _extAttrNameToValueMap);

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraDataSource.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraDataSource.cpp
@@ -52,11 +52,6 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-namespace {
-    using LockType = std::recursive_mutex;
-    LockType dg_access_mutex;
-}
-
 MayaHydraDataSource::MayaHydraDataSource(
     const SdfPath& id,
     TfToken type,
@@ -127,9 +122,6 @@ MayaHydraDataSource::GetNames()
 HdDataSourceBaseHandle
 MayaHydraDataSource::Get(const TfToken& name)
 {
-    // Apply a global lock to avoid race condition while doing parallel DG node evaluation.
-    std::lock_guard<LockType> lock(dg_access_mutex);
-
     if (name == HdMeshSchemaTokens->mesh) {
         if (_type == HdPrimTypeTokens->mesh) {
             auto topology = _adapter->GetMeshTopology();

--- a/lib/mayaHydra/mayaPlugin/plugin.cpp
+++ b/lib/mayaHydra/mayaPlugin/plugin.cpp
@@ -36,6 +36,8 @@
 
 #include <pxr/base/plug/plugin.h>
 #include <pxr/base/plug/registry.h>
+#include <pxr/base/tf/debug.h>
+#include <pxr/imaging/hd/debugCodes.h>
 
 #include <mayaUsdAPI/utils.h>
 
@@ -212,6 +214,10 @@ void onFileOpenCheckOrCreateRenderSettings(void* /*clientData*/)
 
 void initialize()
 {
+    // HYDRA-1919: Maya DG API is not thread-safe. Disable Hydra's parallel
+    // RPrim sync until proper Maya EM integration lands.
+    PXR_NS::TfDebug::Enable(PXR_NS::HD_DISABLE_MULTITHREADED_RPRIM_SYNC);
+
     Fvp::InitializationParams fvpInitParams;
     if (MGlobal::mayaState() != MGlobal::kBatch) {
         // MayaColorPreferencesTranslator ctor will throw an exception


### PR DESCRIPTION
Accessing data from the Maya DG in parallel will cause crashes. Until we get a proper integration with the Maya EM, we should disable Hydra parallel sync.