### PR TITLE
HYDRA-2280 - maya-hydra material and mesh issues uncovered while investigating the walrus chess-set scene

### DIFF
--- a/lib/mayaHydra/hydraExtensions/CMakeLists.txt
+++ b/lib/mayaHydra/hydraExtensions/CMakeLists.txt
@@ -105,7 +105,7 @@ target_link_libraries(${TARGET_NAME}
         gf
         hd
         hdGp
-        hdMtlx
+        $<$<BOOL:${CMAKE_WANT_MATERIALX_BUILD}>:hdMtlx>
         hdx
         js
         kind
@@ -118,7 +118,7 @@ target_link_libraries(${TARGET_NAME}
         usdImaging
         usdImagingGL
         usdLux
-        usdMtlx
+        $<$<BOOL:${CMAKE_WANT_MATERIALX_BUILD}>:usdMtlx>
         usdRender
         usdRi
         usdShade

--- a/lib/mayaHydra/hydraExtensions/CMakeLists.txt
+++ b/lib/mayaHydra/hydraExtensions/CMakeLists.txt
@@ -105,6 +105,7 @@ target_link_libraries(${TARGET_NAME}
         gf
         hd
         hdGp
+        hdMtlx
         hdx
         js
         kind
@@ -117,6 +118,7 @@ target_link_libraries(${TARGET_NAME}
         usdImaging
         usdImagingGL
         usdLux
+        usdMtlx
         usdRender
         usdRi
         usdShade

--- a/lib/mayaHydra/hydraExtensions/adapters/materialAdapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/materialAdapter.cpp
@@ -32,16 +32,23 @@
 #include <pxr/usd/sdf/types.h>
 #include <pxr/usd/usd/prim.h>
 #include <pxr/usd/usd/stage.h>
+#include <pxr/imaging/hdMtlx/hdMtlx.h>
 #include <pxr/usd/usdMtlx/reader.h>
 #include <pxr/usd/usdShade/material.h>
 #include <pxr/usdImaging/usdImaging/materialParamUtils.h>
 #include <pxr/usdImaging/usdImaging/tokens.h>
 
+#include <maya/MGlobal.h>
 #include <maya/MNodeMessage.h>
 #include <maya/MPlug.h>
 #include <maya/MPlugArray.h>
 
+#include <set>
+#include <string>
+#include <vector>
+
 #include <MaterialXCore/Document.h>
+#include <MaterialXFormat/File.h>
 #include <MaterialXFormat/XmlIo.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -58,6 +65,25 @@ TF_DEFINE_PRIVATE_TOKENS(
 const VtValue       _emptyValue;
 const TfToken       _emptyToken;
 const TfTokenVector _stSamplerCoords = { TfToken("st") };
+
+// Collect the node-definition identifiers referenced by 'doc' (including inside
+// nodegraphs) that cannot currently be resolved from the document itself.
+void _CollectUnresolvedNodeDefs(const MaterialX::DocumentPtr& doc, std::set<std::string>& out)
+{
+    std::vector<MaterialX::NodePtr> nodes = doc->getNodes();
+    for (const auto& nodeGraph : doc->getNodeGraphs()) {
+        const auto graphNodes = nodeGraph->getNodes();
+        nodes.insert(nodes.end(), graphNodes.begin(), graphNodes.end());
+    }
+    for (const auto& node : nodes) {
+        if (node && !node->getNodeDef()) {
+            const std::string def = node->getNodeDefString();
+            if (!def.empty()) {
+                out.insert(def);
+            }
+        }
+    }
+}
 
 } // namespace
 
@@ -241,6 +267,16 @@ private:
         auto       p = node.findPlug(MayaAttrs::shadingEngine::surfaceShader, true);
         MPlugArray conns;
         p.connectedTo(conns, true, false);
+
+        // LookdevX / MaterialX materials connect to the separate
+        // "materialXSurfaceShader" attribute rather than "surfaceShader".
+        if (conns.length() == 0) {
+            auto pMtlx = node.findPlug("materialXSurfaceShader", true);
+            if (!pMtlx.isNull()) {
+                pMtlx.connectedTo(conns, true, false);
+            }
+        }
+
         if (conns.length() > 0) {
             _surfaceShader = conns[0].node();
             MFnDependencyNode surfaceNode(_surfaceShader, &status);
@@ -280,65 +316,187 @@ private:
         MStatus status;
         MFnDependencyNode node(_surfaceShader, &status);
         if (!status) {
+            TF_DEBUG(MAYAHYDRALIB_ADAPTER_MATERIALS)
+                .Msg("PopulateMaterialXNetworkMap: Failed to get surface shader node\n");
             return false;
         }
 
         // Fetch the "renderDocument" attribute from the node
-        static const MString renderDocumentStr("renderDocument");  
+        static const MString renderDocumentStr("renderDocument");
         auto mtlxDocPlug = node.findPlug(renderDocumentStr, true);
         if (mtlxDocPlug.isNull()) {
+            TF_DEBUG(MAYAHYDRALIB_ADAPTER_MATERIALS)
+                .Msg("PopulateMaterialXNetworkMap: renderDocument plug not found on node %s\n",
+                     node.name().asChar());
             return false;
         }
 
         // Construct a MaterialX document
-        const MString mtlxDocStr = mtlxDocPlug.asString();
+        MString mtlxDocStr = mtlxDocPlug.asString();
+
         if (0 == mtlxDocStr.length()) {
+            TF_DEBUG(MAYAHYDRALIB_ADAPTER_MATERIALS)
+                .Msg("PopulateMaterialXNetworkMap: renderDocument is empty, attempting to force evaluation on node %s\n",
+                     node.name().asChar());
+
+            // In batch render mode, LookdevX may not have evaluated the node yet.
+            // Pull on the actual source plug that drives the shading engine's
+            // "materialXSurfaceShader" attribute — this is the definitive output of the
+            // LookdevX node and evaluating it triggers its compute function regardless of
+            // what the output attribute is named (it is not necessarily "outColor").
+            {
+                MStatus seStatus;
+                MFnDependencyNode seNode(GetNode(), &seStatus); // GetNode() = shading engine
+                if (seStatus) {
+                    MPlug sePlug = seNode.findPlug("materialXSurfaceShader", true);
+                    if (!sePlug.isNull()) {
+                        MPlug srcPlug = sePlug.source(); // output plug on the LookdevX node
+                        if (!srcPlug.isNull()) {
+                            try {
+                                MObject val;
+                                srcPlug.getValue(val);
+                                TF_DEBUG(MAYAHYDRALIB_ADAPTER_MATERIALS)
+                                    .Msg("PopulateMaterialXNetworkMap: Triggered evaluation via source plug %s, retrying renderDocument\n",
+                                         srcPlug.name().asChar());
+                                mtlxDocStr = mtlxDocPlug.asString();
+                            } catch (...) {
+                                TF_DEBUG(MAYAHYDRALIB_ADAPTER_MATERIALS)
+                                    .Msg("PopulateMaterialXNetworkMap: Source plug evaluation failed\n");
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Fallback: use MEL dgeval which forces the DG scheduler to compute the attribute.
+            if (0 == mtlxDocStr.length()) {
+                try {
+                    MString cmd("dgeval ");
+                    cmd += node.name();
+                    cmd += ".renderDocument";
+                    MGlobal::executeCommand(cmd, false, false);
+                    TF_DEBUG(MAYAHYDRALIB_ADAPTER_MATERIALS)
+                        .Msg("PopulateMaterialXNetworkMap: Triggered evaluation via dgeval, retrying renderDocument\n");
+                    mtlxDocStr = mtlxDocPlug.asString();
+                } catch (...) {
+                    TF_DEBUG(MAYAHYDRALIB_ADAPTER_MATERIALS)
+                        .Msg("PopulateMaterialXNetworkMap: dgeval attempt failed\n");
+                }
+            }
+
+            if (0 == mtlxDocStr.length()) {
+                TF_DEBUG(MAYAHYDRALIB_ADAPTER_MATERIALS)
+                    .Msg("PopulateMaterialXNetworkMap: renderDocument still empty after evaluation attempt\n");
+                return false;
+            }
+        }
+
+        TF_DEBUG(MAYAHYDRALIB_ADAPTER_MATERIALS)
+            .Msg("PopulateMaterialXNetworkMap: renderDocument length = %d on node %s\n",
+                 (int)mtlxDocStr.length(), node.name().asChar());
+        auto mtlxDoc = MaterialX::createDocument();
+
+        // Pass explicit search paths so that any <xi:include> references in the
+        // renderDocument (e.g. custom LookdevX / shader libraries) are resolved.
+        // Use USD's HdMtlxSearchPaths() - the same paths the rest of Hydra/USD use -
+        // and intentionally do NOT inject extra libraries or copy custom node
+        // definitions into the document. Doing so changes the network UsdMtlxRead
+        // produces (wrong material terminal / corrupted graph) and breaks the material
+        // in both the viewport and batch. If a custom definition cannot be resolved
+        // with these paths, the (Fix A) warning below reports it instead.
+        const MaterialX::FileSearchPath searchPaths = HdMtlxSearchPaths();
+        try {
+            MaterialX::readFromXmlString(mtlxDoc, mtlxDocStr.asChar(), searchPaths);
+        } catch (const std::exception& e) {
+            TF_DEBUG(MAYAHYDRALIB_ADAPTER_MATERIALS)
+                .Msg("PopulateMaterialXNetworkMap: Failed to parse MaterialX XML: %s\n", e.what());
             return false;
         }
-        auto mtlxDoc = MaterialX::createDocument();
-        MaterialX::readFromXmlString(mtlxDoc, mtlxDocStr.asChar());
+
+        // (Fix A) Warn about node definitions that still cannot be resolved.
+        // UsdMtlxRead drops unresolved nodes together with the branches feeding them,
+        // which silently diverges the viewport from a batch/USD render, so surface the
+        // missing definitions and the search paths used to make the failure actionable.
+        {
+            std::set<std::string> unresolvedDefs;
+            _CollectUnresolvedNodeDefs(mtlxDoc, unresolvedDefs);
+            if (!unresolvedDefs.empty()) {
+                std::string defList;
+                for (const std::string& def : unresolvedDefs) {
+                    defList += (defList.empty() ? "" : ", ") + def;
+                }
+                TF_WARN(
+                    "MaterialX material '%s': %zu node definition(s) could not be "
+                    "resolved [%s]. These nodes and the branches feeding them will be "
+                    "dropped, so the viewport may not match a batch/USD render. Check "
+                    "the MaterialX library search paths (MATERIALX_SEARCH_PATH / "
+                    "PXR_MTLX_STDLIB_SEARCH_PATHS). Search paths used: %s",
+                    node.name().asChar(),
+                    unresolvedDefs.size(),
+                    defList.c_str(),
+                    searchPaths.asString().c_str());
+            }
+        }
 
         // Create a Usd Stage from the MaterialX document
         auto stage = UsdStage::CreateInMemory("tmp.usda", TfNullPtr);
         UsdMtlxRead(mtlxDoc, stage);
-        
+
         // Search for material group in the Usd Stage
         static const SdfPath basePath("/MaterialX/Materials");
         auto mtlxRange = stage->GetPrimAtPath(basePath).GetChildren();
         if (mtlxRange.empty()) {
+            TF_DEBUG(MAYAHYDRALIB_ADAPTER_MATERIALS)
+                .Msg("PopulateMaterialXNetworkMap: No materials found at /MaterialX/Materials\n");
             return false;
         }
 
         // There should be only one material. Fetch it.
         UsdShadeMaterial mtlxMaterial(*mtlxRange.begin());
         if (!mtlxMaterial) {
+            TF_DEBUG(MAYAHYDRALIB_ADAPTER_MATERIALS)
+                .Msg("PopulateMaterialXNetworkMap: Failed to get material from stage\n");
             return false;
         }
 
         // Get MaterialX output
         UsdShadeOutput mtlxOutput = mtlxMaterial.GetOutput(_tokens->mtlxSurface);
         if (!mtlxOutput) {
+            TF_DEBUG(MAYAHYDRALIB_ADAPTER_MATERIALS)
+                .Msg("PopulateMaterialXNetworkMap: Failed to get mtlx:surface output\n");
             return false;
         }
 
         // Get MaterialX shader outputs
-        UsdShadeAttributeVector mtlxShaderOutputs = 
+        UsdShadeAttributeVector mtlxShaderOutputs =
             UsdShadeUtils::GetValueProducingAttributes(mtlxOutput, /*shaderOutputsOnly*/true);
         if (mtlxShaderOutputs.empty()) {
+            TF_DEBUG(MAYAHYDRALIB_ADAPTER_MATERIALS)
+                .Msg("PopulateMaterialXNetworkMap: No shader outputs found\n");
             return false;
         }
-        
+
         // Finally get MaterialX shader
         UsdShadeShader mtlxShader(mtlxShaderOutputs[0].GetPrim());
         if (!mtlxShader) {
+            TF_DEBUG(MAYAHYDRALIB_ADAPTER_MATERIALS)
+                .Msg("PopulateMaterialXNetworkMap: Failed to get shader prim\n");
             return false;
         }
+
+        TF_DEBUG(MAYAHYDRALIB_ADAPTER_MATERIALS)
+            .Msg("PopulateMaterialXNetworkMap: Successfully extracted MaterialX shader at path %s\n",
+                 mtlxShader.GetPrim().GetPath().GetText());
 
         // Convert the MaterialX shader to HdMaterialNetwork
         UsdImagingBuildHdMaterialNetworkFromTerminal(
             mtlxShader.GetPrim(), _tokens->surface, {_tokens->mtlx},
             {_tokens->mtlx}, &networkMap, UsdTimeCode());
-            
+
+        TF_DEBUG(MAYAHYDRALIB_ADAPTER_MATERIALS)
+            .Msg("PopulateMaterialXNetworkMap: Built HdMaterialNetwork with %zu terminal entries\n",
+                 networkMap.map.size());
+
         return true;
     }
 

--- a/lib/mayaHydra/hydraExtensions/adapters/materialAdapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/materialAdapter.cpp
@@ -32,8 +32,10 @@
 #include <pxr/usd/sdf/types.h>
 #include <pxr/usd/usd/prim.h>
 #include <pxr/usd/usd/stage.h>
+#ifdef WANT_MATERIALX_BUILD
 #include <pxr/imaging/hdMtlx/hdMtlx.h>
 #include <pxr/usd/usdMtlx/reader.h>
+#endif
 #include <pxr/usd/usdShade/material.h>
 #include <pxr/usdImaging/usdImaging/materialParamUtils.h>
 #include <pxr/usdImaging/usdImaging/tokens.h>
@@ -47,9 +49,11 @@
 #include <string>
 #include <vector>
 
+#ifdef WANT_MATERIALX_BUILD
 #include <MaterialXCore/Document.h>
 #include <MaterialXFormat/File.h>
 #include <MaterialXFormat/XmlIo.h>
+#endif
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -66,6 +70,7 @@ const VtValue       _emptyValue;
 const TfToken       _emptyToken;
 const TfTokenVector _stSamplerCoords = { TfToken("st") };
 
+#ifdef WANT_MATERIALX_BUILD
 // Collect the node-definition identifiers referenced by 'doc' (including inside
 // nodegraphs) that cannot currently be resolved from the document itself.
 void _CollectUnresolvedNodeDefs(const MaterialX::DocumentPtr& doc, std::set<std::string>& out)
@@ -84,6 +89,7 @@ void _CollectUnresolvedNodeDefs(const MaterialX::DocumentPtr& doc, std::set<std:
         }
     }
 }
+#endif // WANT_MATERIALX_BUILD
 
 } // namespace
 
@@ -312,6 +318,7 @@ private:
 
     bool PopulateMaterialXNetworkMap(HdMaterialNetworkMap& networkMap)
     {
+#ifdef WANT_MATERIALX_BUILD
         // Get the dependency node
         MStatus status;
         MFnDependencyNode node(_surfaceShader, &status);
@@ -403,7 +410,7 @@ private:
         // definitions into the document. Doing so changes the network UsdMtlxRead
         // produces (wrong material terminal / corrupted graph) and breaks the material
         // in both the viewport and batch. If a custom definition cannot be resolved
-        // with these paths, the (Fix A) warning below reports it instead.
+        // with these paths, the warning below reports it instead.
         const MaterialX::FileSearchPath searchPaths = HdMtlxSearchPaths();
         try {
             MaterialX::readFromXmlString(mtlxDoc, mtlxDocStr.asChar(), searchPaths);
@@ -413,7 +420,7 @@ private:
             return false;
         }
 
-        // (Fix A) Warn about node definitions that still cannot be resolved.
+        // Warn about node definitions that still cannot be resolved.
         // UsdMtlxRead drops unresolved nodes together with the branches feeding them,
         // which silently diverges the viewport from a batch/USD render, so surface the
         // missing definitions and the search paths used to make the failure actionable.
@@ -498,6 +505,13 @@ private:
                  networkMap.map.size());
 
         return true;
+#else
+        // MaterialX support (hdMtlx / usdMtlx) is not available in this USD build,
+        // so there is no MaterialX network to build. Returning false makes the
+        // caller fall back to the standard Maya material network conversion.
+        (void)networkMap;
+        return false;
+#endif // WANT_MATERIALX_BUILD
     }
 
     VtValue GetMaterialResource() override

--- a/lib/mayaHydra/hydraExtensions/adapters/materialAdapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/materialAdapter.cpp
@@ -40,7 +40,6 @@
 #include <pxr/usdImaging/usdImaging/materialParamUtils.h>
 #include <pxr/usdImaging/usdImaging/tokens.h>
 
-#include <maya/MGlobal.h>
 #include <maya/MNodeMessage.h>
 #include <maya/MPlug.h>
 #include <maya/MPlugArray.h>
@@ -372,22 +371,6 @@ private:
                             }
                         }
                     }
-                }
-            }
-
-            // Fallback: use MEL dgeval which forces the DG scheduler to compute the attribute.
-            if (0 == mtlxDocStr.length()) {
-                try {
-                    MString cmd("dgeval ");
-                    cmd += node.name();
-                    cmd += ".renderDocument";
-                    MGlobal::executeCommand(cmd, false, false);
-                    TF_DEBUG(MAYAHYDRALIB_ADAPTER_MATERIALS)
-                        .Msg("PopulateMaterialXNetworkMap: Triggered evaluation via dgeval, retrying renderDocument\n");
-                    mtlxDocStr = mtlxDocPlug.asString();
-                } catch (...) {
-                    TF_DEBUG(MAYAHYDRALIB_ADAPTER_MATERIALS)
-                        .Msg("PopulateMaterialXNetworkMap: dgeval attempt failed\n");
                 }
             }
 

--- a/lib/mayaHydra/hydraExtensions/adapters/meshAdapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/meshAdapter.cpp
@@ -248,8 +248,13 @@ public:
             return {};
         }
 
+        // Tangents are declared with face-varying interpolation, so Hydra expects
+        // exactly one value per face vertex. Returning a mismatched-length primvar
+        // would lead to incorrect shading or downstream errors, so bail out instead.
         if (tangentsCount != numFacesVertices){
-            TF_CODING_ERROR("Number of tangents does not match number of face vertices" );
+            TF_CODING_ERROR("Number of tangents (%zu) does not match number of face vertices (%zu)",
+                            tangentsCount, numFacesVertices);
+            return {};
         }
 
         VtVec3fArray ret(tangentsCount);

--- a/lib/mayaHydra/hydraExtensions/adapters/meshAdapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/meshAdapter.cpp
@@ -252,9 +252,10 @@ public:
             TF_CODING_ERROR("Number of tangents does not match number of face vertices" );
         }
 
-       const auto* tangentsArray = reinterpret_cast<const GfVec2f*>(&mayaTangents[0]);
-        VtVec2fArray ret;
-        ret.assign(tangentsArray, tangentsArray + numFacesVertices);
+        VtVec3fArray ret(tangentsCount);
+        for (size_t i = 0; i < tangentsCount; ++i) {
+            ret[i] = GfVec3f(mayaTangents[i].x, mayaTangents[i].y, mayaTangents[i].z);
+        }
         return VtValue(ret);
     }
 
@@ -506,7 +507,7 @@ public:
                 localDescs.push_back(
                     { MayaHydraAdapterTokens->tangents,
                       interpolation,
-                      HdPrimvarRoleTokens->textureCoordinate });
+                      HdPrimvarRoleTokens->vector });
             }
         }
 

--- a/lib/mayaHydra/hydraExtensions/adapters/shapeAdapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/shapeAdapter.cpp
@@ -17,11 +17,11 @@
 
 #include <mayaHydraLib/adapters/adapterDebugCodes.h>
 #include <mayaHydraLib/adapters/mayaAttrs.h>
+#include <mayaHydraLib/mayaUtils.h>
 
 #include <pxr/base/tf/type.h>
 
-#include <maya/MPlug.h>
-#include <maya/MPlugArray.h>
+#include <maya/MFnDagNode.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -70,39 +70,14 @@ void MayaHydraShapeAdapter::MarkDirty(HdDirtyBits dirtyBits)
     MayaHydraDagAdapter::MarkDirty(dirtyBits);
 }
 
-MObject MayaHydraShapeAdapter::GetMaterial()
+MObject MayaHydraShapeAdapter::GetMaterial(const MObject& shadingComp)
 {
     TF_DEBUG(MAYAHYDRALIB_ADAPTER_GET)
         .Msg(
             "Called MayaHydraShapeAdapter::GetMaterial() - %s\n",
             GetDagPath().partialPathName().asChar());
 
-    MStatus    status;
-    MFnDagNode dagNode(GetDagPath(), &status);
-    if (!status) {
-        return MObject::kNullObj;
-    }
-
-    auto instObjGroups = dagNode.findPlug(MayaAttrs::dagNode::instObjGroups, true);
-    if (instObjGroups.isNull()) {
-        return MObject::kNullObj;
-    }
-
-    MPlugArray conns;
-    instObjGroups.elementByLogicalIndex(0).connectedTo(conns, false, true);
-
-    const auto numConnections = conns.length();
-    if (numConnections == 0) {
-        return MObject::kNullObj;
-    }
-    for (auto i = decltype(numConnections) { 0 }; i < numConnections; ++i) {
-        auto sg = conns[i].node();
-        if (sg.apiType() == MFn::kShadingEngine) {
-            return sg;
-        }
-    }
-
-    return MObject::kNullObj;
+    return MayaHydra::FindShadingEngine(GetDagPath(), shadingComp);
 }
 
 GfBBox3d MayaHydraShapeAdapter::GetBoundingBox()

--- a/lib/mayaHydra/hydraExtensions/adapters/shapeAdapter.h
+++ b/lib/mayaHydra/hydraExtensions/adapters/shapeAdapter.h
@@ -56,8 +56,11 @@ public:
     MAYAHYDRALIB_API
     virtual void MarkDirty(HdDirtyBits dirtyBits) override;
 
+    // Return the shading engine assigned to this shape. Pass a mesh component in
+    // shadingComp to get the shading engine for that specific group of faces
+    // (per-face shading); leave it null to get the whole-object assignment.
     MAYAHYDRALIB_API
-    virtual MObject GetMaterial();
+    virtual MObject GetMaterial(const MObject& shadingComp = MObject::kNullObj);
     MAYAHYDRALIB_API
     virtual bool GetDoubleSided() const override { return true; };
     MAYAHYDRALIB_API

--- a/lib/mayaHydra/hydraExtensions/mayaUtils.cpp
+++ b/lib/mayaHydra/hydraExtensions/mayaUtils.cpp
@@ -18,7 +18,10 @@
 
 #include <mayaHydraLib/adapters/mayaAttrs.h>
 
+#include <pxr/base/tf/diagnostic.h>
+
 #include <maya/MDagPath.h>
+#include <maya/MFnComponent.h>
 #include <maya/MFnDagNode.h>
 #include <maya/MMatrix.h>
 #include <maya/MObjectArray.h>
@@ -26,6 +29,8 @@
 #include <maya/MPlugArray.h>
 #include <maya/MSelectionList.h>
 #include <maya/MStringArray.h>
+
+PXR_NAMESPACE_USING_DIRECTIVE
 
 namespace MAYAHYDRA_NS_DEF {
 
@@ -188,6 +193,68 @@ bool IsDagPathOfGivenType(const MDagPath& dagPath, const MString& type)
     auto shapeDagPath = dagPath;
     shapeDagPath.extendToShape();
     return type == MFnDependencyNode(shapeDagPath.node()).typeName();
+}
+
+// Collect every shading-group assignment on a shape.
+//
+// What: appends one ShadingAssignment per kShadingEngine connected to dagPath,
+// pairing each shading engine with the component (set of faces) it is assigned
+// to. The component is null for a whole-object assignment.
+// How: Maya exposes per-instance assignments through
+// MFnDagNode::getConnectedSetsAndMembers, which returns parallel arrays of sets
+// and their member components. We keep only the shading-engine sets. Callers use
+// this to build Hydra geomSubsets for per-face (multi-material) meshes.
+void GetAllShadingAssignments(const MDagPath& dagPath, std::vector<ShadingAssignment>& out)
+{
+    if (!dagPath.isValid())
+        return;
+
+    MFnDagNode dagNode(dagPath.node());
+    MObjectArray sets, comps;
+    dagNode.getConnectedSetsAndMembers(dagPath.instanceNumber(), sets, comps, /*renderableSetsOnly=*/true);
+    if (sets.length() != comps.length()) {
+        TF_WARN("GetAllShadingAssignments: sets/comps length mismatch on %s", dagPath.fullPathName().asChar());
+        return;
+    }
+    for (uint32_t i = 0; i < sets.length(); ++i) {
+        if (sets[i].apiType() == MFn::kShadingEngine) {
+            out.push_back({ comps[i], sets[i] });
+        }
+    }
+}
+
+// Find the single shading engine that applies to a shape (or to one of its
+// components).
+//
+// What: returns the kShadingEngine MObject assigned to dagPath. When
+// shadingComp is non-null, only the shading engine whose member component
+// matches shadingComp is returned (per-face shading, e.g. one render item of a
+// multi-material mesh); when it is null the first shading engine found is
+// returned (whole-object assignment). Returns kNullObj when nothing is assigned.
+// How: same getConnectedSetsAndMembers enumeration as GetAllShadingAssignments,
+// but short-circuits on the first matching shading engine. MFnComponent::isEqual
+// is used to match the requested component against each set's member component.
+MObject FindShadingEngine(const MDagPath& dagPath, const MObject& shadingComp)
+{
+    if (!dagPath.isValid())
+        return MObject::kNullObj;
+
+    MFnDagNode   dagNode(dagPath.node());
+    MObjectArray sets, comps;
+    dagNode.getConnectedSetsAndMembers(dagPath.instanceNumber(), sets, comps, /*renderableSetsOnly=*/true);
+    if (sets.length() != comps.length()) {
+        TF_WARN("FindShadingEngine: sets/comps length mismatch on %s", dagPath.fullPathName().asChar());
+        return MObject::kNullObj;
+    }
+    for (uint32_t i = 0; i < sets.length(); ++i) {
+        if (sets[i].apiType() == MFn::kShadingEngine) {
+            MObject comp = comps[i];
+            MObject shadingCompCopy = shadingComp;
+            if (shadingCompCopy.isNull() || comp.isNull() || MFnComponent(comp).isEqual(shadingCompCopy))
+                return sets[i];
+        }
+    }
+    return MObject::kNullObj;
 }
 
 } // namespace MAYAHYDRA_NS_DEF

--- a/lib/mayaHydra/hydraExtensions/mayaUtils.h
+++ b/lib/mayaHydra/hydraExtensions/mayaUtils.h
@@ -25,6 +25,7 @@
 
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace MAYAHYDRA_NS_DEF {
 
@@ -227,6 +228,33 @@ std::string GetDomeLightTexture(const MFnDependencyNode& lightNode);
  * @return true if the object is a dag path of the given type, false otherwise
  */
 bool IsDagPathOfGivenType(const MDagPath& dagPath, const MString& type);
+
+/**
+ * @brief Find the shading engine (kShadingEngine) connected to a DAG path.
+ *
+ * When shadingComp is non-null, only returns the shading engine whose component
+ * matches shadingComp (per-face shading). When shadingComp is null, returns the
+ * first shading engine found (whole-object assignment).
+ *
+ * @param[in] dagPath     The DAG path of the shape.
+ * @param[in] shadingComp Optional component for per-face shading matching.
+ *
+ * @return The shading engine MObject, or MObject::kNullObj if none is found.
+ */
+MAYAHYDRALIB_API
+MObject FindShadingEngine(const MDagPath& dagPath, const MObject& shadingComp = MObject::kNullObj);
+
+/// One entry per shading group connected to a DAG path.
+/// component is MObject::kNullObj for whole-object assignments.
+struct ShadingAssignment {
+    MObject component;
+    MObject shadingEngine;
+};
+
+/// Return all shading assignments for dagPath.
+/// Uses getConnectedSetsAndMembers so per-face assignments are included.
+MAYAHYDRALIB_API
+void GetAllShadingAssignments(const MDagPath& dagPath, std::vector<ShadingAssignment>& out);
 
 } // namespace MAYAHYDRA_NS_DEF
 

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
@@ -1441,6 +1441,10 @@ void MayaHydraSceneIndex::OnDagNodeRemoved(const MObject& obj)
 // component / whole object) or from the kMeshPolygonComponent element list, and
 // is published as a faceSet HdGeomSubset with an HdMaterialBindingsSchema so the
 // render delegate shades those faces with the right material.
+// Subsets only apply to meshes, so non-mesh (incl. plugin) shapes are skipped.
+// When a mesh has both a whole-object assignment and per-face assignments, the
+// whole-object subset is skipped to avoid overlapping subsets with undefined
+// material precedence; the whole-object material remains the mesh's binding.
 void MayaHydraSceneIndex::_InsertGeomSubsetsForMesh(
     const MDagPath& dag, const SdfPath& meshPrimId)
 {
@@ -1458,11 +1462,36 @@ void MayaHydraSceneIndex::_InsertGeomSubsetsForMesh(
         return;
     }
 
-    MFnMesh mesh(dag);
+    // geomSubsets only apply to meshes; bail out for any other (incl. plugin) shape.
+    if (!dag.hasFn(MFn::kMesh)) {
+        return;
+    }
+    MStatus meshStatus;
+    MFnMesh mesh(dag, &meshStatus);
+    if (!meshStatus) {
+        return;
+    }
+
+    // A whole-object (null component) assignment covers every face. If the mesh
+    // also has per-face assignments, emitting a full-coverage subset would overlap
+    // them with undefined material precedence, so skip the whole-object subset when
+    // component assignments are present.
+    bool hasComponentAssignments = false;
+    for (const auto& sa : assignments) {
+        if (!sa.component.isNull()) {
+            hasComponentAssignments = true;
+            break;
+        }
+    }
+
     int subsetIndex = 0;
     static const TfToken purposes[] = { HdMaterialBindingsSchemaTokens->allPurpose };
 
     for (const auto& sa : assignments) {
+        if (hasComponentAssignments && sa.component.isNull()) {
+            continue;
+        }
+
         VtIntArray faceIndices;
 
         if (sa.component.isNull()) {
@@ -1480,6 +1509,10 @@ void MayaHydraSceneIndex::_InsertGeomSubsetsForMesh(
                 faceIndices[j] = elements[j];
             }
         } else {
+            // Defensive: for a mesh, getConnectedSetsAndMembers only ever yields a
+            // null component (whole object) or a face component
+            // (kMeshPolygonComponent). Any other component type is unexpected, so
+            // skip it rather than treat its element indices as face indices.
             continue;
         }
 

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
@@ -28,6 +28,9 @@
 #include <mayaHydraLib/sceneIndex/mayaHydraDataSource.h>
 
 #include <pxr/base/tf/envSetting.h>
+#include <pxr/imaging/hd/geomSubsetSchema.h>
+#include <pxr/imaging/hd/materialBindingSchema.h>
+#include <pxr/imaging/hd/materialBindingsSchema.h>
 #include <pxr/imaging/hd/primvarsSchema.h>
 #include <pxr/imaging/hd/retainedDataSource.h>
 #include <pxr/imaging/hd/rprim.h>
@@ -36,8 +39,9 @@
 #include <maya/MDGMessage.h>
 #include <maya/MDagPath.h>
 #include <maya/MDagPathArray.h>
-#include <maya/MFnComponent.h>
 #include <maya/MFnDependencyNode.h>
+#include <maya/MFnMesh.h>
+#include <maya/MFnSingleIndexedComponent.h>
 #include <maya/MNodeClass.h>
 #include <maya/MItDag.h>
 #include <maya/MMaterial.h>
@@ -341,27 +345,8 @@ SdfPath _GetMaterialPath(const SdfPath& base, const MObject& obj)
 
 bool GetShadingEngineNode(const MRenderItem& ri, MObject& shadingEngineNode)
 {
-    MDagPath dagPath = ri.sourceDagPath();
-    if (dagPath.isValid()) {
-        MFnDagNode   dagNode(dagPath.node());
-        MObjectArray sets, comps;
-        dagNode.getConnectedSetsAndMembers(dagPath.instanceNumber(), sets, comps, true);
-        assert(sets.length() == comps.length());
-        for (uint32_t i = 0; i < sets.length(); ++i) {
-            const MObject& object = sets[i];
-            if (object.apiType() == MFn::kShadingEngine) {
-                // To support per-face shading, find the shading node matched with the render item
-                const MObject& comp = comps[i];
-                MObject        shadingComp = ri.shadingComponent();
-                if (shadingComp.isNull() || comp.isNull()
-                    || MFnComponent(comp).isEqual(shadingComp)) {
-                    shadingEngineNode = object;
-                    return true;
-                }
-            }
-        }
-    }
-    return false;
+    shadingEngineNode = FindShadingEngine(ri.sourceDagPath(), ri.shadingComponent());
+    return !shadingEngineNode.isNull();
 }
 
 std::mutex _adaptersToRecreateMutex;
@@ -1442,6 +1427,91 @@ void MayaHydraSceneIndex::OnDagNodeRemoved(const MObject& obj)
     }
 }
 
+// Create the material(s) bound to a mesh and, for multi-material meshes, the
+// Hydra geomSubsets that route each group of faces to its material.
+//
+// What: ensures a material adapter exists for every shading group assigned to
+// 'dag', then - only when there is more than one assignment - emits one
+// HdGeomSubset prim per assignment under 'meshPrimId', each carrying the face
+// indices it covers and a material binding to the corresponding material. A mesh
+// with a single (whole-object) assignment needs no subsets: the regular mesh
+// material binding already covers it, so we return after creating the material.
+// How: GetAllShadingAssignments enumerates the (component, shadingEngine) pairs.
+// For each assignment the face set is taken either from all polygons (null
+// component / whole object) or from the kMeshPolygonComponent element list, and
+// is published as a faceSet HdGeomSubset with an HdMaterialBindingsSchema so the
+// render delegate shades those faces with the right material.
+void MayaHydraSceneIndex::_InsertGeomSubsetsForMesh(
+    const MDagPath& dag, const SdfPath& meshPrimId)
+{
+    std::vector<ShadingAssignment> assignments;
+    GetAllShadingAssignments(dag, assignments);
+
+    for (const auto& sa : assignments) {
+        const auto materialId = GetMaterialPath(sa.shadingEngine);
+        if (TfMapLookupPtr(_materialAdapters, materialId) == nullptr) {
+            CreateMaterial(materialId, sa.shadingEngine);
+        }
+    }
+
+    if (assignments.size() <= 1) {
+        return;
+    }
+
+    MFnMesh mesh(dag);
+    int subsetIndex = 0;
+    static const TfToken purposes[] = { HdMaterialBindingsSchemaTokens->allPurpose };
+
+    for (const auto& sa : assignments) {
+        VtIntArray faceIndices;
+
+        if (sa.component.isNull()) {
+            const int numFaces = mesh.numPolygons();
+            faceIndices.resize(numFaces);
+            for (int f = 0; f < numFaces; ++f) {
+                faceIndices[f] = f;
+            }
+        } else if (sa.component.apiType() == MFn::kMeshPolygonComponent) {
+            MFnSingleIndexedComponent fnComp(sa.component);
+            MIntArray elements;
+            fnComp.getElements(elements);
+            faceIndices.resize(elements.length());
+            for (uint32_t j = 0; j < elements.length(); ++j) {
+                faceIndices[j] = elements[j];
+            }
+        } else {
+            continue;
+        }
+
+        if (faceIndices.empty()) {
+            continue;
+        }
+
+        const SdfPath materialPath = GetMaterialPath(sa.shadingEngine);
+        const SdfPath subsetPath = meshPrimId.AppendChild(
+            TfToken("geomSubset_" + std::to_string(subsetIndex++)));
+
+        HdDataSourceBaseHandle materialBindingSources[] = {
+            HdMaterialBindingSchema::Builder()
+                .SetPath(HdRetainedTypedSampledDataSource<SdfPath>::New(materialPath))
+                .Build()
+        };
+
+        AddPrims({{ subsetPath,
+            HdPrimTypeTokens->geomSubset,
+            HdRetainedContainerDataSource::New(
+                HdGeomSubsetSchemaTokens->geomSubset,
+                HdGeomSubsetSchema::Builder()
+                    .SetType(HdGeomSubsetSchema::BuildTypeDataSource(
+                        HdGeomSubsetSchemaTokens->typeFaceSet))
+                    .SetIndices(HdRetainedTypedSampledDataSource<VtIntArray>::New(faceIndices))
+                    .Build(),
+                HdMaterialBindingsSchema::GetSchemaToken(),
+                HdMaterialBindingsSchema::BuildRetained(
+                    TfArraySize(purposes), purposes, materialBindingSources)) }});
+    }
+}
+
 void MayaHydraSceneIndex::InsertDag(const MDagPath& dag)
 {
     // We don't care about transforms.
@@ -1451,6 +1521,14 @@ void MayaHydraSceneIndex::InsertDag(const MDagPath& dag)
 
     MFnDagNode dagNode(dag);
     if (dagNode.isIntermediateObject()) {
+        return;
+    }
+
+    // In batch mode (useMeshAdapter), MItDag visits every DAG node including
+    // LOD meshes and corrective blend-shape targets that VP2 never makes render
+    // items for.  Skip shapes that are not visible so that only the intended
+    // renderable geometry reaches Hydra, matching viewport behaviour.
+    if (useMeshAdapter() && !dag.isVisible()) {
         return;
     }
 
@@ -1482,13 +1560,7 @@ void MayaHydraSceneIndex::InsertDag(const MDagPath& dag)
 
     auto adapter = CreateShapeAdapter(dag);
     if (adapter) {
-        auto material = adapter->GetMaterial();
-        if (material != MObject::kNullObj) {
-            const auto materialId = GetMaterialPath(material);
-            if (TfMapLookupPtr(_materialAdapters, materialId) == nullptr) {
-                CreateMaterial(materialId, material);
-            }
-        }
+        _InsertGeomSubsetsForMesh(dag, adapter->GetID());
         return;
     }
 

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.h
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.h
@@ -287,6 +287,10 @@ private:
     bool _GetRenderItem(int fastId, MayaHydraRenderItemAdapterPtr& adapter);
     void _AddPrimAncestors(const SdfPath& path);
     void _RemoveEmptyAncestors(const SdfPath& path);
+    // Create the material(s) for a mesh and, when it has more than one shading
+    // group, emit one HdGeomSubset (faceSet + material binding) per assignment so
+    // per-face/multi-material meshes shade correctly. See the .cpp for details.
+    void _InsertGeomSubsetsForMesh(const MDagPath& dag, const SdfPath& meshPrimId);
     void _AddRenderItem(const MayaHydraRenderItemAdapterPtr& ria);
     void _RemoveRenderItem(const MayaHydraRenderItemAdapterPtr& ria);
     bool

--- a/test/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
+++ b/test/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
@@ -155,8 +155,10 @@ endif()
 set(INTERACTIVE_TEST_SCRIPT_FILES_MESH_ADAPTER
     testMeshes.py
     testTransformMeshAdapter.py
+    testMeshAdapterVisibility.py
     cpp/testMeshAdapterTransform.py
     cpp/testMeshPrimvars.py
+    cpp/testMeshGeomSubsets.py
     cpp/testMeshSubdivTags.py
 )
 

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/CMakeLists.txt
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/CMakeLists.txt
@@ -39,6 +39,7 @@ target_sources(${TARGET_NAME}
         testCustomDagNodeTranslation.cpp
         testCameraPrimvars.cpp
         testMeshPrimvars.cpp
+        testMeshGeomSubsets.cpp
         testFlowViewportAPIFilterPrims.cpp
         testSceneCorrectness.cpp
         testSelection.cpp

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testMeshGeomSubsets.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testMeshGeomSubsets.cpp
@@ -1,0 +1,227 @@
+// Copyright 2026 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "testUtils.h"
+
+#include <mayaHydraLib/sceneIndex/mayaHydraSceneIndex.h>
+
+#include <pxr/imaging/hd/geomSubsetSchema.h>
+#include <pxr/imaging/hd/materialBindingsSchema.h>
+#include <pxr/imaging/hd/tokens.h>
+
+#include <pxr/base/vt/array.h>
+#include <pxr/base/vt/types.h>
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <set>
+#include <string>
+#include <vector>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+namespace {
+
+const char* kMeshShapeOptionVar = "mhGeomSubsetMeshShape";
+const char* kMeshShapeFallback = "multiCubeShape";
+
+// Collect every geomSubset prim that is a descendant of the given mesh prim path.
+PrimEntriesVector FindGeomSubsetsUnderMesh(
+    const SceneIndexInspector& inspector,
+    const SdfPath&             meshPrimPath)
+{
+    FindPrimPredicate predicate
+        = [&meshPrimPath](const HdSceneIndexBasePtr& sceneIndex, const SdfPath& primPath) -> bool {
+        return primPath.HasPrefix(meshPrimPath)
+            && sceneIndex->GetPrim(primPath).primType == HdPrimTypeTokens->geomSubset;
+    };
+    return inspector.FindPrims(predicate);
+}
+
+// Read the face indices of a geomSubset prim into a sorted set for order-independent
+// comparison.
+std::set<int> GetGeomSubsetFaceIndices(const HdSceneIndexPrim& prim)
+{
+    std::set<int>      faces;
+    HdGeomSubsetSchema gss = HdGeomSubsetSchema::GetFromParent(prim.dataSource);
+    if (!gss.IsDefined() || !gss.GetIndices()) {
+        return faces;
+    }
+    const VtIntArray indices = gss.GetIndices()->GetTypedValue(0.0f);
+    for (int index : indices) {
+        faces.insert(index);
+    }
+    return faces;
+}
+
+// Read the bound material path of a geomSubset prim (all-purpose binding).
+SdfPath GetGeomSubsetMaterialPath(const HdSceneIndexPrim& prim)
+{
+    HdMaterialBindingsSchema mb = HdMaterialBindingsSchema::GetFromParent(prim.dataSource);
+    if (!mb.IsDefined()) {
+        return {};
+    }
+    auto pathDs = mb.GetMaterialBinding().GetPath();
+    if (!pathDs) {
+        return {};
+    }
+    return pathDs->GetTypedValue(0.0f);
+}
+
+// Locate the mesh prim in the MayaHydraSceneIndex; returns the inspector's scene index
+// and the mesh prim path. Asserts (via gtest macros) when prerequisites are missing.
+HdSceneIndexBaseRefPtr LocateMayaSceneIndexWithMesh(
+    const std::string& shapeNamePart,
+    SdfPath&           outMeshPrimPath)
+{
+    const SceneIndicesVector& sceneIndices = GetTerminalSceneIndices();
+    EXPECT_GT(sceneIndices.size(), 0u);
+
+    HdSceneIndexBaseRefPtr sceneIndexWithMesh
+        = FindTerminalSceneIndexWithPrim(sceneIndices, shapeNamePart, HdPrimTypeTokens->mesh);
+    EXPECT_TRUE(sceneIndexWithMesh)
+        << "Mesh prim not found in any scene index (ensure MAYA_HYDRA_USE_MESH_ADAPTER=1)";
+    if (!sceneIndexWithMesh) {
+        return nullptr;
+    }
+
+    HdSceneIndexBaseRefPtr mayaSceneIndex = FindMayaHydraSceneIndex(sceneIndexWithMesh);
+    EXPECT_TRUE(mayaSceneIndex) << "MayaHydraSceneIndex not found in scene index tree";
+    if (!mayaSceneIndex) {
+        return nullptr;
+    }
+
+    SceneIndexInspector inspector(mayaSceneIndex);
+    PrimEntriesVector   foundPrims
+        = inspector.FindPrims(CreatePrimPredicate(shapeNamePart, HdPrimTypeTokens->mesh), 1);
+    EXPECT_GE(foundPrims.size(), 1u) << "Mesh not found in MayaHydraSceneIndex";
+    if (foundPrims.empty()) {
+        return nullptr;
+    }
+    outMeshPrimPath = foundPrims.front().primPath;
+    return mayaSceneIndex;
+}
+
+} // namespace
+
+// What: per-face material assignments produce one faceSet geomSubset per material group,
+//       each bound to a distinct material, with no full-coverage (overlapping) subset.
+// How: the Python scene assigns shaderBSG to faces 0-2 of a 6-face cube (in addition to the
+//      whole-object shaderASG), then we inspect the geomSubsets under the mesh prim.
+// Expect: the faces {0,1,2} subset is a faceSet bound to a material named "shaderBSG"; every
+//         subset binds to an existing material prim; no subset covers all 6 faces.
+// Why: regression guard for multi-material geomSubset creation and the overlap-avoidance rule.
+TEST(MultiMaterialMesh, PerFaceCreatesGeomSubsets)
+{
+    const std::string meshShapeFull = GetOptionVarOrDefault(kMeshShapeOptionVar, kMeshShapeFallback);
+    const std::string shapeNamePart = GetShapeNameFromFullPath(meshShapeFull);
+
+    SdfPath                meshPrimPath;
+    HdSceneIndexBaseRefPtr mayaSceneIndex
+        = LocateMayaSceneIndexWithMesh(shapeNamePart, meshPrimPath);
+    ASSERT_TRUE(mayaSceneIndex);
+
+    SceneIndexInspector inspector(mayaSceneIndex);
+    PrimEntriesVector   subsets = FindGeomSubsetsUnderMesh(inspector, meshPrimPath);
+    ASSERT_GE(subsets.size(), 1u)
+        << "A multi-material mesh should expose at least one geomSubset";
+
+    const int numFaces = 6; // cube
+
+    bool foundShaderBFaceSubset = false;
+    for (const auto& subsetEntry : subsets) {
+        const HdSceneIndexPrim& subsetPrim = subsetEntry.prim;
+
+        // Every subset must be a faceSet.
+        HdGeomSubsetSchema gss = HdGeomSubsetSchema::GetFromParent(subsetPrim.dataSource);
+        ASSERT_TRUE(gss.IsDefined()) << "geomSubset schema missing on " << subsetEntry.primPath;
+        ASSERT_TRUE(gss.GetType());
+        EXPECT_EQ(gss.GetType()->GetTypedValue(0.0f), HdGeomSubsetSchemaTokens->typeFaceSet);
+
+        const std::set<int> faces = GetGeomSubsetFaceIndices(subsetPrim);
+        EXPECT_FALSE(faces.empty()) << "geomSubset must reference at least one face";
+
+        // Overlap guard: with multiple materials assigned, no subset may cover every face,
+        // otherwise it would overlap the per-face subsets with undefined precedence.
+        EXPECT_LT(static_cast<int>(faces.size()), numFaces)
+            << "No geomSubset should cover all faces when per-face assignments exist";
+
+        // Each subset must bind to a material prim that actually exists in the scene index.
+        const SdfPath materialPath = GetGeomSubsetMaterialPath(subsetPrim);
+        ASSERT_FALSE(materialPath.IsEmpty()) << "geomSubset must have a material binding";
+        EXPECT_EQ(
+            mayaSceneIndex->GetPrim(materialPath).primType, HdPrimTypeTokens->material)
+            << "geomSubset material binding must resolve to a material prim: " << materialPath;
+
+        const std::set<int> shaderBFaces = { 0, 1, 2 };
+        if (materialPath.GetName() == "shaderBSG") {
+            foundShaderBFaceSubset = true;
+            EXPECT_EQ(faces, shaderBFaces)
+                << "shaderBSG should be bound to faces {0,1,2}";
+        }
+    }
+
+    EXPECT_TRUE(foundShaderBFaceSubset)
+        << "Expected a geomSubset bound to the per-face material 'shaderBSG'";
+}
+
+// What: a mesh with a single whole-object material assignment must not create geomSubsets.
+// How: the Python scene assigns one shading group to an entire cube; we inspect the mesh prim.
+// Expect: no geomSubset prims exist under the mesh.
+// Why: regression guard for the early-return when there is at most one shading assignment.
+TEST(MultiMaterialMesh, SingleAssignmentNoGeomSubset)
+{
+    const std::string meshShapeFull = GetOptionVarOrDefault(kMeshShapeOptionVar, kMeshShapeFallback);
+    const std::string shapeNamePart = GetShapeNameFromFullPath(meshShapeFull);
+
+    SdfPath                meshPrimPath;
+    HdSceneIndexBaseRefPtr mayaSceneIndex
+        = LocateMayaSceneIndexWithMesh(shapeNamePart, meshPrimPath);
+    ASSERT_TRUE(mayaSceneIndex);
+
+    SceneIndexInspector inspector(mayaSceneIndex);
+    PrimEntriesVector   subsets = FindGeomSubsetsUnderMesh(inspector, meshPrimPath);
+    EXPECT_TRUE(subsets.empty())
+        << "A single-material mesh must not create geomSubsets, found " << subsets.size();
+}
+
+// What: non-mesh shapes must never produce geomSubsets.
+// How: the Python scene builds a NURBS sphere with a material; we inspect its prim subtree.
+// Expect: no geomSubset prims exist under the NURBS shape (and no crash from MFnMesh use).
+// Why: guards the mesh-only path of _InsertGeomSubsetsForMesh against non-mesh shapes.
+TEST(MultiMaterialMesh, NonMeshNoGeomSubset)
+{
+    const std::string meshShapeFull = GetOptionVarOrDefault(kMeshShapeOptionVar, kMeshShapeFallback);
+    const std::string shapeNamePart = GetShapeNameFromFullPath(meshShapeFull);
+
+    const SceneIndicesVector& sceneIndices = GetTerminalSceneIndices();
+    ASSERT_GT(sceneIndices.size(), 0u);
+
+    // The NURBS surface is exposed as a basisCurves/mesh-free prim; locate the maya scene
+    // index from any terminal and scan the whole tree for geomSubsets carrying the shape name.
+    HdSceneIndexBaseRefPtr mayaSceneIndex = FindMayaHydraSceneIndex(sceneIndices.front());
+    ASSERT_TRUE(mayaSceneIndex) << "MayaHydraSceneIndex not found in scene index tree";
+
+    SceneIndexInspector inspector(mayaSceneIndex);
+    FindPrimPredicate   predicate
+        = [&shapeNamePart](const HdSceneIndexBasePtr& sceneIndex, const SdfPath& primPath) -> bool {
+        return primPath.GetString().find(shapeNamePart) != std::string::npos
+            && sceneIndex->GetPrim(primPath).primType == HdPrimTypeTokens->geomSubset;
+    };
+    PrimEntriesVector subsets = inspector.FindPrims(predicate);
+    EXPECT_TRUE(subsets.empty())
+        << "Non-mesh shapes must not produce geomSubsets, found " << subsets.size();
+}

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testMeshGeomSubsets.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testMeshGeomSubsets.py
@@ -1,0 +1,94 @@
+# Copyright 2026 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import maya.cmds as cmds
+import fixturesUtils
+import mtohUtils
+from testUtils import PluginLoaded
+
+
+class TestMeshGeomSubsets(mtohUtils.MayaHydraBaseTestCase):
+    _file = __file__
+
+    # Create a shading group named 'name' driven by a fresh lambert shader.
+    # The shading group node name becomes the leaf of the Hydra material path, so the
+    # C++ test can identify which material a geomSubset is bound to.
+    def _makeShadingGroup(self, name):
+        shader = cmds.shadingNode("lambert", asShader=True, name=name + "Mtl")
+        sg = cmds.sets(name=name, renderable=True, noSurfaceShader=True, empty=True)
+        cmds.connectAttr(shader + ".outColor", sg + ".surfaceShader", force=True)
+        return sg
+
+    # Multi-material cube: whole-object shaderASG plus a per-face shaderBSG on faces 0-2.
+    def setupPerFaceScene(self):
+        cmds.file(new=True, force=True)
+        cmds.polyCube(name="multiCube")
+        mesh_shape = cmds.ls("multiCubeShape", long=True)[0]
+        sgA = self._makeShadingGroup("shaderASG")
+        sgB = self._makeShadingGroup("shaderBSG")
+        cmds.sets("multiCubeShape", edit=True, forceElement=sgA)
+        cmds.sets("multiCubeShape.f[0:2]", edit=True, forceElement=sgB)
+        self.setHdStormRenderer()
+        cmds.optionVar(stringValue=("mhGeomSubsetMeshShape", mesh_shape))
+        cmds.refresh()
+
+    # Single-material cube: one whole-object shading group, no per-face assignment.
+    def setupSingleScene(self):
+        cmds.file(new=True, force=True)
+        cmds.polyCube(name="multiCube")
+        mesh_shape = cmds.ls("multiCubeShape", long=True)[0]
+        sgA = self._makeShadingGroup("shaderASG")
+        cmds.sets("multiCubeShape", edit=True, forceElement=sgA)
+        self.setHdStormRenderer()
+        cmds.optionVar(stringValue=("mhGeomSubsetMeshShape", mesh_shape))
+        cmds.refresh()
+
+    # Non-mesh shape: a NURBS sphere with a single shading group.
+    def setupNurbsScene(self):
+        cmds.file(new=True, force=True)
+        cmds.sphere(name="nurbsBall")
+        nurbs_shape = cmds.ls("nurbsBallShape", long=True)[0]
+        sgA = self._makeShadingGroup("shaderASG")
+        cmds.sets("nurbsBallShape", edit=True, forceElement=sgA)
+        self.setHdStormRenderer()
+        cmds.optionVar(stringValue=("mhGeomSubsetMeshShape", nurbs_shape))
+        cmds.refresh()
+
+    # What: per-face material assignments create faceSet geomSubsets bound to materials.
+    # How: build the multi-material cube, then run the C++ inspection test.
+    # Expect: the faces {0,1,2} subset binds to shaderBSG; no full-coverage subset.
+    def test_perFaceCreatesGeomSubsets(self):
+        self.setupPerFaceScene()
+        with PluginLoaded('mayaHydraCppTests'):
+            cmds.mayaHydraCppTest(f="MultiMaterialMesh.PerFaceCreatesGeomSubsets")
+
+    # What: a single whole-object assignment must not create geomSubsets.
+    # How: build the single-material cube, then run the C++ inspection test.
+    # Expect: no geomSubset prims under the mesh.
+    def test_singleAssignmentNoGeomSubset(self):
+        self.setupSingleScene()
+        with PluginLoaded('mayaHydraCppTests'):
+            cmds.mayaHydraCppTest(f="MultiMaterialMesh.SingleAssignmentNoGeomSubset")
+
+    # What: non-mesh shapes must not produce geomSubsets.
+    # How: build a NURBS sphere with a material, then run the C++ inspection test.
+    # Expect: no geomSubset prims carrying the NURBS shape name; no crash.
+    def test_nonMeshNoGeomSubset(self):
+        self.setupNurbsScene()
+        with PluginLoaded('mayaHydraCppTests'):
+            cmds.mayaHydraCppTest(f="MultiMaterialMesh.NonMeshNoGeomSubset")
+
+
+if __name__ == '__main__':
+    fixturesUtils.runTests(globals())

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testMeshPrimvars.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testMeshPrimvars.cpp
@@ -21,6 +21,9 @@
 #include <pxr/imaging/hd/primvarsSchema.h>
 #include <pxr/imaging/hd/tokens.h>
 
+#include <pxr/base/vt/array.h>
+#include <pxr/base/vt/types.h>
+
 #include <maya/MGlobal.h>
 
 #include <gtest/gtest.h>
@@ -183,5 +186,66 @@ TEST(MeshPrimvars, ParamAttributesMatchGetLogic)
         EXPECT_TRUE(paramAttrs.count(attr)) << "Attribute '" << attr
             << "' is handled by NodeDirtiedCallback or AttributeChangedCallback but is missing "
                "from kMeshParamAttributeNames in meshAdapter.cpp.";
+    }
+}
+
+// What: a mesh with UVs must expose tangents as a VtVec3fArray with the "vector" role.
+// How: read the tangents primvar (value, role, interpolation) from the mesh prim, and
+//      cross-check that the st primvar keeps the textureCoordinate role.
+// Expect: tangents value holds VtVec3fArray (not a 2-component type), role is vector,
+//         interpolation is faceVarying; st (if present) keeps the textureCoordinate role.
+// Why: regression guard for the mesh adapter tangents fix, which previously reinterpret_cast
+//      the Maya tangents to GfVec2f and tagged them with the textureCoordinate role.
+TEST(MeshPrimvars, TangentsAreVec3WithVectorRole)
+{
+    const std::string meshShapeFull = GetOptionVarOrDefault(kMeshShapeOptionVar, kMeshShapeFallback);
+    const std::string shapeNamePart = GetShapeNameFromFullPath(meshShapeFull);
+
+    const SceneIndicesVector& sceneIndices = GetTerminalSceneIndices();
+    ASSERT_GT(sceneIndices.size(), 0u);
+
+    HdSceneIndexBaseRefPtr sceneIndexWithMesh = FindTerminalSceneIndexWithPrim(
+        sceneIndices, shapeNamePart, HdPrimTypeTokens->mesh);
+    ASSERT_TRUE(sceneIndexWithMesh)
+        << "Mesh prim not found in any scene index (ensure MAYA_HYDRA_USE_MESH_ADAPTER=1)";
+
+    auto mayaSceneIndex = FindMayaHydraSceneIndex(sceneIndexWithMesh);
+    ASSERT_TRUE(mayaSceneIndex) << "MayaHydraSceneIndex not found in scene index tree";
+
+    SceneIndexInspector inspector(mayaSceneIndex);
+    PrimEntriesVector   foundPrims
+        = inspector.FindPrims(CreatePrimPredicate(shapeNamePart, HdPrimTypeTokens->mesh), 1);
+    ASSERT_GE(foundPrims.size(), 1u) << "Mesh not found in MayaHydraSceneIndex";
+
+    HdSceneIndexPrim prim = foundPrims.front().prim;
+    ASSERT_NE(prim.dataSource, nullptr);
+
+    HdPrimvarsSchema primvars = HdPrimvarsSchema::GetFromParent(prim.dataSource);
+
+    HdPrimvarSchema tangents = primvars.GetPrimvar(TfToken("tangents"));
+    ASSERT_TRUE(tangents.IsDefined()) << "tangents primvar should be present on a mesh with UVs";
+
+    // Type: tangents are 3-component vectors, so the value must hold a VtVec3fArray.
+    ASSERT_TRUE(tangents.GetPrimvarValue());
+    VtValue tangentsValue = tangents.GetPrimvarValue()->GetValue(0.0f);
+    EXPECT_TRUE(tangentsValue.IsHolding<VtVec3fArray>())
+        << "tangents must be VtVec3fArray, got: " << tangentsValue.GetTypeName();
+
+    // Role: tangents are direction vectors, not texture coordinates.
+    ASSERT_TRUE(tangents.GetRole());
+    EXPECT_EQ(tangents.GetRole()->GetTypedValue(0.0f), HdPrimvarRoleTokens->vector)
+        << "tangents role must be 'vector'";
+
+    // Interpolation: tangents are authored per face-vertex.
+    ASSERT_TRUE(tangents.GetInterpolation());
+    EXPECT_EQ(
+        tangents.GetInterpolation()->GetTypedValue(0.0f), HdPrimvarSchemaTokens->faceVarying)
+        << "tangents interpolation must be 'faceVarying'";
+
+    // Control: the st primvar coexists with tangents and keeps the textureCoordinate role.
+    HdPrimvarSchema st = primvars.GetPrimvar(TfToken("st"));
+    if (st.IsDefined() && st.GetRole()) {
+        EXPECT_EQ(st.GetRole()->GetTypedValue(0.0f), HdPrimvarRoleTokens->textureCoordinate)
+            << "st role must remain 'textureCoordinate'";
     }
 }

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testMeshPrimvars.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testMeshPrimvars.py
@@ -60,6 +60,14 @@ class TestMeshPrimvars(mtohUtils.MayaHydraBaseTestCase):
         with PluginLoaded('mayaHydraCppTests'):
             cmds.mayaHydraCppTest(f="MeshPrimvars.ParamAttributesMatchGetLogic")
 
+    # What: tangents primvar must be a VtVec3fArray with the "vector" role.
+    # How: build the UV cube scene, then run the C++ tangents type/role test.
+    # Expect: tangents are VtVec3fArray, role vector, interpolation faceVarying.
+    def test_tangentsAreVec3WithVectorRole(self):
+        self.setupScene()
+        with PluginLoaded('mayaHydraCppTests'):
+            cmds.mayaHydraCppTest(f="MeshPrimvars.TangentsAreVec3WithVectorRole")
+
 
 if __name__ == '__main__':
     fixturesUtils.runTests(globals())

--- a/test/lib/mayaUsd/render/mayaToHydra/testMeshAdapterVisibility.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/testMeshAdapterVisibility.py
@@ -1,0 +1,89 @@
+# Copyright 2026 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import os
+
+import maya.cmds as cmds
+
+import fixturesUtils
+import mtohUtils
+
+
+class TestMeshAdapterVisibility(mtohUtils.MayaHydraBaseTestCase):
+    '''Validate that the mesh-adapter InsertDag path skips invisible shapes.
+
+    In batch / mesh-adapter mode the scene index is populated by iterating the whole DAG
+    (MItDag), which visits LOD meshes and corrective blend-shape targets that VP2 never makes
+    render items for. InsertDag must skip shapes that are not visible so only renderable
+    geometry reaches Hydra, matching viewport behaviour.
+    '''
+
+    _file = __file__
+
+    def matchingRprims(self, rprims, matching):
+        return len([rprim for rprim in rprims if matching in rprim])
+
+    # Force a full repopulate so InsertDag re-runs with the current visibility state.
+    def repopulate(self):
+        self.setViewport2Renderer()
+        self.setHdStormRenderer()
+        cmds.refresh()
+
+    # What: an invisible mesh must not be inserted into the Hydra render index.
+    # How: create a visible and a hidden cube, repopulate, then inspect the render index.
+    # Expect: the visible cube's rprim is present; the hidden cube's rprim is absent.
+    def test_invisibleMeshIsSkipped(self):
+        if not os.getenv('MAYA_HYDRA_USE_MESH_ADAPTER'):
+            self.skipTest("Visibility filtering on InsertDag only applies to the mesh adapter path.")
+
+        self.setHdStormRenderer()
+
+        cmds.polyCube(name="visibleCube")
+        cmds.polyCube(name="hiddenCube")
+        cmds.setAttr("hiddenCube.visibility", 0)
+
+        # Repopulate so the hidden cube is evaluated by InsertDag while already invisible.
+        self.repopulate()
+
+        rprims = self.getIndex()
+        self.assertGreaterEqual(
+            self.matchingRprims(rprims, "visibleCubeShape"), 1,
+            "Visible mesh should be present in the render index")
+        self.assertEqual(
+            self.matchingRprims(rprims, "hiddenCubeShape"), 0,
+            "Hidden mesh must be skipped by the mesh-adapter InsertDag path")
+
+    # What: a mesh hidden via an invisible ancestor transform must also be skipped.
+    # How: parent a cube under a hidden group, repopulate, then inspect the render index.
+    # Expect: the cube's rprim is absent (dag.isVisible() accounts for ancestor visibility).
+    def test_meshUnderHiddenGroupIsSkipped(self):
+        if not os.getenv('MAYA_HYDRA_USE_MESH_ADAPTER'):
+            self.skipTest("Visibility filtering on InsertDag only applies to the mesh adapter path.")
+
+        self.setHdStormRenderer()
+
+        cmds.polyCube(name="childCube")
+        group = cmds.group("childCube", name="hiddenGroup")
+        cmds.setAttr(group + ".visibility", 0)
+
+        self.repopulate()
+
+        rprims = self.getIndex()
+        self.assertEqual(
+            self.matchingRprims(rprims, "childCubeShape"), 0,
+            "Mesh under a hidden group must be skipped by the mesh-adapter InsertDag path")
+
+
+if __name__ == '__main__':
+    fixturesUtils.runTests(globals())


### PR DESCRIPTION
## Summary

This PR addresses several maya-hydra material and mesh issues uncovered while investigating the walrus chess-set scene, plus the supporting build configuration. The changes span MaterialX network translation, mesh tangents, multi-material (per-face) mesh binding, and batch-mode DAG traversal.

## Changes

### MaterialX
- **Warn on unresolved MaterialX node definitions** (`materialAdapter.cpp`): after parsing the MaterialX document, emit a `TF_WARN` listing any node definitions that could not be resolved, along with the search paths used. Previously, `UsdMtlxRead` silently dropped unresolved nodes *and the branches feeding them*, causing the interactive viewport network to diverge from a batch/USD render with no diagnostic. The warning makes this actionable.
- **Guard MaterialX usage behind `WANT_MATERIALX_BUILD`** (`materialAdapter.cpp`, `CMakeLists.txt`): the repo's top-level CMake supports USD packages built without `hdMtlx` (it disables MaterialX in that case). All MaterialX-dependent includes (`hdMtlx`, `usdMtlx`, MaterialX headers) and code (`PopulateMaterialXNetworkMap`) are now gated behind `WANT_MATERIALX_BUILD`, and the `hdMtlx`/`usdMtlx` link libraries are gated behind `CMAKE_WANT_MATERIALX_BUILD`. When MaterialX is disabled, material resolution falls back to the standard Maya material network converter.

### Mesh tangents
- **Fix tangent primvar type** (`meshAdapter.cpp`): tangents from Maya's `MFnMesh::getTangents` (3-float `MFloatVectorArray`) were `reinterpret_cast` to `GfVec2f`, which mis-strided the buffer and corrupted the data. They are now built into a `VtVec3fArray` with an explicit `GfVec3f(x, y, z)` conversion, matching OpenUSD/Hydra, where tangents are `VtVec3fArray`/`GfVec3f` and consumed as `vec3`.
- **Fix tangent primvar role** (`meshAdapter.cpp`): the `tangents` primvar role was `textureCoordinate`; it is now `vector`, matching how OpenUSD tags direction vectors (`UsdImagingUsdToHdRole`; velocities/accelerations use `vector`). `st` continues to use `textureCoordinate`.

### Multi-material (per-face) meshes
- **Emit geom subsets for multi-material meshes** (`mayaHydraSceneIndex.cpp/.h`, `mayaUtils.cpp/.h`, `shapeAdapter.cpp/.h`): added `GetAllShadingAssignments` / `FindShadingEngine` helpers and `_InsertGeomSubsetsForMesh`, which create the bound material(s) and, when a mesh has more than one shading group, emit one `HdGeomSubset` (faceSet + material binding) per assignment so per-face/multi-material meshes shade correctly. `MayaHydraShapeAdapter::GetMaterial` now accepts an optional component to support per-face lookups.

### Batch-mode DAG traversal
- **Skip invisible shapes in batch `InsertDag`** (`mayaHydraSceneIndex.cpp`): in batch mode (`useMeshAdapter`), `MItDag` visits every DAG node including LOD meshes and corrective blend-shape targets that VP2 never makes render items for. Invisible shapes are now skipped so only the intended renderable geometry reaches Hydra, matching viewport behavior.

## Notes

- An earlier approach that bridged `MATERIALX_SEARCH_PATH` by importing custom nodedefs/nodegraphs into the per-material document was implemented and reverted: mutating the document changed what `UsdMtlxRead` interpreted, producing a corrupted network (wrong terminal) in both viewport and batch. The recommended way to achieve viewport↔batch library parity is configuration (add the custom library to `PXR_MTLX_STDLIB_SEARCH_PATHS`), not document mutation.
- The walrus eye material issue that originally triggered the investigation was a separate material-authoring bug (missing `Mask`), fixed by the artist in LookdevX.

## Testing

- [ ] Walrus chess-set scene renders correctly in the HdArnold viewport and batch.
- [ ] Multi-material meshes shade per-face correctly in the viewport.
- [ ] Meshes with tangents (e.g. normal-mapped MaterialX materials) render correctly.
- [ ] Builds configure and compile both with and without MaterialX support (`CMAKE_WANT_MATERIALX_BUILD` ON/OFF).
- [ ] Batch render does not include hidden LOD/blend-shape geometry.