### PR TITLE
Moved path mapping support to MayaUsdProxyShapeSceneIndexBase.

### DIFF
--- a/lib/flowViewport/selection/fvpPathMapperRegistry.cpp
+++ b/lib/flowViewport/selection/fvpPathMapperRegistry.cpp
@@ -152,7 +152,9 @@ PrimSelections PathMapperRegistry::UfePathToPrimSelections(
             else {
                 primSelections = mapper->UfePathToPrimSelections(appPath);
                 if (primSelections.empty()) {
-                    TF_WARN("Mapping for path %s returned no prim path.", Ufe::PathString::string(appPath).c_str());
+                    // Maintenance warning: test usdProxyShapeRenderSettings
+                    // checks that this warning string is not emitted.
+                    TF_WARN("Mapping for application path %s returned no prim path.", Ufe::PathString::string(appPath).c_str());
                 }
             }
         }

--- a/lib/flowViewport/selection/fvpPathMapperRegistry.cpp
+++ b/lib/flowViewport/selection/fvpPathMapperRegistry.cpp
@@ -151,11 +151,8 @@ PrimSelections PathMapperRegistry::UfePathToPrimSelections(
             }
             else {
                 primSelections = mapper->UfePathToPrimSelections(appPath);
-                if (primSelections.empty()) {
-                    // Maintenance warning: test usdProxyShapeRenderSettings
-                    // checks that this warning string is not emitted.
-                    TF_WARN("Mapping for application path %s returned no prim path.", Ufe::PathString::string(appPath).c_str());
-                }
+                TF_VERIFY(!primSelections.empty(),
+                          "Mapping for application path %s returned no prim path.", Ufe::PathString::string(appPath).c_str());
             }
         }
     }

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mhMayaUsdProxyShapeSceneIndex.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mhMayaUsdProxyShapeSceneIndex.cpp
@@ -19,131 +19,7 @@
 #include <mayaHydraLib/pick/mhPickHandlerRegistry.h>
 #include <mayaHydraLib/pick/mhUsdPickHandler.h>
 
-#include <flowViewport/fvpInstruments.h>
-#include <flowViewport/selection/fvpPathMapperRegistry.h>
-
-// mayaHydra headers
-#include "ufeExtensions/Global.h"
-
-#include <pxr/imaging/hd/instanceSchema.h>
-#include <pxr/imaging/hd/instancerTopologySchema.h>
-#include <pxr/imaging/hd/tokens.h>
-#include <pxr/usdImaging/usdImaging/usdPrimInfoSchema.h>
-
-#include <ufe/scene.h>
-#include <ufe/sceneNotification.h>
-
-#include <optional>
-
 PXR_NAMESPACE_USING_DIRECTIVE
-
-namespace {
-
-const std::string digits = "0123456789";
-
-// Pixar macros won't work without PXR_NS.
-PXR_NAMESPACE_USING_DIRECTIVE
-using namespace Ufe;
-using namespace MayaHydra;
-
-SdfPath append(const SdfPath& prefix, const SdfPath& src)
-{
-    return prefix.AppendPath(src.MakeRelativePath(SdfPath::AbsoluteRootPath()));
-}
-
-Fvp::PrimSelections addPrefix(const SdfPath& sceneIndexPathPrefix, const Fvp::PrimSelections& src)
-{
-    // Copy the source into the destination, and patch up the destination.
-    Fvp::PrimSelections dst { src };
-
-    for (auto& d : dst) {
-        d.primPath = append(sceneIndexPathPrefix, d.primPath);
-
-        for (auto& dis : d.nestedInstanceIndices) {
-            dis.instancerPath = append(sceneIndexPathPrefix, dis.instancerPath);
-        }
-    }
-    return dst;
-}
-
-// UFE Observer that unpacks SceneCompositeNotification's.  Belongs in UFE
-// itself.
-class SceneObserver : public Observer
-{
-public:
-    SceneObserver() = default;
-
-    virtual void handleOp(const SceneCompositeNotification::Op& op) = 0;
-
-private:
-    void operator()(const Notification& notification) override
-    {
-        const auto& sceneChanged = notification.staticCast<SceneChanged>();
-
-        if (SceneChanged::SceneCompositeNotification == sceneChanged.opType()) {
-            const auto& compNotification = notification.staticCast<SceneCompositeNotification>();
-            for (const auto& op : compNotification) {
-                handleOp(op);
-            }
-        } else {
-            handleOp(sceneChanged);
-        }
-    }
-};
-
-class UsdPathMapperSceneObserver : public SceneObserver
-{
-public:
-    UsdPathMapperSceneObserver(MayaUsdProxyShapeSceneIndex& psSi)
-        : SceneObserver()
-        , _psSi(psSi)
-    {
-    }
-
-private:
-    // If the proxy shape's app path changes, update the app path key in the
-    // path mapper registry.
-    void handleOp(const SceneCompositeNotification::Op& op) override
-    {
-        if (op.opType == SceneChanged::ObjectPathChange
-            && ((op.subOpType == ObjectPathChange::ObjectReparent)
-                || (op.subOpType == ObjectPathChange::ObjectRename))) {
-            const auto& siPath = _psSi.GetSceneIndexAppPath();
-            if (siPath.startsWith(op.path)) {
-                const auto oldPath = siPath;
-                auto       newPath = oldPath.reparent(op.path, op.item->path());
-                _psSi.SetSceneIndexAppPath(newPath);
-
-                // Update our entry in the path mapper registry.
-                TF_AXIOM(Fvp::PathMapperRegistry::Instance().Update(oldPath, newPath));
-            }
-        }
-    }
-
-    MayaUsdProxyShapeSceneIndex& _psSi;
-};
-
-class UsdPathMapper : public Fvp::PathMapper
-{
-public:
-    UsdPathMapper(const MayaUsdProxyShapeSceneIndex& psSi)
-        : _psSi(psSi)
-    {
-    }
-
-    Fvp::PrimSelections UfePathToPrimSelections(const Ufe::Path& appPath) const override
-    {
-        return _psSi.UfePathToPrimSelections(appPath);
-    }
-
-    std::string Name() const override { return "UsdPathMapper"; }
-
-private:
-    // Non-owning reference to prevent ownership cycle.
-    const MayaUsdProxyShapeSceneIndex& _psSi;
-};
-
-} // namespace
 
 namespace MAYAHYDRA_NS_DEF {
 
@@ -154,11 +30,8 @@ MayaUsdProxyShapeSceneIndex::MayaUsdProxyShapeSceneIndex(
     const MObjectHandle&                   dagNodeHandle,
     const SdfPath&                         sceneIndexPathPrefix,
     const Ufe::Path&                       sceneIndexAppPath)
-    : ParentClass(proxyStage, sceneIndexChainLastElement, usdImagingStageSceneIndex, dagNodeHandle)
-    , _sceneIndexPathPrefix(sceneIndexPathPrefix)
-    , _sceneIndexAppPath(sceneIndexAppPath)
-    , _appSceneObserver(std::make_shared<UsdPathMapperSceneObserver>(*this))
-    , _usdPathMapper(std::make_shared<UsdPathMapper>(*this))
+    : ParentClass(proxyStage, sceneIndexChainLastElement, usdImagingStageSceneIndex, dagNodeHandle,
+                  sceneIndexPathPrefix, sceneIndexAppPath)
 {
     // Add our pick handler to the pick handler registry if there is none.
     auto& phr = MayaHydra::PickHandlerRegistry::Instance();
@@ -167,19 +40,6 @@ MayaUsdProxyShapeSceneIndex::MayaUsdProxyShapeSceneIndex(
         auto pickHandler = std::make_shared<UsdPickHandler>();
         TF_AXIOM(phr.Register(sceneIndexPathPrefix, pickHandler));
     }
-
-    // The gateway node (proxy shape) is a Maya node, so the scene index
-    // path must be a single segment.
-    TF_AXIOM(sceneIndexAppPath.nbSegments() == 1);
-
-    // Observe the scene to be informed of path changes to the gateway node
-    // (proxy shape) that corresponds to our scene index data producer.
-    Scene::instance().addObserver(_appSceneObserver);
-
-    // Register a mapper in the path mapper registry, if there is none
-    // for this path.
-    _unregisterPathMapper = Fvp::PathMapperRegistry::Instance().Register(
-        _sceneIndexAppPath, _usdPathMapper);
 }
 
 MayaUsdProxyShapeSceneIndex::~MayaUsdProxyShapeSceneIndex()
@@ -198,16 +58,6 @@ void MayaUsdProxyShapeSceneIndex::_DestroyDerived()
     if (_unregisterPickHandler) {
         TF_AXIOM(PickHandlerRegistry::Instance().Unregister(_sceneIndexPathPrefix));
     }
-
-    // Unregister our path mapper.
-    if (_unregisterPathMapper) {
-        Fvp::PathMapperRegistry::Instance().Unregister(_sceneIndexAppPath);
-    }
-
-    // Ufe::Subject has automatic cleanup of stale observers, but this can
-    // be problematic on application exit if the library of the observer is
-    // cleaned up before that of the subject, so simply stop observing.
-    Scene::instance().removeObserver(_appSceneObserver);
 }
 
 MayaUsdProxyShapeSceneIndexRefPtr MayaUsdProxyShapeSceneIndex::New(
@@ -225,147 +75,6 @@ MayaUsdProxyShapeSceneIndexRefPtr MayaUsdProxyShapeSceneIndex::New(
         dagNodeHandle,
         sceneIndexPathPrefix,
         sceneIndexAppPath));
-}
-
-Fvp::PrimSelections
-MayaUsdProxyShapeSceneIndex::UfePathToPrimSelections(const Ufe::Path& appPath) const
-{
-    // If the data model object application path does not match the path we
-    // translate, return an empty path.
-    if (!appPath.startsWith(_sceneIndexAppPath)) {
-        return {};
-    }
-
-    // If the application path is our prefix, just return the
-    // corresponding scene index path.
-    if (appPath == _sceneIndexAppPath) {
-        return Fvp::PrimSelections { Fvp::PrimSelection { _sceneIndexPathPrefix } };
-    }
-
-    // The scene index path is composed of 2 parts, in order:
-    // 1) The scene index path prefix, which is fixed on construction.
-    // 2) The second segment of the UFE path, with each UFE path component
-    //    becoming an SdfPath component. If the last component is a number,
-    //    then we are dealing with an instance selection.
-    TF_AXIOM(appPath.nbSegments() == 2);
-    SdfPath                                primPath = SdfPath::AbsoluteRootPath();
-    std::optional<Fvp::InstancesSelection> instanceSelection;
-
-    auto       secondSegment = appPath.getSegments()[1];
-    const auto lastComponentString = secondSegment.components().back().string();
-    const bool lastComponentIsNumeric
-        = lastComponentString.find_first_not_of(digits) == std::string::npos;
-    const size_t lastComponentIndex = secondSegment.size() - 1;
-
-    for (size_t iComponent = 0; iComponent < secondSegment.size(); iComponent++) {
-        // Native instancing : if the current prim path points to a native instance, repath to the
-        // prototype before appending the following UFE components
-        HdSceneIndexPrim prim = GetPrim(primPath);
-        HdInstanceSchema instanceSchema = HdInstanceSchema::GetFromParent(prim.dataSource);
-        if (instanceSchema.IsDefined()) {
-            auto             instancerPath = instanceSchema.GetInstancer()->GetTypedValue(0);
-            HdSceneIndexPrim instancerPrim = GetPrim(instancerPath);
-            HdInstancerTopologySchema instancerTopologySchema
-                = HdInstancerTopologySchema::GetFromParent(instancerPrim.dataSource);
-            auto prototypes = instancerTopologySchema.GetPrototypes()->GetTypedValue(0);
-            auto prototypeIndex = instanceSchema.GetPrototypeIndex()->GetTypedValue(0);
-            primPath = prototypes[prototypeIndex];
-            instanceSelection = { instancerPath,
-                                  prototypeIndex,
-                                  { instanceSchema.GetInstanceIndex()->GetTypedValue(0) } };
-        }
-
-        // SdfPath components cannot be numeric.  This happens with point instance selections.
-        auto targetChildPath = ((iComponent == lastComponentIndex) && lastComponentIsNumeric)
-            ? SdfPath()
-            : primPath.AppendChild(TfToken(secondSegment.components()[iComponent].string()));
-        auto actualChildPaths = GetChildPrimPaths(primPath);
-        if (!targetChildPath.IsEmpty()
-            && std::find(actualChildPaths.begin(), actualChildPaths.end(), targetChildPath)
-                != actualChildPaths.end()) {
-            // Append if the new path is valid
-            primPath = targetChildPath;
-        } else if (iComponent == lastComponentIndex) {
-            // If the last component is a number, we are dealing with an instance selection.
-            // But there are other cases like when you assign a USD Preview surface material to a
-            // usd prim, it has a shader prim in the material which doesn't appear in the hydra
-            // hierarchy but is actually present and we end up in this case as well.
-            if (lastComponentIsNumeric) {
-                // Point instancing : instance selection. The path should end with a number
-                // corresponding to the selected instance,
-                // and the remainder of the path points to the point instancer.
-                HdSceneIndexPrim          instancerPrim = GetPrim(primPath);
-                HdInstancerTopologySchema instancerTopologySchema
-                    = HdInstancerTopologySchema::GetFromParent(instancerPrim.dataSource);
-                auto instanceIndicesByPrototype = instancerTopologySchema.GetInstanceIndices();
-                for (int iInstanceIndices = 0; static_cast<size_t>(iInstanceIndices)
-                     < instanceIndicesByPrototype.GetNumElements();
-                     iInstanceIndices++) {
-                    auto instanceIndices
-                        = instanceIndicesByPrototype.GetElement(iInstanceIndices)->GetTypedValue(0);
-                    if (std::find(
-                            instanceIndices.begin(),
-                            instanceIndices.end(),
-                            std::stoi(lastComponentString))
-                        != instanceIndices.end()) {
-                        instanceSelection
-                            = { primPath, iInstanceIndices, { std::stoi(lastComponentString) } };
-                        break;
-                    }
-                }
-            }
-        } else {
-            // There is no prim corresponding to the converted path
-            TF_WARN("Could not convert UFE path %s to Hydra prims.", appPath.string().data());
-            return {};
-        }
-    }
-
-    Fvp::PrimSelection  baseSelection = instanceSelection.has_value()
-         ? Fvp::PrimSelection { primPath, { instanceSelection.value() } }
-         : Fvp::PrimSelection { primPath };
-    Fvp::PrimSelections primSelections({ baseSelection });
-
-    // Point instancing : propagate selection to propagated prototypes
-    auto ancestorsRange = primPath.GetAncestorsRange();
-    for (const auto& ancestorPath : ancestorsRange) {
-        HdSceneIndexPrim            currPrim = GetPrim(ancestorPath);
-        UsdImagingUsdPrimInfoSchema usdPrimInfo
-            = UsdImagingUsdPrimInfoSchema::GetFromParent(currPrim.dataSource);
-        if (!usdPrimInfo.IsDefined()) {
-            continue;
-        }
-        auto propagatedProtosDataSource = usdPrimInfo.GetPiPropagatedPrototypes();
-        if (!propagatedProtosDataSource) {
-            continue;
-        }
-        auto propagatedProtoNames = propagatedProtosDataSource->GetNames();
-        for (const auto& propagatedProtoName : propagatedProtoNames) {
-            auto propagatedProtoPathDataSource = HdTypedSampledDataSource<SdfPath>::Cast(
-                propagatedProtosDataSource->Get(propagatedProtoName));
-            if (propagatedProtoPathDataSource) {
-                SdfPath propagatedProtoPath = propagatedProtoPathDataSource->GetTypedValue(0);
-                SdfPath propagatedPrimPath
-                    = primPath.ReplacePrefix(ancestorPath, propagatedProtoPath);
-                HdSceneIndexPrim propagatedPrim = GetPrim(propagatedPrimPath);
-                // This check controls which types of prims have their selection data source
-                // propagated. Currently we skip instancers so that selecting an instancer A that is
-                // both drawing geometry but also prototyped and propagated for another instancer B
-                // will only mark the geometry-drawing instancer A as selected. This can be changed.
-                // For now (2024/05/28), this only affects selection highlighting.
-                if (propagatedPrim.primType != HdPrimTypeTokens->instancer) {
-                    primSelections.push_back(
-                        { propagatedPrimPath, primSelections.front().nestedInstanceIndices });
-                }
-            }
-        }
-        break; // We found propagated prototypes, exit now to avoid propagating selection to
-               // prototypes of other parents
-    }
-
-    // Now have primSelections in the namespace of this scene index.  Need to
-    // account for the prefix, which is added downstream of this scene index.
-    return addPrefix(_sceneIndexPathPrefix, primSelections);
 }
 
 } // namespace MAYAHYDRA_NS_DEF

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mhMayaUsdProxyShapeSceneIndex.h
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mhMayaUsdProxyShapeSceneIndex.h
@@ -21,11 +21,6 @@
 
 #include <mayaHydraLib/sceneIndex/mhMayaUsdProxyShapeSceneIndexBase.h>
 
-// Flow Viewport Toolkit headers.
-#include <flowViewport/selection/fvpPathMapper.h>
-
-#include <ufe/observer.h>
-
 PXR_NAMESPACE_USING_DIRECTIVE
 
 namespace MAYAHYDRA_NS_DEF {
@@ -55,14 +50,6 @@ public:
 
     ~MayaUsdProxyShapeSceneIndex() override;
 
-    Fvp::PrimSelections UfePathToPrimSelections(const Ufe::Path& appPath) const;
-
-    const Ufe::Path& GetSceneIndexAppPath() const { return _sceneIndexAppPath; }
-    void             SetSceneIndexAppPath(const Ufe::Path& sceneIndexAppPath)
-    {
-        _sceneIndexAppPath = sceneIndexAppPath;
-    }
-
 private:
     MayaUsdProxyShapeSceneIndex(
         const MAYAUSDAPI_NS::ProxyStage&       proxyStage,
@@ -75,14 +62,7 @@ private:
     void _Destroy() override;
     void _DestroyDerived();
 
-    // Path mapper support.
-    const SdfPath                   _sceneIndexPathPrefix;
-    Ufe::Path                       _sceneIndexAppPath;
-    const Ufe::Observer::Ptr        _appSceneObserver{};
-    const Fvp::PathMapperConstPtr   _usdPathMapper{};
-
     bool _unregisterPickHandler{false};
-    bool _unregisterPathMapper{false};
 };
 
 } // namespace MAYAHYDRA_NS_DEF

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mhMayaUsdProxyShapeSceneIndexBase.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mhMayaUsdProxyShapeSceneIndexBase.cpp
@@ -17,11 +17,129 @@
 #include "mhMayaUsdProxyShapeSceneIndexBase.h"
 
 #include <flowViewport/fvpInstruments.h>
+#include <flowViewport/selection/fvpPathMapper.h>
+#include <flowViewport/selection/fvpPathMapperRegistry.h>
 
 //mayaHydra headers
 #include "ufeExtensions/Global.h"
 
+#include <pxr/imaging/hd/instanceSchema.h>
+#include <pxr/imaging/hd/instancerTopologySchema.h>
+#include <pxr/imaging/hd/tokens.h>
+#include <pxr/usdImaging/usdImaging/usdPrimInfoSchema.h>
+
+#include <ufe/scene.h>
+#include <ufe/sceneNotification.h>
+
+#include <optional>
+
 PXR_NAMESPACE_USING_DIRECTIVE
+
+namespace {
+
+const std::string digits = "0123456789";
+
+SdfPath append(const SdfPath& prefix, const SdfPath& src)
+{
+    return prefix.AppendPath(src.MakeRelativePath(SdfPath::AbsoluteRootPath()));
+}
+
+Fvp::PrimSelections addPrefix(const SdfPath& sceneIndexPathPrefix, const Fvp::PrimSelections& src)
+{
+    // Copy the source into the destination, and patch up the destination.
+    Fvp::PrimSelections dst { src };
+
+    for (auto& d : dst) {
+        d.primPath = append(sceneIndexPathPrefix, d.primPath);
+
+        for (auto& dis : d.nestedInstanceIndices) {
+            dis.instancerPath = append(sceneIndexPathPrefix, dis.instancerPath);
+        }
+    }
+    return dst;
+}
+
+class UsdPathMapper : public Fvp::PathMapper
+{
+public:
+    UsdPathMapper(const MayaHydra::MayaUsdProxyShapeSceneIndexBase& psSi)
+        : _psSi(psSi)
+    {
+    }
+
+    Fvp::PrimSelections UfePathToPrimSelections(const Ufe::Path& appPath) const override
+    {
+        return _psSi.UfePathToPrimSelections(appPath);
+    }
+
+    std::string Name() const override { return "UsdPathMapper"; }
+
+private:
+    // Non-owning reference to prevent ownership cycle.
+    const MayaHydra::MayaUsdProxyShapeSceneIndexBase& _psSi;
+};
+
+using namespace Ufe;
+using namespace MayaHydra;
+
+// UFE Observer that unpacks SceneCompositeNotification's.  Belongs in UFE
+// itself.
+class SceneObserver : public Observer
+{
+public:
+    SceneObserver() = default;
+
+    virtual void handleOp(const SceneCompositeNotification::Op& op) = 0;
+
+private:
+    void operator()(const Notification& notification) override
+    {
+        const auto& sceneChanged = notification.staticCast<SceneChanged>();
+
+        if (SceneChanged::SceneCompositeNotification == sceneChanged.opType()) {
+            const auto& compNotification = notification.staticCast<SceneCompositeNotification>();
+            for (const auto& op : compNotification) {
+                handleOp(op);
+            }
+        } else {
+            handleOp(sceneChanged);
+        }
+    }
+};
+
+class UsdPathMapperSceneObserver : public SceneObserver
+{
+public:
+    UsdPathMapperSceneObserver(MayaUsdProxyShapeSceneIndexBase& psSi)
+        : SceneObserver()
+        , _psSi(psSi)
+    {
+    }
+
+private:
+    // If the proxy shape's app path changes, update the app path key in the
+    // path mapper registry.
+    void handleOp(const SceneCompositeNotification::Op& op) override
+    {
+        if (op.opType == SceneChanged::ObjectPathChange
+            && ((op.subOpType == ObjectPathChange::ObjectReparent)
+                || (op.subOpType == ObjectPathChange::ObjectRename))) {
+            const auto& siPath = _psSi.GetSceneIndexAppPath();
+            if (siPath.startsWith(op.path)) {
+                const auto oldPath = siPath;
+                auto       newPath = oldPath.reparent(op.path, op.item->path());
+                _psSi.SetSceneIndexAppPath(newPath);
+
+                // Update our entry in the path mapper registry.
+                TF_AXIOM(Fvp::PathMapperRegistry::Instance().Update(oldPath, newPath));
+            }
+        }
+    }
+
+    MayaUsdProxyShapeSceneIndexBase& _psSi;
+};
+
+} // namespace
 
 namespace MAYAHYDRA_NS_DEF {
 
@@ -29,18 +147,37 @@ MayaUsdProxyShapeSceneIndexBase::MayaUsdProxyShapeSceneIndexBase(
     const MAYAUSDAPI_NS::ProxyStage&       proxyStage,
     const HdSceneIndexBaseRefPtr&          sceneIndexChainLastElement,
     const UsdImagingStageSceneIndexRefPtr& usdImagingStageSceneIndex,
-    const MObjectHandle&                   dagNodeHandle
+    const MObjectHandle&                   dagNodeHandle,
+    const SdfPath&                         sceneIndexPathPrefix,
+    const Ufe::Path&                       sceneIndexAppPath
 )
     : ParentClass(sceneIndexChainLastElement)
     , InputSceneIndexUtils(sceneIndexChainLastElement)
+    , _sceneIndexPathPrefix(sceneIndexPathPrefix)
     , _usdImagingStageSceneIndex(usdImagingStageSceneIndex)
     , _proxyStage(proxyStage)
     , _dagNodeHandle(dagNodeHandle)
+    , _sceneIndexAppPath(sceneIndexAppPath)
+    , _usdPathMapper(std::make_shared<UsdPathMapper>(*this))
+    , _appSceneObserver(std::make_shared<UsdPathMapperSceneObserver>(*this))
 {
+    // The gateway node (proxy shape) is a Maya node, so the scene index
+    // path must be a single segment.
+    TF_AXIOM(sceneIndexAppPath.nbSegments() == 1);
+
     TfWeakPtr<MayaUsdProxyShapeSceneIndexBase> ptr(this);
     _stageSetNoticeKey = TfNotice::Register(ptr, &MayaUsdProxyShapeSceneIndexBase::_StageSet);
     _stageInvalidateNoticeKey = TfNotice::Register(ptr, &MayaUsdProxyShapeSceneIndexBase::_StageInvalidate);
     _objectsChangedNoticeKey = TfNotice::Register(ptr, &MayaUsdProxyShapeSceneIndexBase::_ObjectsChanged);
+
+    // Observe the scene to be informed of path changes to the gateway node
+    // (proxy shape) that corresponds to our scene index data producer.
+    Scene::instance().addObserver(_appSceneObserver);
+
+    // Register a mapper in the path mapper registry, if there is none
+    // for this path.
+    _unregisterPathMapper = Fvp::PathMapperRegistry::Instance().Register(
+        _sceneIndexAppPath, _usdPathMapper);
 
     Fvp::Instruments::instance().set(kNbPopulateCalls, VtValue(_nbPopulateCalls));
 }
@@ -52,19 +189,32 @@ MayaUsdProxyShapeSceneIndexBase::~MayaUsdProxyShapeSceneIndexBase()
 
 void MayaUsdProxyShapeSceneIndexBase::_Destroy()
 {
+    if (_unregisterPathMapper) {
+        Fvp::PathMapperRegistry::Instance().Unregister(_sceneIndexAppPath);
+    }
+
+    // Ufe::Subject has automatic cleanup of stale observers, but this can
+    // be problematic on application exit if the library of the observer is
+    // cleaned up before that of the subject, so simply stop observing.
+    Scene::instance().removeObserver(_appSceneObserver);
+
     TfNotice::Revoke(_stageSetNoticeKey);
     TfNotice::Revoke(_stageInvalidateNoticeKey);
     TfNotice::Revoke(_objectsChangedNoticeKey);
 }
 
 MayaUsdProxyShapeSceneIndexBaseRefPtr MayaUsdProxyShapeSceneIndexBase::New(
-    const MAYAUSDAPI_NS::ProxyStage&       proxyStage, 
+    const MAYAUSDAPI_NS::ProxyStage&       proxyStage,
     const HdSceneIndexBaseRefPtr&          sceneIndexChainLastElement,
     const UsdImagingStageSceneIndexRefPtr& usdImagingStageSceneIndex,
-    const MObjectHandle&                   dagNodeHandle
+    const MObjectHandle&                   dagNodeHandle,
+    const SdfPath&                         sceneIndexPathPrefix,
+    const Ufe::Path&                       sceneIndexAppPath
 )
 {
-    return TfCreateRefPtr(new MayaUsdProxyShapeSceneIndexBase(proxyStage, sceneIndexChainLastElement, usdImagingStageSceneIndex, dagNodeHandle));
+    return TfCreateRefPtr(new MayaUsdProxyShapeSceneIndexBase(
+        proxyStage, sceneIndexChainLastElement, usdImagingStageSceneIndex, dagNodeHandle,
+        sceneIndexPathPrefix, sceneIndexAppPath));
 }
 
 void MayaUsdProxyShapeSceneIndexBase::UpdateTime()
@@ -185,6 +335,147 @@ bool MayaUsdProxyShapeSceneIndexBase::HasPendingUpdates() const
     //When we receive a stage invalidate we remove the stage and set populate to false
     //We need to re-populate to see the changes
     return (false == _populated);
+}
+
+Fvp::PrimSelections
+MayaUsdProxyShapeSceneIndexBase::UfePathToPrimSelections(const Ufe::Path& appPath) const
+{
+    // If the data model object application path does not match the path we
+    // translate, return an empty path.
+    if (!appPath.startsWith(_sceneIndexAppPath)) {
+        return {};
+    }
+
+    // If the application path is our prefix, just return the
+    // corresponding scene index path.
+    if (appPath == _sceneIndexAppPath) {
+        return Fvp::PrimSelections { Fvp::PrimSelection { _sceneIndexPathPrefix } };
+    }
+
+    // The scene index path is composed of 2 parts, in order:
+    // 1) The scene index path prefix, which is fixed on construction.
+    // 2) The second segment of the UFE path, with each UFE path component
+    //    becoming an SdfPath component. If the last component is a number,
+    //    then we are dealing with an instance selection.
+    TF_AXIOM(appPath.nbSegments() == 2);
+    SdfPath                                primPath = SdfPath::AbsoluteRootPath();
+    std::optional<Fvp::InstancesSelection> instanceSelection;
+
+    auto       secondSegment = appPath.getSegments()[1];
+    const auto lastComponentString = secondSegment.components().back().string();
+    const bool lastComponentIsNumeric
+        = lastComponentString.find_first_not_of(digits) == std::string::npos;
+    const size_t lastComponentIndex = secondSegment.size() - 1;
+
+    for (size_t iComponent = 0; iComponent < secondSegment.size(); iComponent++) {
+        // Native instancing : if the current prim path points to a native instance, repath to the
+        // prototype before appending the following UFE components
+        HdSceneIndexPrim prim = GetPrim(primPath);
+        HdInstanceSchema instanceSchema = HdInstanceSchema::GetFromParent(prim.dataSource);
+        if (instanceSchema.IsDefined()) {
+            auto             instancerPath = instanceSchema.GetInstancer()->GetTypedValue(0);
+            HdSceneIndexPrim instancerPrim = GetPrim(instancerPath);
+            HdInstancerTopologySchema instancerTopologySchema
+                = HdInstancerTopologySchema::GetFromParent(instancerPrim.dataSource);
+            auto prototypes = instancerTopologySchema.GetPrototypes()->GetTypedValue(0);
+            auto prototypeIndex = instanceSchema.GetPrototypeIndex()->GetTypedValue(0);
+            primPath = prototypes[prototypeIndex];
+            instanceSelection = { instancerPath,
+                                  prototypeIndex,
+                                  { instanceSchema.GetInstanceIndex()->GetTypedValue(0) } };
+        }
+
+        // SdfPath components cannot be numeric.  This happens with point instance selections.
+        auto targetChildPath = ((iComponent == lastComponentIndex) && lastComponentIsNumeric)
+            ? SdfPath()
+            : primPath.AppendChild(TfToken(secondSegment.components()[iComponent].string()));
+        auto actualChildPaths = GetChildPrimPaths(primPath);
+        if (!targetChildPath.IsEmpty()
+            && std::find(actualChildPaths.begin(), actualChildPaths.end(), targetChildPath)
+                != actualChildPaths.end()) {
+            // Append if the new path is valid
+            primPath = targetChildPath;
+        } else if (iComponent == lastComponentIndex) {
+            // If the last component is a number, we are dealing with an instance selection.
+            // But there are other cases like when you assign a USD Preview surface material to a
+            // usd prim, it has a shader prim in the material which doesn't appear in the hydra
+            // hierarchy but is actually present and we end up in this case as well.
+            if (lastComponentIsNumeric) {
+                // Point instancing : instance selection. The path should end with a number
+                // corresponding to the selected instance,
+                // and the remainder of the path points to the point instancer.
+                HdSceneIndexPrim          instancerPrim = GetPrim(primPath);
+                HdInstancerTopologySchema instancerTopologySchema
+                    = HdInstancerTopologySchema::GetFromParent(instancerPrim.dataSource);
+                auto instanceIndicesByPrototype = instancerTopologySchema.GetInstanceIndices();
+                for (int iInstanceIndices = 0; static_cast<size_t>(iInstanceIndices)
+                     < instanceIndicesByPrototype.GetNumElements();
+                     iInstanceIndices++) {
+                    auto instanceIndices
+                        = instanceIndicesByPrototype.GetElement(iInstanceIndices)->GetTypedValue(0);
+                    if (std::find(
+                            instanceIndices.begin(),
+                            instanceIndices.end(),
+                            std::stoi(lastComponentString))
+                        != instanceIndices.end()) {
+                        instanceSelection
+                            = { primPath, iInstanceIndices, { std::stoi(lastComponentString) } };
+                        break;
+                    }
+                }
+            }
+        } else {
+            // There is no prim corresponding to the converted path
+            TF_WARN("Could not convert UFE path %s to Hydra prims.", appPath.string().data());
+            return {};
+        }
+    }
+
+    Fvp::PrimSelection  baseSelection = instanceSelection.has_value()
+         ? Fvp::PrimSelection { primPath, { instanceSelection.value() } }
+         : Fvp::PrimSelection { primPath };
+    Fvp::PrimSelections primSelections({ baseSelection });
+
+    // Point instancing : propagate selection to propagated prototypes
+    auto ancestorsRange = primPath.GetAncestorsRange();
+    for (const auto& ancestorPath : ancestorsRange) {
+        HdSceneIndexPrim            currPrim = GetPrim(ancestorPath);
+        UsdImagingUsdPrimInfoSchema usdPrimInfo
+            = UsdImagingUsdPrimInfoSchema::GetFromParent(currPrim.dataSource);
+        if (!usdPrimInfo.IsDefined()) {
+            continue;
+        }
+        auto propagatedProtosDataSource = usdPrimInfo.GetPiPropagatedPrototypes();
+        if (!propagatedProtosDataSource) {
+            continue;
+        }
+        auto propagatedProtoNames = propagatedProtosDataSource->GetNames();
+        for (const auto& propagatedProtoName : propagatedProtoNames) {
+            auto propagatedProtoPathDataSource = HdTypedSampledDataSource<SdfPath>::Cast(
+                propagatedProtosDataSource->Get(propagatedProtoName));
+            if (propagatedProtoPathDataSource) {
+                SdfPath propagatedProtoPath = propagatedProtoPathDataSource->GetTypedValue(0);
+                SdfPath propagatedPrimPath
+                    = primPath.ReplacePrefix(ancestorPath, propagatedProtoPath);
+                HdSceneIndexPrim propagatedPrim = GetPrim(propagatedPrimPath);
+                // This check controls which types of prims have their selection data source
+                // propagated. Currently we skip instancers so that selecting an instancer A that is
+                // both drawing geometry but also prototyped and propagated for another instancer B
+                // will only mark the geometry-drawing instancer A as selected. This can be changed.
+                // For now (2024/05/28), this only affects selection highlighting.
+                if (propagatedPrim.primType != HdPrimTypeTokens->instancer) {
+                    primSelections.push_back(
+                        { propagatedPrimPath, primSelections.front().nestedInstanceIndices });
+                }
+            }
+        }
+        break; // We found propagated prototypes, exit now to avoid propagating selection to
+               // prototypes of other parents
+    }
+
+    // Now have primSelections in the namespace of this scene index.  Need to
+    // account for the prefix, which is added downstream of this scene index.
+    return addPrefix(_sceneIndexPathPrefix, primSelections);
 }
 
 } // namespace MAYAHYDRA_NS_DEF

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mhMayaUsdProxyShapeSceneIndexBase.h
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mhMayaUsdProxyShapeSceneIndexBase.h
@@ -25,6 +25,8 @@
 
 // Flow Viewport Toolkit headers.
 #include "flowViewport/sceneIndex/fvpSceneIndexUtils.h"
+#include <flowViewport/selection/fvpPathMapperFwd.h>
+#include <flowViewport/selection/fvpSelectionTypes.h>
 
 //Usd/Hydra headers
 #include <pxr/base/tf/declarePtrs.h>
@@ -35,6 +37,7 @@
 //Maya headers
 #include <maya/MObjectHandle.h>
 
+#include <ufe/observer.h>
 #include <ufe/path.h>
 
 #include <memory>
@@ -65,12 +68,23 @@ public:
     New(const MAYAUSDAPI_NS::ProxyStage&       proxyStage,
         const HdSceneIndexBaseRefPtr&          sceneIndexChainLastElement,
         const UsdImagingStageSceneIndexRefPtr& usdImagingStageSceneIndex,
-        const MObjectHandle&                   dagNodeHandle
+        const MObjectHandle&                   dagNodeHandle,
+        const PXR_NS::SdfPath&                 sceneIndexPathPrefix,
+        const Ufe::Path&                       sceneIndexAppPath
     );
 
     // From HdSceneIndexBase
     HdSceneIndexPrim GetPrim(const SdfPath& primPath) const override;
     SdfPathVector GetChildPrimPaths(const SdfPath& primPath) const override;
+
+    MAYAHYDRALIB_API
+    Fvp::PrimSelections UfePathToPrimSelections(const Ufe::Path& appPath) const;
+
+    const Ufe::Path& GetSceneIndexAppPath() const { return _sceneIndexAppPath; }
+    void             SetSceneIndexAppPath(const Ufe::Path& sceneIndexAppPath)
+    {
+        _sceneIndexAppPath = sceneIndexAppPath;
+    }
 
     virtual ~MayaUsdProxyShapeSceneIndexBase();
 
@@ -106,8 +120,12 @@ protected:
         const MAYAUSDAPI_NS::ProxyStage&       proxyStage,
         const HdSceneIndexBaseRefPtr&          sceneIndexChainLastElement,
         const UsdImagingStageSceneIndexRefPtr& usdImagingStageSceneIndex,
-        const MObjectHandle&                   dagNodeHandle
+        const MObjectHandle&                   dagNodeHandle,
+        const PXR_NS::SdfPath&                 sceneIndexPathPrefix,
+        const Ufe::Path&                       sceneIndexAppPath
     );
+
+    const SdfPath                   _sceneIndexPathPrefix;
 
 private:
 
@@ -119,6 +137,10 @@ private:
     MAYAUSDAPI_NS::ProxyStage       _proxyStage;
     std::atomic<bool>               _populated { false };
     MObjectHandle                   _dagNodeHandle;
+    Ufe::Path                       _sceneIndexAppPath;
+    const Fvp::PathMapperConstPtr   _usdPathMapper{};
+    const Ufe::Observer::Ptr        _appSceneObserver{};
+    bool                            _unregisterPathMapper{false};
     TfNotice::Key                   _stageSetNoticeKey;
     TfNotice::Key                   _stageInvalidateNoticeKey;
     TfNotice::Key                   _objectsChangedNoticeKey;

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/registration.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/registration.cpp
@@ -255,7 +255,7 @@ void MayaHydraSceneIndexRegistry::_AddSceneIndexForNode(MObject& dagNode)
     // can register a pick handler.
     auto mayaUsdProxyShapeSceneIndex = _interactive ? 
         MayaUsdProxyShapeSceneIndexBaseRefPtr(MayaUsdProxyShapeSceneIndex::New(proxyStage, finalSceneIndex, stageSceneIndex, MObjectHandle(dagNode), registration->sceneIndexPathPrefix, Ufe::Path(UfeExtensions::dagPathToUfePathSegment(dagPath)))) :
-        MayaUsdProxyShapeSceneIndexBase::New(proxyStage, finalSceneIndex, stageSceneIndex, MObjectHandle(dagNode));
+        MayaUsdProxyShapeSceneIndexBase::New(proxyStage, finalSceneIndex, stageSceneIndex, MObjectHandle(dagNode), registration->sceneIndexPathPrefix, Ufe::Path(UfeExtensions::dagPathToUfePathSegment(dagPath)));
     registration->pluginSceneIndex = mayaUsdProxyShapeSceneIndex;
     registration->interpretRprimPathFn = &(MayaUsdProxyShapeSceneIndex::InterpretRprimPath);
     mayaUsdProxyShapeSceneIndex->Populate();

--- a/lib/mayaHydra/mayaPlugin/batchRendering/batchRenderer.cpp
+++ b/lib/mayaHydra/mayaPlugin/batchRendering/batchRenderer.cpp
@@ -555,10 +555,8 @@ void BatchRenderer::_SetActiveRenderSettingsPrimFromScene()
     }
 
     const auto hydraRsPath = GetActiveRenderSettingsHydraPath();
-    if (hydraRsPath.IsEmpty()) {
-        // Maintenance warning: test usdProxyShapeRenderSettings
-        // checks that this warning string is not emitted.
-        TF_WARN("Invalid Hydra active render settings prim path.");
+    if (!TF_VERIFY(!hydraRsPath.IsEmpty(), 
+                   "Invalid Hydra active render settings prim path.")) {
         return;
     }
 

--- a/lib/mayaHydra/mayaPlugin/batchRendering/batchRenderer.cpp
+++ b/lib/mayaHydra/mayaPlugin/batchRendering/batchRenderer.cpp
@@ -556,6 +556,8 @@ void BatchRenderer::_SetActiveRenderSettingsPrimFromScene()
 
     const auto hydraRsPath = GetActiveRenderSettingsHydraPath();
     if (hydraRsPath.IsEmpty()) {
+        // Maintenance warning: test usdProxyShapeRenderSettings
+        // checks that this warning string is not emitted.
         TF_WARN("Invalid Hydra active render settings prim path.");
         return;
     }

--- a/lib/mayaHydra/mayaPlugin/renderSettingsUtils.cpp
+++ b/lib/mayaHydra/mayaPlugin/renderSettingsUtils.cpp
@@ -246,6 +246,8 @@ SdfPath GetActiveRenderSettingsHydraPath()
     auto hydraPath = Fvp::ufePathToPrimSelections(ufePath);
 
     // Render settings are not instanced, so there will be a single path.
+    // Maintenance warning: test usdProxyShapeRenderSettings checks
+    // that this warning string is not emitted.
     if (!TF_VERIFY(hydraPath.size() == 1, "Expected single path for active render settings.")) {
         return {};
     }

--- a/lib/mayaHydra/mayaPlugin/renderSettingsUtils.cpp
+++ b/lib/mayaHydra/mayaPlugin/renderSettingsUtils.cpp
@@ -246,8 +246,6 @@ SdfPath GetActiveRenderSettingsHydraPath()
     auto hydraPath = Fvp::ufePathToPrimSelections(ufePath);
 
     // Render settings are not instanced, so there will be a single path.
-    // Maintenance warning: test usdProxyShapeRenderSettings checks
-    // that this warning string is not emitted.
     if (!TF_VERIFY(hydraPath.size() == 1, "Expected single path for active render settings.")) {
         return {};
     }

--- a/test/lib/cmdLineRender/CMakeLists.txt
+++ b/test/lib/cmdLineRender/CMakeLists.txt
@@ -244,7 +244,7 @@ endif()
 # )
 
 # Test that USD render settings stored in a MayaUsdProxyShape node produce no
-# path mapper warnings errors.  Only checks Render stdout / stderr output,
+# path mapper warnings errors.  Launches Render and checks for success,
 # no image comparison.
 set(_usdProxyShapeRenderSettings_dir
     "${CMAKE_BINARY_DIR}/test/Temporary/usdProxyShapeRenderSettings/projects/default/images")
@@ -278,14 +278,13 @@ function(_add_usdProxyShapeRenderSettings_test)
 
     set_property(TEST "${test_name}" APPEND PROPERTY ENVIRONMENT
         "MAYA_IGNORE_DIALOGS=1")
+    # Set TF_VERIFY to generate a TF_FATAL_ERROR.
+    # PathMapperRegistry::UfePathToPrimSelections() use TF_VERIFY to check
+    # for path mapper failures, so this will cause the test to fail.
+    set_property(TEST "${test_name}" APPEND PROPERTY ENVIRONMENT
+        "TF_FATAL_VERIFY=1")
     set_property(TEST "${test_name}" APPEND PROPERTY LABELS cmdLineRender)
 
-    # Fail if any of these error/warning patterns appear in stdout or stderr.
-    # Each semicolon-separated entry is a separate regex checked independently.
-    set_tests_properties("${test_name}" PROPERTIES
-        FAIL_REGULAR_EXPRESSION
-            "Mapping for application path;Expected single path for active render settings;Invalid Hydra active render settings prim path"
-    )
 endfunction()
 _add_usdProxyShapeRenderSettings_test()
 

--- a/test/lib/cmdLineRender/CMakeLists.txt
+++ b/test/lib/cmdLineRender/CMakeLists.txt
@@ -243,6 +243,52 @@ endif()
 #     RENDERER_ARGS "-s 5 -e 9"
 # )
 
+# Test that USD render settings stored in a MayaUsdProxyShape node produce no
+# path mapper warnings errors.  Only checks Render stdout / stderr output,
+# no image comparison.
+set(_usdProxyShapeRenderSettings_dir
+    "${CMAKE_BINARY_DIR}/test/Temporary/usdProxyShapeRenderSettings/projects/default/images")
+function(_add_usdProxyShapeRenderSettings_test)
+    set(test_name usdProxyShapeRenderSettings)
+    set(SCENE_PATH
+        "${CMAKE_CURRENT_SOURCE_DIR}/scenes/renderSettings/usdProxyShapeRenderSettings.ma")
+
+    if(WIN32)
+        add_test(
+            NAME "${test_name}"
+            COMMAND PowerShell -Command
+                "& \"${RENDER_EXECUTABLE}\" -renderer \"HdArnoldRendererPlugin\" -rd \"${_usdProxyShapeRenderSettings_dir}\" \"${SCENE_PATH}\"; exit \$LASTEXITCODE"
+        )
+    else()
+        add_test(
+            NAME "${test_name}"
+            COMMAND ${RENDER_EXECUTABLE} -renderer HdArnoldRendererPlugin -rd "${_usdProxyShapeRenderSettings_dir}" "${SCENE_PATH}"
+        )
+    endif()
+
+    _mayaHydra_setup_test_common_path_vars()
+    list(APPEND ALL_PATH_VARS MAYA_RENDER_DESC_PATH)
+    _mayaHydra_setup_test_common_defaults("${test_name}")
+    _mayaHydra_setup_test_plugins()
+    list(APPEND MAYAHYDRA_VARNAME_MAYA_RENDER_DESC_PATH
+         "${CMAKE_INSTALL_PREFIX}/renderDesc")
+    list(APPEND MAYAHYDRA_VARNAME_PYTHONPATH "${MAYA_HYDRA_DIR}/scripts")
+    _mayaHydra_setup_test_USD_paths()
+    _mayaHydra_setup_test_finalize_env("${test_name}")
+
+    set_property(TEST "${test_name}" APPEND PROPERTY ENVIRONMENT
+        "MAYA_IGNORE_DIALOGS=1")
+    set_property(TEST "${test_name}" APPEND PROPERTY LABELS cmdLineRender)
+
+    # Fail if any of these error/warning patterns appear in stdout or stderr.
+    # Each semicolon-separated entry is a separate regex checked independently.
+    set_tests_properties("${test_name}" PROPERTIES
+        FAIL_REGULAR_EXPRESSION
+            "Mapping for application path;Expected single path for active render settings;Invalid Hydra active render settings prim path"
+    )
+endfunction()
+_add_usdProxyShapeRenderSettings_test()
+
 # Stage UVChecker.png within this test’s temporary Maya project so it can be
 # resolved via the workspace root when using `-proj`.
 #

--- a/test/lib/cmdLineRender/scenes/renderSettings/usdProxyShapeRenderSettings.ma
+++ b/test/lib/cmdLineRender/scenes/renderSettings/usdProxyShapeRenderSettings.ma
@@ -1,0 +1,406 @@
+//Maya ASCII 2027 scene
+//Name: usdProxyShapeRenderSettings.ma
+//Last modified: Tue, Jun 09, 2026 03:40:16 PM
+//Codeset: 1252
+requires maya "2027";
+requires -nodeType "mayaUsdLayerManager" -nodeType "UsdDefaultSettings" -nodeType "mayaUsdProxyShape"
+		 -dataType "pxrUsdStageData" "mayaUsdPlugin" "0.38.0";
+currentUnit -l centimeter -a degree -t film;
+fileInfo "application" "maya";
+fileInfo "product" "Maya 2027";
+fileInfo "version" "2027";
+fileInfo "cutIdentifier" "202605290040-8b729f6591";
+fileInfo "osv" "Windows 11 Enterprise v2009 (Build: 26200)";
+fileInfo "UUID" "D33774A0-4D42-B2C9-CEE6-7EBF32F1C4A0";
+createNode transform -s -n "persp";
+	rename -uid "DDADBD98-4D34-6869-512A-64BB34774DFE";
+	setAttr ".v" no;
+	setAttr ".t" -type "double3" -1.8797504150587532 3.8853271448019653 6.4556658570451209 ;
+	setAttr ".r" -type "double3" -27.338352729604072 -27.400000000000336 -8.9561262811830947e-16 ;
+createNode camera -s -n "perspShape" -p "persp";
+	rename -uid "A317F961-4358-263A-C201-689937D430DD";
+	setAttr -k off ".v" no;
+	setAttr ".fl" 34.999999999999993;
+	setAttr ".coi" 7.7991610654258174;
+	setAttr ".imn" -type "string" "persp";
+	setAttr ".den" -type "string" "persp_depth";
+	setAttr ".man" -type "string" "persp_mask";
+	setAttr ".hc" -type "string" "viewSet -p %camera";
+createNode transform -s -n "top";
+	rename -uid "3C461E6A-402D-E07C-2AA7-DB85243FF062";
+	setAttr ".v" no;
+	setAttr ".t" -type "double3" 0 1000.1 0 ;
+	setAttr ".r" -type "double3" -90 0 0 ;
+createNode camera -s -n "topShape" -p "top";
+	rename -uid "9530A212-4AF8-98EE-FE5D-2384E4634547";
+	setAttr -k off ".v" no;
+	setAttr ".rnd" no;
+	setAttr ".coi" 1000.1;
+	setAttr ".ow" 30;
+	setAttr ".imn" -type "string" "top";
+	setAttr ".den" -type "string" "top_depth";
+	setAttr ".man" -type "string" "top_mask";
+	setAttr ".hc" -type "string" "viewSet -t %camera";
+	setAttr ".o" yes;
+createNode transform -s -n "front";
+	rename -uid "33DC78BD-4A82-9687-A945-D3824C692F0C";
+	setAttr ".v" no;
+	setAttr ".t" -type "double3" 0 0 1000.1 ;
+createNode camera -s -n "frontShape" -p "front";
+	rename -uid "E142038C-4290-3ED1-176A-C2BE6B6409E4";
+	setAttr -k off ".v" no;
+	setAttr ".rnd" no;
+	setAttr ".coi" 1000.1;
+	setAttr ".ow" 30;
+	setAttr ".imn" -type "string" "front";
+	setAttr ".den" -type "string" "front_depth";
+	setAttr ".man" -type "string" "front_mask";
+	setAttr ".hc" -type "string" "viewSet -f %camera";
+	setAttr ".o" yes;
+createNode transform -s -n "side";
+	rename -uid "32A53D16-4C68-26C2-5F60-A995643EA920";
+	setAttr ".v" no;
+	setAttr ".t" -type "double3" 1000.1 0 0 ;
+	setAttr ".r" -type "double3" 0 90 0 ;
+createNode camera -s -n "sideShape" -p "side";
+	rename -uid "73284CF0-4946-75B4-F3DE-F38BDCB0B45B";
+	setAttr -k off ".v" no;
+	setAttr ".rnd" no;
+	setAttr ".coi" 1000.1;
+	setAttr ".ow" 30;
+	setAttr ".imn" -type "string" "side";
+	setAttr ".den" -type "string" "side_depth";
+	setAttr ".man" -type "string" "side_mask";
+	setAttr ".hc" -type "string" "viewSet -s %camera";
+	setAttr ".o" yes;
+createNode transform -n "pCube1";
+	rename -uid "D73A9AB3-4BAA-D60B-7AF9-10BADD1C2C09";
+createNode mesh -n "pCubeShape1" -p "pCube1";
+	rename -uid "1EC2CCE2-4E71-5F2E-C422-F4AAF844C451";
+	setAttr -k off ".v";
+	setAttr ".vir" yes;
+	setAttr ".vif" yes;
+	setAttr ".uvst[0].uvsn" -type "string" "map1";
+	setAttr ".cuvs" -type "string" "map1";
+	setAttr ".dcc" -type "string" "Ambient+Diffuse";
+	setAttr ".covm[0]"  0 1 1;
+	setAttr ".cdvm[0]"  0 1 1;
+createNode transform -n "directionalLight1";
+	rename -uid "C28F0DC1-4D4C-16B1-77B0-2E890C7821C9";
+	setAttr ".t" -type "double3" -0.78523765186346561 2.0212382093467411 3.3477513995091099 ;
+	setAttr ".r" -type "double3" -34.210321735927231 -16.293942981867836 -343.63118217878497 ;
+createNode directionalLight -n "directionalLightShape1" -p "directionalLight1";
+	rename -uid "1E96361B-4B82-000F-2811-0E8C10A34C35";
+	setAttr -k off ".v";
+createNode transform -n "AnimCubeRenderSettings2";
+	rename -uid "47404076-4F51-0C35-708E-DF9104A7C7D5";
+createNode mayaUsdProxyShape -n "AnimCubeRenderSettings2Shape" -p "AnimCubeRenderSettings2";
+	rename -uid "0FA67D96-401D-7317-0B68-DC8899357207";
+	addAttr -r false -ci true -h true -sn "forceCompute" -ln "forceCompute" -min 0 
+		-max 1 -at "bool";
+	addAttr -h true -sn "usdStageLoadRules" -ln "usdStageLoadRules" -dt "string";
+	addAttr -h true -sn "usdStageTargetLayer" -ln "usdStageTargetLayer" -dt "string";
+	setAttr -k off ".v";
+	setAttr ".covm[0]"  0 1 1;
+	setAttr ".cdvm[0]"  0 1 1;
+	setAttr ".fp" -type "string" "./usdProxyShapeRenderSettings.usda";
+	setAttr ".pp" -type "string" "";
+	setAttr ".epp" -type "string" "";
+	setAttr ".usdStageLoadRules" -type "string" "/=all";
+	setAttr ".usdStageTargetLayer" -type "string" "./usdProxyShapeRenderSettings.usda";
+createNode lightLinker -s -n "lightLinker1";
+	rename -uid "92D6F518-4DED-2F62-F837-7AB720BD827C";
+	setAttr -s 2 ".lnk";
+	setAttr -s 2 ".slnk";
+createNode shapeEditorManager -n "shapeEditorManager";
+	rename -uid "0F009047-43E8-460A-6EE3-65B46C127CD6";
+createNode poseInterpolatorManager -n "poseInterpolatorManager";
+	rename -uid "071C2E7A-4E15-9AD0-0834-B99C39C582E0";
+createNode displayLayerManager -n "layerManager";
+	rename -uid "3F5C8B20-4EC5-E739-940C-BD93A2081F59";
+createNode displayLayer -n "defaultLayer";
+	rename -uid "1D8E7431-44E3-0885-B504-EF85C551C725";
+	setAttr ".ufem" -type "stringArray" 0  ;
+createNode renderLayerManager -n "renderLayerManager";
+	rename -uid "FC6630DB-455D-3F19-A397-FEB151CB3E06";
+createNode renderLayer -n "defaultRenderLayer";
+	rename -uid "2112F2D9-463A-AF1C-5803-ECA8D2DC5F1E";
+	setAttr ".g" yes;
+createNode UsdDefaultSettings -n "UsdDefaultRenderSettings";
+	rename -uid "ED4E131A-4E6C-B324-63D7-1E8F3B605134";
+	setAttr ".srl" -type "string" "#usda 1.0\n(\n    renderSettingsPrimPath = \"/Render/SceneRenderSettings\"\n)\n\ndef Scope \"Render\"\n{\n    def RenderSettings \"SceneRenderSettings\"\n    {\n        custom string adskUsd:externalCamera = \"|persp\" (\n            displayName = \"External Camera\"\n        )\n        rel products = </Render/BeautyProduct>\n    }\n\n    def RenderVar \"color\"\n    {\n        uniform string sourceName = \"color\"\n    }\n\n    def RenderProduct \"BeautyProduct\"\n    {\n        rel orderedVars = </Render/color>\n        token productName = \"./default.png\"\n    }\n}\n\n";
+	setAttr ".ssl" -type "string" "#usda 1.0\n\n";
+	setAttr ".asp" -type "string" "|AnimCubeRenderSettings2|AnimCubeRenderSettings2Shape,/Render/MainRender";
+lockNode -l 1 ;
+createNode polyCube -n "polyCube1";
+	rename -uid "14530A55-4E98-7ABF-D8E1-FDBB7F1906EF";
+	setAttr ".cuv" 4;
+createNode animCurveTL -n "pCube1_translateX";
+	rename -uid "86698461-430B-D51F-5B51-A498ACF29BCD";
+	setAttr ".tan" 18;
+	setAttr ".wgt" no;
+	setAttr -s 2 ".ktv[0:1]"  0 0 10 4.2876932089674389;
+createNode animCurveTL -n "pCube1_translateY";
+	rename -uid "511AA266-44E4-C0AA-0F4F-CDAD7D420B1D";
+	setAttr ".tan" 18;
+	setAttr ".wgt" no;
+	setAttr -s 2 ".ktv[0:1]"  0 0 10 0;
+createNode animCurveTL -n "pCube1_translateZ";
+	rename -uid "A1171359-40B8-896D-D94F-7180DE76C739";
+	setAttr ".tan" 18;
+	setAttr ".wgt" no;
+	setAttr -s 2 ".ktv[0:1]"  0 0 10 0;
+createNode script -n "uiConfigurationScriptNode";
+	rename -uid "06964C7E-485C-7A08-926E-A586A429F8C2";
+	setAttr ".b" -type "string" (
+		"// Maya Mel UI Configuration File.\n//\n//  This script is machine generated.  Edit at your own risk.\n//\n//\n\nglobal string $gMainPane;\nif (`paneLayout -exists $gMainPane`) {\n\n\tglobal int $gUseScenePanelConfig;\n\tint    $useSceneConfig = $gUseScenePanelConfig;\n\tint    $nodeEditorPanelVisible = stringArrayContains(\"nodeEditorPanel1\", `getPanel -vis`);\n\tint    $nodeEditorWorkspaceControlOpen = (`workspaceControl -exists nodeEditorPanel1Window` && `workspaceControl -q -visible nodeEditorPanel1Window`);\n\tint    $menusOkayInPanels = `optionVar -q allowMenusInPanels`;\n\tint    $nVisPanes = `paneLayout -q -nvp $gMainPane`;\n\tint    $nPanes = 0;\n\tstring $editorName;\n\tstring $panelName;\n\tstring $itemFilterName;\n\tstring $panelConfig;\n\n\t//\n\t//  get current state of the UI\n\t//\n\tsceneUIReplacement -update $gMainPane;\n\n\t$panelName = `sceneUIReplacement -getNextPanel \"modelPanel\" (localizedPanelLabel(\"Top View\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tmodelPanel -edit -l (localizedPanelLabel(\"Top View\")) -mbv $menusOkayInPanels  $panelName;\n"
+		+ "\t\t$editorName = $panelName;\n        modelEditor -e \n            -camera \"|top\" \n            -useInteractiveMode 0\n            -displayLights \"default\" \n            -displayAppearance \"smoothShaded\" \n            -activeOnly 0\n            -ignorePanZoom 0\n            -wireframeOnShaded 0\n            -headsUpDisplay 1\n            -holdOuts 1\n            -selectionHiliteDisplay 1\n            -useDefaultMaterial 0\n            -bufferMode \"double\" \n            -twoSidedLighting 0\n            -backfaceCulling 0\n            -xray 0\n            -jointXray 0\n            -activeComponentsXray 0\n            -displayTextures 0\n            -smoothWireframe 0\n            -lineWidth 1\n            -textureAnisotropic 0\n            -textureHilight 1\n            -textureSampling 2\n            -textureDisplay \"modulate\" \n            -textureMaxSize 32768\n            -fogging 0\n            -fogSource \"fragment\" \n            -fogMode \"linear\" \n            -fogStart 0\n            -fogEnd 100\n            -fogDensity 0.1\n            -fogColor 0.5 0.5 0.5 1 \n"
+		+ "            -depthOfFieldPreview 1\n            -maxConstantTransparency 1\n            -rendererName \"vp2Renderer\" \n            -objectFilterShowInHUD 1\n            -isFiltered 0\n            -colorResolution 256 256 \n            -bumpResolution 512 512 \n            -textureCompression 0\n            -transparencyAlgorithm \"frontAndBackCull\" \n            -transpInShadows 0\n            -cullingOverride \"none\" \n            -lowQualityLighting 0\n            -maximumNumHardwareLights 1\n            -occlusionCulling 0\n            -shadingModel 0\n            -useBaseRenderer 0\n            -useReducedRenderer 0\n            -smallObjectCulling 0\n            -smallObjectThreshold -1 \n            -interactiveDisableShadows 0\n            -interactiveBackFaceCull 0\n            -sortTransparent 1\n            -controllers 1\n            -nurbsCurves 1\n            -nurbsSurfaces 1\n            -polymeshes 1\n            -subdivSurfaces 1\n            -planes 1\n            -lights 1\n            -cameras 1\n            -controlVertices 1\n"
+		+ "            -hulls 1\n            -grid 1\n            -imagePlane 1\n            -joints 1\n            -ikHandles 1\n            -deformers 1\n            -dynamics 1\n            -particleInstancers 1\n            -fluids 1\n            -hairSystems 1\n            -follicles 1\n            -nCloths 1\n            -nParticles 1\n            -nRigids 1\n            -dynamicConstraints 1\n            -locators 1\n            -manipulators 1\n            -pluginShapes 1\n            -dimensions 1\n            -handles 1\n            -pivots 1\n            -textures 1\n            -strokes 1\n            -motionTrails 1\n            -clipGhosts 1\n            -bluePencil 1\n            -greasePencils 0\n            -excludeObjectPreset \"All\" \n            -shadows 0\n            -captureSequenceNumber -1\n            -width 638\n            -height 438\n            -sceneRenderFilter 0\n            $editorName;\n        modelEditor -e -viewSelected 0 $editorName;\n        modelEditor -e \n            -pluginObjects \"gpuCacheDisplayFilter\" 1 \n            -pluginObjects \"mayaUsdProxyShapeBaseDisplayFilter\" 1 \n"
+		+ "            $editorName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextPanel \"modelPanel\" (localizedPanelLabel(\"Side View\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tmodelPanel -edit -l (localizedPanelLabel(\"Side View\")) -mbv $menusOkayInPanels  $panelName;\n\t\t$editorName = $panelName;\n        modelEditor -e \n            -camera \"|side\" \n            -useInteractiveMode 0\n            -displayLights \"default\" \n            -displayAppearance \"smoothShaded\" \n            -activeOnly 0\n            -ignorePanZoom 0\n            -wireframeOnShaded 0\n            -headsUpDisplay 1\n            -holdOuts 1\n            -selectionHiliteDisplay 1\n            -useDefaultMaterial 0\n            -bufferMode \"double\" \n            -twoSidedLighting 0\n            -backfaceCulling 0\n            -xray 0\n            -jointXray 0\n            -activeComponentsXray 0\n            -displayTextures 0\n            -smoothWireframe 0\n            -lineWidth 1\n"
+		+ "            -textureAnisotropic 0\n            -textureHilight 1\n            -textureSampling 2\n            -textureDisplay \"modulate\" \n            -textureMaxSize 32768\n            -fogging 0\n            -fogSource \"fragment\" \n            -fogMode \"linear\" \n            -fogStart 0\n            -fogEnd 100\n            -fogDensity 0.1\n            -fogColor 0.5 0.5 0.5 1 \n            -depthOfFieldPreview 1\n            -maxConstantTransparency 1\n            -rendererName \"vp2Renderer\" \n            -objectFilterShowInHUD 1\n            -isFiltered 0\n            -colorResolution 256 256 \n            -bumpResolution 512 512 \n            -textureCompression 0\n            -transparencyAlgorithm \"frontAndBackCull\" \n            -transpInShadows 0\n            -cullingOverride \"none\" \n            -lowQualityLighting 0\n            -maximumNumHardwareLights 1\n            -occlusionCulling 0\n            -shadingModel 0\n            -useBaseRenderer 0\n            -useReducedRenderer 0\n            -smallObjectCulling 0\n            -smallObjectThreshold -1 \n"
+		+ "            -interactiveDisableShadows 0\n            -interactiveBackFaceCull 0\n            -sortTransparent 1\n            -controllers 1\n            -nurbsCurves 1\n            -nurbsSurfaces 1\n            -polymeshes 1\n            -subdivSurfaces 1\n            -planes 1\n            -lights 1\n            -cameras 1\n            -controlVertices 1\n            -hulls 1\n            -grid 1\n            -imagePlane 1\n            -joints 1\n            -ikHandles 1\n            -deformers 1\n            -dynamics 1\n            -particleInstancers 1\n            -fluids 1\n            -hairSystems 1\n            -follicles 1\n            -nCloths 1\n            -nParticles 1\n            -nRigids 1\n            -dynamicConstraints 1\n            -locators 1\n            -manipulators 1\n            -pluginShapes 1\n            -dimensions 1\n            -handles 1\n            -pivots 1\n            -textures 1\n            -strokes 1\n            -motionTrails 1\n            -clipGhosts 1\n            -bluePencil 1\n            -greasePencils 0\n"
+		+ "            -excludeObjectPreset \"All\" \n            -shadows 0\n            -captureSequenceNumber -1\n            -width 98\n            -height 0\n            -sceneRenderFilter 0\n            $editorName;\n        modelEditor -e -viewSelected 0 $editorName;\n        modelEditor -e \n            -pluginObjects \"gpuCacheDisplayFilter\" 1 \n            -pluginObjects \"mayaUsdProxyShapeBaseDisplayFilter\" 1 \n            $editorName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextPanel \"modelPanel\" (localizedPanelLabel(\"Front View\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tmodelPanel -edit -l (localizedPanelLabel(\"Front View\")) -mbv $menusOkayInPanels  $panelName;\n\t\t$editorName = $panelName;\n        modelEditor -e \n            -camera \"|front\" \n            -useInteractiveMode 0\n            -displayLights \"default\" \n            -displayAppearance \"smoothShaded\" \n            -activeOnly 0\n            -ignorePanZoom 0\n            -wireframeOnShaded 0\n"
+		+ "            -headsUpDisplay 1\n            -holdOuts 1\n            -selectionHiliteDisplay 1\n            -useDefaultMaterial 0\n            -bufferMode \"double\" \n            -twoSidedLighting 0\n            -backfaceCulling 0\n            -xray 0\n            -jointXray 0\n            -activeComponentsXray 0\n            -displayTextures 0\n            -smoothWireframe 0\n            -lineWidth 1\n            -textureAnisotropic 0\n            -textureHilight 1\n            -textureSampling 2\n            -textureDisplay \"modulate\" \n            -textureMaxSize 32768\n            -fogging 0\n            -fogSource \"fragment\" \n            -fogMode \"linear\" \n            -fogStart 0\n            -fogEnd 100\n            -fogDensity 0.1\n            -fogColor 0.5 0.5 0.5 1 \n            -depthOfFieldPreview 1\n            -maxConstantTransparency 1\n            -rendererName \"vp2Renderer\" \n            -objectFilterShowInHUD 1\n            -isFiltered 0\n            -colorResolution 256 256 \n            -bumpResolution 512 512 \n            -textureCompression 0\n"
+		+ "            -transparencyAlgorithm \"frontAndBackCull\" \n            -transpInShadows 0\n            -cullingOverride \"none\" \n            -lowQualityLighting 0\n            -maximumNumHardwareLights 1\n            -occlusionCulling 0\n            -shadingModel 0\n            -useBaseRenderer 0\n            -useReducedRenderer 0\n            -smallObjectCulling 0\n            -smallObjectThreshold -1 \n            -interactiveDisableShadows 0\n            -interactiveBackFaceCull 0\n            -sortTransparent 1\n            -controllers 1\n            -nurbsCurves 1\n            -nurbsSurfaces 1\n            -polymeshes 1\n            -subdivSurfaces 1\n            -planes 1\n            -lights 1\n            -cameras 1\n            -controlVertices 1\n            -hulls 1\n            -grid 1\n            -imagePlane 1\n            -joints 1\n            -ikHandles 1\n            -deformers 1\n            -dynamics 1\n            -particleInstancers 1\n            -fluids 1\n            -hairSystems 1\n            -follicles 1\n            -nCloths 1\n"
+		+ "            -nParticles 1\n            -nRigids 1\n            -dynamicConstraints 1\n            -locators 1\n            -manipulators 1\n            -pluginShapes 1\n            -dimensions 1\n            -handles 1\n            -pivots 1\n            -textures 1\n            -strokes 1\n            -motionTrails 1\n            -clipGhosts 1\n            -bluePencil 1\n            -greasePencils 0\n            -excludeObjectPreset \"All\" \n            -shadows 0\n            -captureSequenceNumber -1\n            -width 98\n            -height 0\n            -sceneRenderFilter 0\n            $editorName;\n        modelEditor -e -viewSelected 0 $editorName;\n        modelEditor -e \n            -pluginObjects \"gpuCacheDisplayFilter\" 1 \n            -pluginObjects \"mayaUsdProxyShapeBaseDisplayFilter\" 1 \n            $editorName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextPanel \"modelPanel\" (localizedPanelLabel(\"Persp View\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n"
+		+ "\t\tmodelPanel -edit -l (localizedPanelLabel(\"Persp View\")) -mbv $menusOkayInPanels  $panelName;\n\t\t$editorName = $panelName;\n        modelEditor -e \n            -camera \"|persp\" \n            -useInteractiveMode 0\n            -displayLights \"all\" \n            -displayAppearance \"smoothShaded\" \n            -activeOnly 0\n            -ignorePanZoom 0\n            -wireframeOnShaded 0\n            -headsUpDisplay 1\n            -holdOuts 1\n            -selectionHiliteDisplay 1\n            -useDefaultMaterial 0\n            -bufferMode \"double\" \n            -twoSidedLighting 0\n            -backfaceCulling 0\n            -xray 0\n            -jointXray 0\n            -activeComponentsXray 0\n            -displayTextures 0\n            -smoothWireframe 0\n            -lineWidth 1\n            -textureAnisotropic 0\n            -textureHilight 1\n            -textureSampling 2\n            -textureDisplay \"modulate\" \n            -textureMaxSize 32768\n            -fogging 0\n            -fogSource \"fragment\" \n            -fogMode \"linear\" \n"
+		+ "            -fogStart 0\n            -fogEnd 100\n            -fogDensity 0.1\n            -fogColor 0.5 0.5 0.5 1 \n            -depthOfFieldPreview 1\n            -maxConstantTransparency 1\n            -rendererName \"vp2Renderer\" \n            -rendererOverrideName \"mayaHydraRenderOverride_HdStormRendererPlugin\" \n            -objectFilterShowInHUD 1\n            -isFiltered 0\n            -colorResolution 256 256 \n            -bumpResolution 512 512 \n            -textureCompression 0\n            -transparencyAlgorithm \"frontAndBackCull\" \n            -transpInShadows 0\n            -cullingOverride \"none\" \n            -lowQualityLighting 0\n            -maximumNumHardwareLights 1\n            -occlusionCulling 0\n            -shadingModel 0\n            -useBaseRenderer 0\n            -useReducedRenderer 0\n            -smallObjectCulling 0\n            -smallObjectThreshold -1 \n            -interactiveDisableShadows 0\n            -interactiveBackFaceCull 0\n            -sortTransparent 1\n            -controllers 1\n            -nurbsCurves 1\n"
+		+ "            -nurbsSurfaces 1\n            -polymeshes 1\n            -subdivSurfaces 1\n            -planes 1\n            -lights 1\n            -cameras 1\n            -controlVertices 1\n            -hulls 1\n            -grid 1\n            -imagePlane 1\n            -joints 1\n            -ikHandles 1\n            -deformers 1\n            -dynamics 1\n            -particleInstancers 1\n            -fluids 1\n            -hairSystems 1\n            -follicles 1\n            -nCloths 1\n            -nParticles 1\n            -nRigids 1\n            -dynamicConstraints 1\n            -locators 1\n            -manipulators 1\n            -pluginShapes 1\n            -dimensions 1\n            -handles 1\n            -pivots 1\n            -textures 1\n            -strokes 1\n            -motionTrails 1\n            -clipGhosts 1\n            -bluePencil 1\n            -greasePencils 0\n            -excludeObjectPreset \"All\" \n            -shadows 0\n            -captureSequenceNumber -1\n            -width 1761\n            -height 1048\n            -sceneRenderFilter 0\n"
+		+ "            $editorName;\n        modelEditor -e -viewSelected 0 $editorName;\n        modelEditor -e \n            -pluginObjects \"gpuCacheDisplayFilter\" 1 \n            -pluginObjects \"mayaUsdProxyShapeBaseDisplayFilter\" 1 \n            $editorName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextPanel \"outlinerPanel\" (localizedPanelLabel(\"ToggledOutliner\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\toutlinerPanel -edit -l (localizedPanelLabel(\"ToggledOutliner\")) -mbv $menusOkayInPanels  $panelName;\n\t\t$editorName = $panelName;\n        outlinerEditor -e \n            -docTag \"isolOutln_fromSeln\" \n            -showShapes 1\n            -showAssignedMaterials 1\n            -showTimeEditor 1\n            -showReferenceNodes 1\n            -showReferenceMembers 1\n            -showAttributes 0\n            -showConnected 0\n            -showAnimCurvesOnly 0\n            -showMuteInfo 0\n            -organizeByLayer 1\n            -organizeByClip 1\n"
+		+ "            -showAnimLayerWeight 1\n            -autoExpandLayers 1\n            -autoExpand 0\n            -showDagOnly 1\n            -showAssets 1\n            -showContainedOnly 1\n            -showPublishedAsConnected 0\n            -showParentContainers 0\n            -showContainerContents 1\n            -ignoreDagHierarchy 0\n            -expandConnections 0\n            -showUpstreamCurves 1\n            -showUnitlessCurves 1\n            -showCompounds 1\n            -showLeafs 1\n            -showNumericAttrsOnly 0\n            -highlightActive 1\n            -autoSelectNewObjects 0\n            -doNotSelectNewObjects 0\n            -dropIsParent 1\n            -transmitFilters 0\n            -setFilter \"defaultSetFilter\" \n            -showSetMembers 1\n            -allowMultiSelection 1\n            -alwaysToggleSelect 0\n            -directSelect 0\n            -isSet 0\n            -isSetMember 0\n            -showUfeItems 1\n            -displayMode \"DAG\" \n            -expandObjects 0\n            -setsIgnoreFilters 1\n            -containersIgnoreFilters 0\n"
+		+ "            -editAttrName 0\n            -showAttrValues 0\n            -highlightSecondary 0\n            -showUVAttrsOnly 0\n            -showTextureNodesOnly 0\n            -attrAlphaOrder \"default\" \n            -animLayerFilterOptions \"allAffecting\" \n            -sortOrder \"none\" \n            -longNames 0\n            -niceNames 1\n            -selectCommand \"print(\\\"\\\")\" \n            -showNamespace 1\n            -showPinIcons 0\n            -mapMotionTrails 0\n            -ignoreHiddenAttribute 0\n            -ignoreOutlinerColor 0\n            -renderFilterVisible 0\n            -renderFilterIndex 0\n            -selectionOrder \"chronological\" \n            -expandAttribute 0\n            $editorName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextPanel \"outlinerPanel\" (localizedPanelLabel(\"Outliner\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\toutlinerPanel -edit -l (localizedPanelLabel(\"Outliner\")) -mbv $menusOkayInPanels  $panelName;\n"
+		+ "\t\t$editorName = $panelName;\n        outlinerEditor -e \n            -showShapes 0\n            -showAssignedMaterials 0\n            -showTimeEditor 1\n            -showReferenceNodes 0\n            -showReferenceMembers 0\n            -showAttributes 0\n            -showConnected 0\n            -showAnimCurvesOnly 0\n            -showMuteInfo 0\n            -organizeByLayer 1\n            -organizeByClip 1\n            -showAnimLayerWeight 1\n            -autoExpandLayers 1\n            -autoExpand 0\n            -showDagOnly 1\n            -showAssets 1\n            -showContainedOnly 1\n            -showPublishedAsConnected 0\n            -showParentContainers 0\n            -showContainerContents 1\n            -ignoreDagHierarchy 0\n            -expandConnections 0\n            -showUpstreamCurves 1\n            -showUnitlessCurves 1\n            -showCompounds 1\n            -showLeafs 1\n            -showNumericAttrsOnly 0\n            -highlightActive 1\n            -autoSelectNewObjects 0\n            -doNotSelectNewObjects 0\n            -dropIsParent 1\n"
+		+ "            -transmitFilters 0\n            -setFilter \"defaultSetFilter\" \n            -showSetMembers 1\n            -allowMultiSelection 1\n            -alwaysToggleSelect 0\n            -directSelect 0\n            -showUfeItems 1\n            -displayMode \"DAG\" \n            -expandObjects 0\n            -setsIgnoreFilters 1\n            -containersIgnoreFilters 0\n            -editAttrName 0\n            -showAttrValues 0\n            -highlightSecondary 0\n            -showUVAttrsOnly 0\n            -showTextureNodesOnly 0\n            -attrAlphaOrder \"default\" \n            -animLayerFilterOptions \"allAffecting\" \n            -sortOrder \"none\" \n            -longNames 0\n            -niceNames 1\n            -showNamespace 1\n            -showPinIcons 0\n            -mapMotionTrails 0\n            -ignoreHiddenAttribute 0\n            -ignoreOutlinerColor 0\n            -renderFilterVisible 0\n            $editorName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"graphEditor\" (localizedPanelLabel(\"Graph Editor\")) `;\n"
+		+ "\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Graph Editor\")) -mbv $menusOkayInPanels  $panelName;\n\n\t\t\t$editorName = ($panelName+\"OutlineEd\");\n            outlinerEditor -e \n                -showShapes 1\n                -showAssignedMaterials 0\n                -showTimeEditor 1\n                -showReferenceNodes 0\n                -showReferenceMembers 0\n                -showAttributes 1\n                -showConnected 1\n                -showAnimCurvesOnly 1\n                -showMuteInfo 0\n                -organizeByLayer 1\n                -organizeByClip 1\n                -showAnimLayerWeight 1\n                -autoExpandLayers 1\n                -autoExpand 1\n                -showDagOnly 0\n                -showAssets 1\n                -showContainedOnly 0\n                -showPublishedAsConnected 0\n                -showParentContainers 0\n                -showContainerContents 0\n                -ignoreDagHierarchy 0\n                -expandConnections 1\n"
+		+ "                -showUpstreamCurves 1\n                -showUnitlessCurves 1\n                -showCompounds 0\n                -showLeafs 1\n                -showNumericAttrsOnly 1\n                -highlightActive 0\n                -autoSelectNewObjects 1\n                -doNotSelectNewObjects 0\n                -dropIsParent 1\n                -transmitFilters 1\n                -setFilter \"0\" \n                -showSetMembers 0\n                -allowMultiSelection 1\n                -alwaysToggleSelect 0\n                -directSelect 0\n                -showUfeItems 1\n                -displayMode \"DAG\" \n                -expandObjects 0\n                -setsIgnoreFilters 1\n                -containersIgnoreFilters 0\n                -editAttrName 0\n                -showAttrValues 0\n                -highlightSecondary 0\n                -showUVAttrsOnly 0\n                -showTextureNodesOnly 0\n                -attrAlphaOrder \"default\" \n                -animLayerFilterOptions \"allAffecting\" \n                -sortOrder \"none\" \n"
+		+ "                -longNames 0\n                -niceNames 1\n                -showNamespace 1\n                -showPinIcons 1\n                -mapMotionTrails 1\n                -ignoreHiddenAttribute 0\n                -ignoreOutlinerColor 0\n                -renderFilterVisible 0\n                $editorName;\n\n\t\t\t$editorName = ($panelName+\"GraphEd\");\n            animCurveEditor -e \n                -displayValues 0\n                -snapTime \"integer\" \n                -snapValue \"none\" \n                -showPlayRangeShades \"on\" \n                -lockPlayRangeShades \"off\" \n                -smoothness \"fine\" \n                -resultSamples 1\n                -resultScreenSamples 0\n                -resultUpdate \"delayed\" \n                -showUpstreamCurves 1\n                -showRowButtons 1\n                -tangentScale 1\n                -tangentLineThickness 1\n                -keyMinScale 1\n                -stackedCurvesMin -1\n                -stackedCurvesMax 1\n                -stackedCurvesSpace 0.2\n                -preSelectionHighlight 0\n"
+		+ "                -limitToSelectedCurves 0\n                -constrainDrag 0\n                -valueLinesToggle 0\n                -outliner \"graphEditor1OutlineEd\" \n                -highlightAffectedCurves 0\n                $editorName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"dopeSheetPanel\" (localizedPanelLabel(\"Dope Sheet\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Dope Sheet\")) -mbv $menusOkayInPanels  $panelName;\n\n\t\t\t$editorName = ($panelName+\"OutlineEd\");\n            outlinerEditor -e \n                -showShapes 1\n                -showAssignedMaterials 0\n                -showTimeEditor 1\n                -showReferenceNodes 0\n                -showReferenceMembers 0\n                -showAttributes 1\n                -showConnected 1\n                -showAnimCurvesOnly 1\n                -showMuteInfo 0\n                -organizeByLayer 1\n                -organizeByClip 1\n"
+		+ "                -showAnimLayerWeight 1\n                -autoExpandLayers 1\n                -autoExpand 0\n                -showDagOnly 0\n                -showAssets 1\n                -showContainedOnly 0\n                -showPublishedAsConnected 0\n                -showParentContainers 0\n                -showContainerContents 0\n                -ignoreDagHierarchy 0\n                -expandConnections 1\n                -showUpstreamCurves 1\n                -showUnitlessCurves 0\n                -showCompounds 0\n                -showLeafs 1\n                -showNumericAttrsOnly 1\n                -highlightActive 0\n                -autoSelectNewObjects 0\n                -doNotSelectNewObjects 1\n                -dropIsParent 1\n                -transmitFilters 0\n                -setFilter \"0\" \n                -showSetMembers 1\n                -allowMultiSelection 1\n                -alwaysToggleSelect 0\n                -directSelect 0\n                -showUfeItems 1\n                -displayMode \"DAG\" \n                -expandObjects 0\n"
+		+ "                -setsIgnoreFilters 1\n                -containersIgnoreFilters 0\n                -editAttrName 0\n                -showAttrValues 0\n                -highlightSecondary 0\n                -showUVAttrsOnly 0\n                -showTextureNodesOnly 0\n                -attrAlphaOrder \"default\" \n                -animLayerFilterOptions \"allAffecting\" \n                -sortOrder \"none\" \n                -longNames 0\n                -niceNames 1\n                -showNamespace 1\n                -showPinIcons 0\n                -mapMotionTrails 1\n                -ignoreHiddenAttribute 0\n                -ignoreOutlinerColor 0\n                -renderFilterVisible 0\n                $editorName;\n\n\t\t\t$editorName = ($panelName+\"DopeSheetEd\");\n            dopeSheetEditor -e \n                -displayValues 0\n                -snapTime \"none\" \n                -snapValue \"none\" \n                -outliner \"dopeSheetPanel1OutlineEd\" \n                -hierarchyBelow 0\n                -selectionWindow 0 0 0 0 \n                $editorName;\n"
+		+ "\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"timeEditorPanel\" (localizedPanelLabel(\"Time Editor\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Time Editor\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"clipEditorPanel\" (localizedPanelLabel(\"Trax Editor\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Trax Editor\")) -mbv $menusOkayInPanels  $panelName;\n\n\t\t\t$editorName = clipEditorNameFromPanel($panelName);\n            clipEditor -e \n                -displayValues 0\n                -snapTime \"none\" \n                -snapValue \"none\" \n                -initialized 0\n                -manageSequencer 0 \n                $editorName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n"
+		+ "\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"sequenceEditorPanel\" (localizedPanelLabel(\"Sequencer\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Sequencer\")) -mbv $menusOkayInPanels  $panelName;\n\n\t\t\t$editorName = sequenceEditorNameFromPanel($panelName);\n            cameraSequencer -e \n                -displayValues 0\n                -snapTime \"none\" \n                -snapValue \"none\" \n                -initialized 0\n                -showThumbnail 1\n                $editorName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"hyperGraphPanel\" (localizedPanelLabel(\"Hypergraph Hierarchy\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Hypergraph Hierarchy\")) -mbv $menusOkayInPanels  $panelName;\n\n\t\t\t$editorName = ($panelName+\"HyperGraphEd\");\n            hyperGraph -e \n                -graphLayoutStyle \"hierarchicalLayout\" \n"
+		+ "                -orientation \"horiz\" \n                -mergeConnections 0\n                -zoom 1\n                -animateTransition 0\n                -showRelationships 1\n                -showShapes 0\n                -showDeformers 0\n                -showExpressions 0\n                -showConstraints 0\n                -showConnectionFromSelected 0\n                -showConnectionToSelected 0\n                -showConstraintLabels 0\n                -showUnderworld 0\n                -showInvisible 0\n                -showNamespace 1\n                -transitionFrames 1\n                -opaqueContainers 0\n                -freeform 0\n                -imagePosition 0 0 \n                -imageScale 1\n                -imageEnabled 0\n                -graphType \"DAG\" \n                -heatMapDisplay 0\n                -updateSelection 1\n                -updateNodeAdded 1\n                -useDrawOverrideColor 0\n                -limitGraphTraversal -1\n                -range 0 0 \n                -iconSize \"smallIcons\" \n                -showCachedConnections 0\n"
+		+ "                $editorName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"hyperShadePanel\" (localizedPanelLabel(\"Hypershade\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Hypershade\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"visorPanel\" (localizedPanelLabel(\"Visor\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Visor\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"nodeEditorPanel\" (localizedPanelLabel(\"Node Editor\")) `;\n\tif ($nodeEditorPanelVisible || $nodeEditorWorkspaceControlOpen) {\n\t\tif (\"\" == $panelName) {\n\t\t\tif ($useSceneConfig) {\n\t\t\t\t$panelName = `scriptedPanel -unParent  -type \"nodeEditorPanel\" -l (localizedPanelLabel(\"Node Editor\")) -mbv $menusOkayInPanels `;\n"
+		+ "\n\t\t\t$editorName = ($panelName+\"NodeEditorEd\");\n            nodeEditor -e \n                -allAttributes 0\n                -allNodes 0\n                -autoSizeNodes 1\n                -consistentNameSize 1\n                -createNodeCommand \"nodeEdCreateNodeCommand\" \n                -connectNodeOnCreation 0\n                -connectOnDrop 0\n                -copyConnectionsOnPaste 0\n                -connectionStyle \"bezier\" \n                -defaultPinnedState 0\n                -additiveGraphingMode 0\n                -connectedGraphingMode 1\n                -settingsChangedCallback \"nodeEdSyncControls\" \n                -traversalDepthLimit -1\n                -keyPressCommand \"nodeEdKeyPressCommand\" \n                -nodeTitleMode \"name\" \n                -gridSnap 0\n                -gridVisibility 1\n                -crosshairOnEdgeDragging 0\n                -popupMenuScript \"nodeEdBuildPanelMenus\" \n                -showNamespace 1\n                -showShapes 1\n                -showSGShapes 0\n                -showTransforms 1\n"
+		+ "                -useAssets 1\n                -syncedSelection 1\n                -extendToShapes 1\n                -showUnitConversions 0\n                -editorMode \"default\" \n                -hasWatchpoint 0\n                $editorName;\n\t\t\t}\n\t\t} else {\n\t\t\t$label = `panel -q -label $panelName`;\n\t\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Node Editor\")) -mbv $menusOkayInPanels  $panelName;\n\n\t\t\t$editorName = ($panelName+\"NodeEditorEd\");\n            nodeEditor -e \n                -allAttributes 0\n                -allNodes 0\n                -autoSizeNodes 1\n                -consistentNameSize 1\n                -createNodeCommand \"nodeEdCreateNodeCommand\" \n                -connectNodeOnCreation 0\n                -connectOnDrop 0\n                -copyConnectionsOnPaste 0\n                -connectionStyle \"bezier\" \n                -defaultPinnedState 0\n                -additiveGraphingMode 0\n                -connectedGraphingMode 1\n                -settingsChangedCallback \"nodeEdSyncControls\" \n                -traversalDepthLimit -1\n"
+		+ "                -keyPressCommand \"nodeEdKeyPressCommand\" \n                -nodeTitleMode \"name\" \n                -gridSnap 0\n                -gridVisibility 1\n                -crosshairOnEdgeDragging 0\n                -popupMenuScript \"nodeEdBuildPanelMenus\" \n                -showNamespace 1\n                -showShapes 1\n                -showSGShapes 0\n                -showTransforms 1\n                -useAssets 1\n                -syncedSelection 1\n                -extendToShapes 1\n                -showUnitConversions 0\n                -editorMode \"default\" \n                -hasWatchpoint 0\n                $editorName;\n\t\t\tif (!$useSceneConfig) {\n\t\t\t\tpanel -e -l $label $panelName;\n\t\t\t}\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"createNodePanel\" (localizedPanelLabel(\"Create Node\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Create Node\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n"
+		+ "\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"polyTexturePlacementPanel\" (localizedPanelLabel(\"UV Editor\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"UV Editor\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"renderWindowPanel\" (localizedPanelLabel(\"Render View\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Render View\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextPanel \"shapePanel\" (localizedPanelLabel(\"Shape Editor\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tshapePanel -edit -l (localizedPanelLabel(\"Shape Editor\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n"
+		+ "\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextPanel \"posePanel\" (localizedPanelLabel(\"Pose Editor\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tposePanel -edit -l (localizedPanelLabel(\"Pose Editor\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"dynRelEdPanel\" (localizedPanelLabel(\"Dynamic Relationships\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Dynamic Relationships\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"relationshipPanel\" (localizedPanelLabel(\"Relationship Editor\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Relationship Editor\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n"
+		+ "\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"referenceEditorPanel\" (localizedPanelLabel(\"Reference Editor\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Reference Editor\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"dynPaintScriptedPanelType\" (localizedPanelLabel(\"Paint Effects\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Paint Effects\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"scriptEditorPanel\" (localizedPanelLabel(\"Script Editor\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Script Editor\")) -mbv $menusOkayInPanels  $panelName;\n"
+		+ "\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"profilerPanel\" (localizedPanelLabel(\"Profiler Tool\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Profiler Tool\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"motionMakerEditorPanel\" (localizedPanelLabel(\"MotionMaker Editor\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"MotionMaker Editor\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"contentBrowserPanel\" (localizedPanelLabel(\"Content Browser\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Content Browser\")) -mbv $menusOkayInPanels  $panelName;\n"
+		+ "\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\tif ($useSceneConfig) {\n        string $configName = `getPanel -cwl (localizedPanelLabel(\"Current Layout\"))`;\n        if (\"\" != $configName) {\n\t\t\tpanelConfiguration -edit -label (localizedPanelLabel(\"Current Layout\")) \n\t\t\t\t-userCreated false\n\t\t\t\t-defaultImage \"vacantCell.png\"\n\t\t\t\t-image \"\"\n\t\t\t\t-sc false\n\t\t\t\t-configString \"global string $gMainPane; paneLayout -e -cn \\\"single\\\" -ps 1 100 100 $gMainPane;\"\n\t\t\t\t-removeAllPanels\n\t\t\t\t-ap false\n\t\t\t\t\t(localizedPanelLabel(\"Persp View\")) \n\t\t\t\t\t\"modelPanel\"\n"
+		+ "\t\t\t\t\t\"$panelName = `modelPanel -unParent -l (localizedPanelLabel(\\\"Persp View\\\")) -mbv $menusOkayInPanels `;\\n$editorName = $panelName;\\nmodelEditor -e \\n    -cam `findStartUpCamera persp` \\n    -useInteractiveMode 0\\n    -displayLights \\\"all\\\" \\n    -displayAppearance \\\"smoothShaded\\\" \\n    -activeOnly 0\\n    -ignorePanZoom 0\\n    -wireframeOnShaded 0\\n    -headsUpDisplay 1\\n    -holdOuts 1\\n    -selectionHiliteDisplay 1\\n    -useDefaultMaterial 0\\n    -bufferMode \\\"double\\\" \\n    -twoSidedLighting 0\\n    -backfaceCulling 0\\n    -xray 0\\n    -jointXray 0\\n    -activeComponentsXray 0\\n    -displayTextures 0\\n    -smoothWireframe 0\\n    -lineWidth 1\\n    -textureAnisotropic 0\\n    -textureHilight 1\\n    -textureSampling 2\\n    -textureDisplay \\\"modulate\\\" \\n    -textureMaxSize 32768\\n    -fogging 0\\n    -fogSource \\\"fragment\\\" \\n    -fogMode \\\"linear\\\" \\n    -fogStart 0\\n    -fogEnd 100\\n    -fogDensity 0.1\\n    -fogColor 0.5 0.5 0.5 1 \\n    -depthOfFieldPreview 1\\n    -maxConstantTransparency 1\\n    -rendererName \\\"vp2Renderer\\\" \\n    -rendererOverrideName \\\"mayaHydraRenderOverride_HdStormRendererPlugin\\\" \\n    -objectFilterShowInHUD 1\\n    -isFiltered 0\\n    -colorResolution 256 256 \\n    -bumpResolution 512 512 \\n    -textureCompression 0\\n    -transparencyAlgorithm \\\"frontAndBackCull\\\" \\n    -transpInShadows 0\\n    -cullingOverride \\\"none\\\" \\n    -lowQualityLighting 0\\n    -maximumNumHardwareLights 1\\n    -occlusionCulling 0\\n    -shadingModel 0\\n    -useBaseRenderer 0\\n    -useReducedRenderer 0\\n    -smallObjectCulling 0\\n    -smallObjectThreshold -1 \\n    -interactiveDisableShadows 0\\n    -interactiveBackFaceCull 0\\n    -sortTransparent 1\\n    -controllers 1\\n    -nurbsCurves 1\\n    -nurbsSurfaces 1\\n    -polymeshes 1\\n    -subdivSurfaces 1\\n    -planes 1\\n    -lights 1\\n    -cameras 1\\n    -controlVertices 1\\n    -hulls 1\\n    -grid 1\\n    -imagePlane 1\\n    -joints 1\\n    -ikHandles 1\\n    -deformers 1\\n    -dynamics 1\\n    -particleInstancers 1\\n    -fluids 1\\n    -hairSystems 1\\n    -follicles 1\\n    -nCloths 1\\n    -nParticles 1\\n    -nRigids 1\\n    -dynamicConstraints 1\\n    -locators 1\\n    -manipulators 1\\n    -pluginShapes 1\\n    -dimensions 1\\n    -handles 1\\n    -pivots 1\\n    -textures 1\\n    -strokes 1\\n    -motionTrails 1\\n    -clipGhosts 1\\n    -bluePencil 1\\n    -greasePencils 0\\n    -excludeObjectPreset \\\"All\\\" \\n    -shadows 0\\n    -captureSequenceNumber -1\\n    -width 1761\\n    -height 1048\\n    -sceneRenderFilter 0\\n    $editorName;\\nmodelEditor -e -viewSelected 0 $editorName;\\nmodelEditor -e \\n    -pluginObjects \\\"gpuCacheDisplayFilter\\\" 1 \\n    -pluginObjects \\\"mayaUsdProxyShapeBaseDisplayFilter\\\" 1 \\n    $editorName\"\n"
+		+ "\t\t\t\t\t\"modelPanel -edit -l (localizedPanelLabel(\\\"Persp View\\\")) -mbv $menusOkayInPanels  $panelName;\\n$editorName = $panelName;\\nmodelEditor -e \\n    -cam `findStartUpCamera persp` \\n    -useInteractiveMode 0\\n    -displayLights \\\"all\\\" \\n    -displayAppearance \\\"smoothShaded\\\" \\n    -activeOnly 0\\n    -ignorePanZoom 0\\n    -wireframeOnShaded 0\\n    -headsUpDisplay 1\\n    -holdOuts 1\\n    -selectionHiliteDisplay 1\\n    -useDefaultMaterial 0\\n    -bufferMode \\\"double\\\" \\n    -twoSidedLighting 0\\n    -backfaceCulling 0\\n    -xray 0\\n    -jointXray 0\\n    -activeComponentsXray 0\\n    -displayTextures 0\\n    -smoothWireframe 0\\n    -lineWidth 1\\n    -textureAnisotropic 0\\n    -textureHilight 1\\n    -textureSampling 2\\n    -textureDisplay \\\"modulate\\\" \\n    -textureMaxSize 32768\\n    -fogging 0\\n    -fogSource \\\"fragment\\\" \\n    -fogMode \\\"linear\\\" \\n    -fogStart 0\\n    -fogEnd 100\\n    -fogDensity 0.1\\n    -fogColor 0.5 0.5 0.5 1 \\n    -depthOfFieldPreview 1\\n    -maxConstantTransparency 1\\n    -rendererName \\\"vp2Renderer\\\" \\n    -rendererOverrideName \\\"mayaHydraRenderOverride_HdStormRendererPlugin\\\" \\n    -objectFilterShowInHUD 1\\n    -isFiltered 0\\n    -colorResolution 256 256 \\n    -bumpResolution 512 512 \\n    -textureCompression 0\\n    -transparencyAlgorithm \\\"frontAndBackCull\\\" \\n    -transpInShadows 0\\n    -cullingOverride \\\"none\\\" \\n    -lowQualityLighting 0\\n    -maximumNumHardwareLights 1\\n    -occlusionCulling 0\\n    -shadingModel 0\\n    -useBaseRenderer 0\\n    -useReducedRenderer 0\\n    -smallObjectCulling 0\\n    -smallObjectThreshold -1 \\n    -interactiveDisableShadows 0\\n    -interactiveBackFaceCull 0\\n    -sortTransparent 1\\n    -controllers 1\\n    -nurbsCurves 1\\n    -nurbsSurfaces 1\\n    -polymeshes 1\\n    -subdivSurfaces 1\\n    -planes 1\\n    -lights 1\\n    -cameras 1\\n    -controlVertices 1\\n    -hulls 1\\n    -grid 1\\n    -imagePlane 1\\n    -joints 1\\n    -ikHandles 1\\n    -deformers 1\\n    -dynamics 1\\n    -particleInstancers 1\\n    -fluids 1\\n    -hairSystems 1\\n    -follicles 1\\n    -nCloths 1\\n    -nParticles 1\\n    -nRigids 1\\n    -dynamicConstraints 1\\n    -locators 1\\n    -manipulators 1\\n    -pluginShapes 1\\n    -dimensions 1\\n    -handles 1\\n    -pivots 1\\n    -textures 1\\n    -strokes 1\\n    -motionTrails 1\\n    -clipGhosts 1\\n    -bluePencil 1\\n    -greasePencils 0\\n    -excludeObjectPreset \\\"All\\\" \\n    -shadows 0\\n    -captureSequenceNumber -1\\n    -width 1761\\n    -height 1048\\n    -sceneRenderFilter 0\\n    $editorName;\\nmodelEditor -e -viewSelected 0 $editorName;\\nmodelEditor -e \\n    -pluginObjects \\\"gpuCacheDisplayFilter\\\" 1 \\n    -pluginObjects \\\"mayaUsdProxyShapeBaseDisplayFilter\\\" 1 \\n    $editorName\"\n"
+		+ "\t\t\t\t$configName;\n\n            setNamedPanelLayout (localizedPanelLabel(\"Current Layout\"));\n        }\n\n        panelHistory -e -clear mainPanelHistory;\n        sceneUIReplacement -clear;\n\t}\n\n\ngrid -spacing 5 -size 12 -divisions 5 -displayAxes yes -displayGridLines yes -displayDivisionLines yes -displayPerspectiveLabels no -displayOrthographicLabels no -displayAxesBold yes -perspectiveLabelPosition axis -orthographicLabelPosition edge;\nviewManip -drawCompass 0 -compassAngle 0 -frontParameters \"\" -homeParameters \"\" -selectionLockParameters \"\";\n}\n");
+	setAttr ".st" 3;
+createNode script -n "sceneConfigurationScriptNode";
+	rename -uid "F0D66B94-41BB-1470-7892-E481BC92FD04";
+	setAttr ".b" -type "string" "playbackOptions -min 0 -max 10 -ast 0 -aet 10 ";
+	setAttr ".st" 6;
+createNode trackInfoManager -n "trackInfoManager1";
+	rename -uid "CE544CE6-484B-9E6A-C176-3298D722130B";
+createNode mayaUsdLayerManager -n "mayaUsdLayerManager1";
+	rename -uid "0704A3F1-4907-DDE7-699E-F1912B11F3B1";
+	setAttr ".sst" -type "string" "|AnimCubeRenderSettings2|AnimCubeRenderSettings2Shape";
+select -ne :time1;
+	setAttr ".o" 0;
+select -ne :hardwareRenderingGlobals;
+	setAttr ".otfna" -type "stringArray" 22 "NURBS Curves" "NURBS Surfaces" "Polygons" "Subdiv Surface" "Particles" "Particle Instance" "Fluids" "Strokes" "Image Planes" "UI" "Lights" "Cameras" "Locators" "Joints" "IK Handles" "Deformers" "Motion Trails" "Components" "Hair Systems" "Follicles" "Misc. UI" "Ornaments"  ;
+	setAttr ".otfva" -type "Int32Array" 22 0 1 1 1 1 1
+		 1 1 1 0 0 0 0 0 0 0 0 0
+		 0 0 0 0 ;
+	setAttr ".fprt" yes;
+	setAttr ".rtfm" 1;
+select -ne :renderPartition;
+	setAttr -s 2 ".st";
+select -ne :renderGlobalsList1;
+select -ne :defaultShaderList1;
+	setAttr -s 6 ".s";
+select -ne :postProcessList1;
+	setAttr -s 2 ".p";
+select -ne :defaultRenderingList1;
+select -ne :lightList1;
+select -ne :standardSurface1;
+	setAttr ".bc" -type "float3" 0.40000001 0.40000001 0.40000001 ;
+	setAttr ".sr" 0.5;
+select -ne :openPBR_shader1;
+	setAttr ".bc" -type "float3" 0.40000001 0.40000001 0.40000001 ;
+	setAttr ".sr" 0.5;
+select -ne :initialShadingGroup;
+	setAttr ".ro" yes;
+select -ne :initialParticleSE;
+	setAttr ".ro" yes;
+select -ne :defaultRenderGlobals;
+	addAttr -ci true -sn "mtohMotionSampleStart" -ln "mtohMotionSampleStart" -at "float";
+	addAttr -ci true -sn "mtohMotionSampleEnd" -ln "mtohMotionSampleEnd" -at "float";
+	addAttr -ci true -sn "mayaHydraRenderPurpose" -ln "mayaHydraRenderPurpose" -dv 1 
+		-min 0 -max 1 -at "bool";
+	addAttr -ci true -sn "mayaHydraProxyPurpose" -ln "mayaHydraProxyPurpose" -dv 1 -min 
+		0 -max 1 -at "bool";
+	addAttr -ci true -sn "mayaHydraGuidePurpose" -ln "mayaHydraGuidePurpose" -dv 1 -min 
+		0 -max 1 -at "bool";
+	addAttr -ci true -sn "mtohTextureMemoryPerTexture" -ln "mtohTextureMemoryPerTexture" 
+		-dv 4096 -min 1 -max 262144 -smn 16384 -at "long";
+	addAttr -ci true -sn "mtohMaximumShadowMapResolution" -ln "mtohMaximumShadowMapResolution" 
+		-dv 2048 -min 32 -max 8192 -at "long";
+	addAttr -ci true -sn "mayaHydraRefinementLevel" -ln "mayaHydraRefinementLevel" -min 
+		0 -max 8 -at "long";
+	addAttr -ci true -sn "HdStormRendererPlugin__enableTinyPrimCulling" -ln "HdStormRendererPlugin__enableTinyPrimCulling" 
+		-min 0 -max 1 -at "bool";
+	addAttr -ci true -sn "HdStormRendererPlugin__volumeRaymarchingStepSize" -ln "HdStormRendererPlugin__volumeRaymarchingStepSize" 
+		-dv 1 -at "float";
+	addAttr -ci true -sn "HdStormRendererPlugin__volumeRaymarchingStepSizeLighting" 
+		-ln "HdStormRendererPlugin__volumeRaymarchingStepSizeLighting" -dv 10 -at "float";
+	addAttr -ci true -sn "HdStormRendererPlugin__volumeMaxTextureMemoryPerField" -ln "HdStormRendererPlugin__volumeMaxTextureMemoryPerField" 
+		-dv 128 -at "float";
+	addAttr -ci true -sn "HdStormRendererPlugin__maxLights" -ln "HdStormRendererPlugin__maxLights" 
+		-dv 16 -at "long";
+	addAttr -ci true -sn "HdStormRendererPlugin__domeLightCameraVisibility" -ln "HdStormRendererPlugin__domeLightCameraVisibility" 
+		-dv 1 -min 0 -max 1 -at "bool";
+	addAttr -ci true -sn "HdStormRendererPlugin__enableExposureCompensation" -ln "HdStormRendererPlugin__enableExposureCompensation" 
+		-dv 1 -min 0 -max 1 -at "bool";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__enable_progressive_render" -ln "HdArnoldRendererPlugin__enable_progressive_render" 
+		-dv 1 -min 0 -max 1 -at "bool";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__progressive_min_AA_samples" -ln "HdArnoldRendererPlugin__progressive_min_AA_samples" 
+		-dv -4 -at "long";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__enable_adaptive_sampling" -ln "HdArnoldRendererPlugin__enable_adaptive_sampling" 
+		-min 0 -max 1 -at "bool";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__enable_gpu_rendering" -ln "HdArnoldRendererPlugin__enable_gpu_rendering" 
+		-min 0 -max 1 -at "bool";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__interactive_target_fps" -ln "HdArnoldRendererPlugin__interactive_target_fps" 
+		-dv 32 -at "float";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__interactive_target_fps_min" -ln "HdArnoldRendererPlugin__interactive_target_fps_min" 
+		-dv 8 -at "float";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__interactive_fps_min" -ln "HdArnoldRendererPlugin__interactive_fps_min" 
+		-dv 2 -at "float";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__threads" -ln "HdArnoldRendererPlugin__threads" 
+		-dv -1 -at "long";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__AA_samples" -ln "HdArnoldRendererPlugin__AA_samples" 
+		-dv 3 -at "long";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__AA_samples_max" -ln "HdArnoldRendererPlugin__AA_samples_max" 
+		-dv 20 -at "long";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__GI_diffuse_samples" -ln "HdArnoldRendererPlugin__GI_diffuse_samples" 
+		-dv 2 -at "long";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__GI_specular_samples" -ln "HdArnoldRendererPlugin__GI_specular_samples" 
+		-dv 2 -at "long";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__GI_transmission_samples" -ln "HdArnoldRendererPlugin__GI_transmission_samples" 
+		-dv 2 -at "long";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__GI_sss_samples" -ln "HdArnoldRendererPlugin__GI_sss_samples" 
+		-dv 2 -at "long";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__GI_volume_samples" -ln "HdArnoldRendererPlugin__GI_volume_samples" 
+		-dv 2 -at "long";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__auto_transparency_depth" -ln "HdArnoldRendererPlugin__auto_transparency_depth" 
+		-dv 10 -at "long";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__GI_diffuse_depth" -ln "HdArnoldRendererPlugin__GI_diffuse_depth" 
+		-dv 1 -at "long";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__GI_specular_depth" -ln "HdArnoldRendererPlugin__GI_specular_depth" 
+		-dv 1 -at "long";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__GI_transmission_depth" -ln "HdArnoldRendererPlugin__GI_transmission_depth" 
+		-dv 8 -at "long";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__GI_volume_depth" -ln "HdArnoldRendererPlugin__GI_volume_depth" 
+		-at "long";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__GI_total_depth" -ln "HdArnoldRendererPlugin__GI_total_depth" 
+		-dv 10 -at "long";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__abort_on_error" -ln "HdArnoldRendererPlugin__abort_on_error" 
+		-min 0 -max 1 -at "bool";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__ignore_textures" -ln "HdArnoldRendererPlugin__ignore_textures" 
+		-min 0 -max 1 -at "bool";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__ignore_shaders" -ln "HdArnoldRendererPlugin__ignore_shaders" 
+		-min 0 -max 1 -at "bool";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__ignore_atmosphere" -ln "HdArnoldRendererPlugin__ignore_atmosphere" 
+		-min 0 -max 1 -at "bool";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__ignore_lights" -ln "HdArnoldRendererPlugin__ignore_lights" 
+		-min 0 -max 1 -at "bool";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__ignore_shadows" -ln "HdArnoldRendererPlugin__ignore_shadows" 
+		-min 0 -max 1 -at "bool";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__ignore_subdivision" -ln "HdArnoldRendererPlugin__ignore_subdivision" 
+		-min 0 -max 1 -at "bool";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__ignore_displacement" -ln "HdArnoldRendererPlugin__ignore_displacement" 
+		-min 0 -max 1 -at "bool";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__ignore_bump" -ln "HdArnoldRendererPlugin__ignore_bump" 
+		-min 0 -max 1 -at "bool";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__ignore_motion" -ln "HdArnoldRendererPlugin__ignore_motion" 
+		-min 0 -max 1 -at "bool";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__ignore_motion_blur" -ln "HdArnoldRendererPlugin__ignore_motion_blur" 
+		-min 0 -max 1 -at "bool";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__ignore_dof" -ln "HdArnoldRendererPlugin__ignore_dof" 
+		-min 0 -max 1 -at "bool";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__ignore_smoothing" -ln "HdArnoldRendererPlugin__ignore_smoothing" 
+		-min 0 -max 1 -at "bool";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__ignore_sss" -ln "HdArnoldRendererPlugin__ignore_sss" 
+		-min 0 -max 1 -at "bool";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__ignore_operators" -ln "HdArnoldRendererPlugin__ignore_operators" 
+		-min 0 -max 1 -at "bool";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__report_mtohns_file" -ln "HdArnoldRendererPlugin__report_mtohns_file" 
+		-dt "string";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__log_mtohns_verbosity" -ln "HdArnoldRendererPlugin__log_mtohns_verbosity" 
+		-dv 2 -at "long";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__log_mtohns_file" -ln "HdArnoldRendererPlugin__log_mtohns_file" 
+		-dt "string";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__profile_mtohns_file" -ln "HdArnoldRendererPlugin__profile_mtohns_file" 
+		-dt "string";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__stats_mtohns_file" -ln "HdArnoldRendererPlugin__stats_mtohns_file" 
+		-dt "string";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__plugin_searchpath" -ln "HdArnoldRendererPlugin__plugin_searchpath" 
+		-dt "string";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__asset_searchpath" -ln "HdArnoldRendererPlugin__asset_searchpath" 
+		-dt "string";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__osl_includepath" -ln "HdArnoldRendererPlugin__osl_includepath" 
+		-dt "string";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__subdiv_dicing_camera" -ln "HdArnoldRendererPlugin__subdiv_dicing_camera" 
+		-dt "string";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__subdiv_frustum_culling" -ln "HdArnoldRendererPlugin__subdiv_frustum_culling" 
+		-min 0 -max 1 -at "bool";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__subdiv_frustum_padding" -ln "HdArnoldRendererPlugin__subdiv_frustum_padding" 
+		-at "float";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__shader_override" -ln "HdArnoldRendererPlugin__shader_override" 
+		-dt "string";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__background" -ln "HdArnoldRendererPlugin__background" 
+		-dt "string";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__atmosphere" -ln "HdArnoldRendererPlugin__atmosphere" 
+		-dt "string";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__aov_shaders" -ln "HdArnoldRendererPlugin__aov_shaders" 
+		-dt "string";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__imager" -ln "HdArnoldRendererPlugin__imager" 
+		-dt "string";
+	addAttr -ci true -sn "HdArnoldRendererPlugin__texture_auto_generate_tx" -ln "HdArnoldRendererPlugin__texture_auto_generate_tx" 
+		-dv 1 -min 0 -max 1 -at "bool";
+	addAttr -ci true -h true -sn "dss" -ln "defaultSurfaceShader" -dt "string";
+	setAttr ".mayaHydraProxyPurpose" no;
+	setAttr ".mayaHydraGuidePurpose" no;
+	setAttr ".dss" -type "string" "openPBR_shader1";
+select -ne :defaultResolution;
+	setAttr ".pa" 1;
+select -ne :defaultLightSet;
+select -ne :defaultColorMgtGlobals;
+	setAttr ".cfe" yes;
+	setAttr ".cfp" -type "string" "<MAYA_RESOURCES>/OCIO-configs/Maya2022-default/config.ocio";
+	setAttr ".vtn" -type "string" "ACES 1.0 SDR-video (sRGB)";
+	setAttr ".vn" -type "string" "ACES 1.0 SDR-video";
+	setAttr ".dn" -type "string" "sRGB";
+	setAttr ".wsn" -type "string" "ACEScg";
+	setAttr ".otn" -type "string" "ACES 1.0 SDR-video (sRGB)";
+	setAttr ".potn" -type "string" "ACES 1.0 SDR-video (sRGB)";
+select -ne :hardwareRenderGlobals;
+	setAttr ".ctrs" 256;
+	setAttr ".btrs" 512;
+select -ne :ikSystem;
+	setAttr -s 4 ".sol";
+connectAttr "pCube1_translateX.o" "pCube1.tx";
+connectAttr "pCube1_translateY.o" "pCube1.ty";
+connectAttr "pCube1_translateZ.o" "pCube1.tz";
+connectAttr "polyCube1.out" "pCubeShape1.i";
+connectAttr ":time1.o" "AnimCubeRenderSettings2Shape.tm";
+relationship "link" ":lightLinker1" ":initialShadingGroup.message" ":defaultLightSet.message";
+relationship "link" ":lightLinker1" ":initialParticleSE.message" ":defaultLightSet.message";
+relationship "shadowLink" ":lightLinker1" ":initialShadingGroup.message" ":defaultLightSet.message";
+relationship "shadowLink" ":lightLinker1" ":initialParticleSE.message" ":defaultLightSet.message";
+connectAttr "layerManager.dli[0]" "defaultLayer.id";
+connectAttr "renderLayerManager.rlmi[0]" "defaultRenderLayer.rlid";
+connectAttr "trackInfoManager1.msg" ":sequenceManager1.tim";
+connectAttr "defaultRenderLayer.msg" ":defaultRenderingList1.r" -na;
+connectAttr "directionalLightShape1.ltd" ":lightList1.l" -na;
+connectAttr "pCubeShape1.iog" ":initialShadingGroup.dsm" -na;
+connectAttr "directionalLight1.iog" ":defaultLightSet.dsm" -na;
+// End of usdProxyShapeRenderSettings.ma

--- a/test/lib/cmdLineRender/scenes/renderSettings/usdProxyShapeRenderSettings.usda
+++ b/test/lib/cmdLineRender/scenes/renderSettings/usdProxyShapeRenderSettings.usda
@@ -1,0 +1,52 @@
+#usda 1.0
+(
+    defaultPrim = "Render"
+    renderSettingsPrimPath = "/Render/MainRender"
+    startTimeCode = 1
+    endTimeCode = 10
+)
+
+def Scope "Cameras"
+{
+    def Camera "main_cam"
+    {
+        float2 clippingRange = (0.1, 10000)
+        float focalLength = 35
+        float focusDistance = 5
+        float horizontalAperture = 35.999928
+        float verticalAperture = 23.999952
+        float3 xformOp:rotateXYZ = (62.482925, 0, 43.994915)
+        double3 xformOp:translate = (3.8079010269722375, -3.943897492221248, 3.3559257702291783)
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateXYZ"]
+    }
+}
+
+def Scope "Render"
+{
+    def RenderSettings "MainRender"
+    {
+        rel camera = </Cameras/main_cam>
+        float pixelAspectRatio = 1
+        rel products = [
+            </Render/ProductMainCam>,
+        ]
+        int2 resolution = (512, 512)
+    }
+
+    def RenderProduct "ProductMainCam"
+    {
+        rel camera = </Cameras/main_cam>
+        rel orderedVars = [</Render/Vars/color>]
+        token productName = "../images/mainCamFrame1.png"
+        uniform token productType = "raster"
+        uniform int2 resolution = (512, 512)
+    }
+
+    def Scope "Vars"
+    {
+        def RenderVar "color"
+        {
+            string sourceName = "color"
+        }
+    }
+}


### PR DESCRIPTION
Path mapping used to be just for selection highlighting, to map an application (selection) path into a Hydra path.

It is now used to map an application render settings path into a Hydra render settings path, and therefore can no longer be reserved for interactive use.

Simply moved over all of the path mapping functionality from the derived interactive proxy shape scene index class to the base.  The only functionality left in the derived interactive proxy shape scene index class is for pick handling.
