### PR TITLE
HYDRA-2274 : Make maya hydra compliant with usd 26.05

### DIFF
--- a/lib/mayaHydra/flowViewportAPIExamples/flowViewportAPILocator/mhFlowViewportAPILocator.cpp
+++ b/lib/mayaHydra/flowViewportAPIExamples/flowViewportAPILocator/mhFlowViewportAPILocator.cpp
@@ -235,6 +235,12 @@ MhFlowViewportAPILocator* getLocator(const Ufe::Path& cubePath)
         return nullptr;
     }
     auto locatorDagPath = UfeExtensions::ufeToDagPath(cubePath.pop());
+    if (!locatorDagPath.isValid()) {
+        TF_WARN(
+            "Failed to convert UFE path %s to a valid Maya DAG path.",
+            Ufe::PathString::string(cubePath).c_str());
+        return nullptr;
+    }
     MFnDependencyNode fn(locatorDagPath.node());
     return dynamic_cast<MhFlowViewportAPILocator*>(fn.userNode());
 }

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
@@ -624,6 +624,14 @@ Fvp::PrimSelections MayaHydraSceneIndex::UfePathToPrimSelections(const Ufe::Path
     // the UFE path to a string, then does a Dag path lookup with the string.
 
     auto       dagPath = UfeExtensions::ufeToDagPath(appPath);
+    if (!dagPath.isValid()) {
+        TF_WARN(
+            "MayaHydraSceneIndex::UfePathToPrimSelections: Could not convert UFE path %s to a valid "
+            "Maya DAG path.",
+            Ufe::PathString::string(appPath).c_str());
+        return {};
+    }
+
     const bool extendToShape = _UseTheShapeDagPath(
         dagPath); // For Hydra some prims, we need to use the shape dag path not the transform, as
                   // this is what gets translated to an hydra path

--- a/lib/mayaHydra/mayaPlugin/renderOverride.cpp
+++ b/lib/mayaHydra/mayaPlugin/renderOverride.cpp
@@ -946,6 +946,14 @@ MStatus MtohRenderOverride::Render(
             if (isPass0) {
                 // Do not share the AOVs, for the first pass only
                 HdTaskSharedPtrVector passTasks = currentPass->GetRenderTasks();
+#if PXR_VERSION >= 2605
+                if (_sceneGlobalsSceneIndex) {
+                    const SdfPath& cameraPath = currentPass->params().renderParams.camera;
+                    if (!cameraPath.IsEmpty()) {
+                        _sceneGlobalsSceneIndex->SetPrimaryCameraPrimPath(cameraPath);
+                    }
+                }
+#endif
                 
                 /*Debug code left here if needed later
                 hvt::FramePass& framePassToDebug = *currentPass;
@@ -966,6 +974,14 @@ MStatus MtohRenderOverride::Render(
                             { PXR_NS::HdAovTokens->color, PXR_NS::HdAovTokens->depth }
                     );
                     HdTaskSharedPtrVector passTasks = currentPass->GetRenderTasks(inputAOVs);
+#if PXR_VERSION >= 2605
+                    if (_sceneGlobalsSceneIndex) {
+                        const SdfPath& cameraPath = currentPass->params().renderParams.camera;
+                        if (!cameraPath.IsEmpty()) {
+                            _sceneGlobalsSceneIndex->SetPrimaryCameraPrimPath(cameraPath);
+                        }
+                    }
+#endif
 
                     /*Debug code left here if needed later
                     hvt::FramePass& framePassToDebug = *currentPass;
@@ -1277,7 +1293,7 @@ MStatus MtohRenderOverride::Render(
         if (isMayaCamera) { // TODO: Support USD Camera
             MFnCamera camera(camPath, &status);
             if (status == MStatus::kSuccess) {
-                if (_mayaHydraSceneIndex && !camera.isOrtho()) { // TODO: Support Persp Camera
+                if (_mayaHydraSceneIndex && !camera.isOrtho()) {
                     SdfPath cameraPath = _mayaHydraSceneIndex->SetCameraViewport(camPath, _viewport);
                     // Apply on all passes
                     const int numFramePasses = _GetNumFramePasses();
@@ -1292,6 +1308,21 @@ MStatus MtohRenderOverride::Render(
                     }
                     if (vpDirty)
                         _mayaHydraSceneIndex->MarkSprimDirty(cameraPath, HdCamera::DirtyParams);
+#if PXR_VERSION >= 2605
+                    if (_sceneGlobalsSceneIndex && !cameraPath.IsEmpty()) {
+                        _sceneGlobalsSceneIndex->SetPrimaryCameraPrimPath(cameraPath);
+                    }
+#endif
+                } else if (camera.isOrtho()) {
+                    // Orthographic views use the free camera derived from viewport matrices.
+                    const int numFramePasses = _GetNumFramePasses();
+                    for (int i = 0; i < numFramePasses; ++i) {
+                        const hvt::FramePassPtr& currentPass = _GetFramePass(i);
+                        if (!currentPass) {
+                            continue;
+                        }
+                        currentPass->params().renderParams.camera = SdfPath();
+                    }
                 }
             }
         }

--- a/lib/mayaHydra/ufeExtensions/Global.cpp
+++ b/lib/mayaHydra/ufeExtensions/Global.cpp
@@ -63,7 +63,11 @@ MDagPath nameToDagPath(const std::string& name)
     // Not found?  Empty selection list.
     if (!selection.isEmpty()) {
         MStatus status = selection.getDagPath(0, dag);
-        CHECK_MSTATUS(status);
+        if (!status) {
+            dag = MDagPath();
+            TF_WARN(
+                "Failed to get dag path for '%s': %s", name.c_str(), status.errorString().asChar());
+        }
     }
     return dag;
 }


### PR DESCRIPTION
The change in this PR is to make MayaHydra compile with usd 26.05.
The main change is in the HVT submodule where I created a branch in the HVT repo https://github.com/Autodesk/hydra-viewport-toolbox/tree/mayaHydra/usd-26.05 . This branch contains some commits to compile with usd 26.05 but updating to the latest from main broke usd 24.11 for maya 2026. So I had to make a branch and cherry-pick some specific commits to make maya hydra compile with usd 26.05 and 24.11. In the future we will switch to the main branch again from HVT when it compiles with usd 24.11 and delete the maya hdyra branch and update the [tag](https://github.com/Autodesk/hydra-viewport-toolbox/releases/tag/v0.26.05.0_hydra_viewport_toolbox) which currently points on the head of the maya hydra branch.