### PR TITLE
HYDRA-2383 : Add unit test for HdArnold custom nodes

### DIFF
--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -336,6 +336,16 @@ function(_mayaHydra_setup_test_plugins)
         # like having a locally installed MtoA fixed it, but we can't rely on that.
         list(APPEND MAYAHYDRA_VARNAME_MAYA_MODULE_PATH
              "${MTOA_LOCATION}")
+        # Unit tests like testArnoldCustomNodes.cpp rely on mtoa's USD plugins such as 
+        # HdArnoldRendererPlugin and mtoaSIP to be registered so that maya-hydra can 
+        # find them during startup. Append the bundle path to PXR_PLUGINPATH_NAME.
+        if(DEFINED PXR_VERSION)
+            set(_MTOA_USD_BUNDLE "${MTOA_LOCATION}/usd/bundle/${PXR_VERSION}")
+            if(EXISTS "${_MTOA_USD_BUNDLE}")
+                list(APPEND MAYAHYDRA_VARNAME_${PXR_OVERRIDE_PLUGINPATH_NAME}
+                     "${_MTOA_USD_BUNDLE}")
+            endif()
+        endif()
     endif()
     
     # lookdevx

--- a/test/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
+++ b/test/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
@@ -108,6 +108,7 @@ set(INTERACTIVE_TEST_SCRIPT_FILES
     cpp/testLightPrimvars.py|depOnPlugins:mtoa
     cpp/testDataSourceNames.py
     cpp/testCustomDagNodeTranslation.py|depOnPlugins:mtoa
+    cpp/testArnoldCustomNodes.py|depOnPlugins:mtoa
     cpp/testCameraPrimvars.py
     cpp/testUsdStageInvalidate.py
     cpp/testCamera.py

--- a/test/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
+++ b/test/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
@@ -108,7 +108,6 @@ set(INTERACTIVE_TEST_SCRIPT_FILES
     cpp/testLightPrimvars.py|depOnPlugins:mtoa
     cpp/testDataSourceNames.py
     cpp/testCustomDagNodeTranslation.py|depOnPlugins:mtoa
-    cpp/testArnoldCustomNodes.py|depOnPlugins:mtoa
     cpp/testCameraPrimvars.py
     cpp/testUsdStageInvalidate.py
     cpp/testCamera.py
@@ -135,6 +134,13 @@ if (MAYA_HAS_VIEW_SELECTED_OBJECT_API)
         cpp/testUsdPointInstancingIsolateSelectBBox.py
         testIsolateSelectPerShape.py
         testIsolateSelectMultipleInstances.py|depOnPlugins:bifrost
+    )
+endif()
+
+# mtoa custom nodes/attributes not supported on Maya 2026
+if(MAYA_APP_VERSION VERSION_GREATER 2026)
+    list(APPEND INTERACTIVE_TEST_SCRIPT_FILES
+        cpp/testArnoldCustomNodes.py|depOnPlugins:mtoa
     )
 endif()
 

--- a/test/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
+++ b/test/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
@@ -137,7 +137,7 @@ if (MAYA_HAS_VIEW_SELECTED_OBJECT_API)
     )
 endif()
 
-# mtoa custom nodes/attributes not supported on Maya 2026
+# mtoa custom nodes/attributes not supported on Maya 2026 and earlier.
 if(MAYA_APP_VERSION VERSION_GREATER 2026)
     list(APPEND INTERACTIVE_TEST_SCRIPT_FILES
         cpp/testArnoldCustomNodes.py|depOnPlugins:mtoa

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/CMakeLists.txt
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/CMakeLists.txt
@@ -37,6 +37,7 @@ target_sources(${TARGET_NAME}
         testLightPrimvars.cpp
         testDataSourceNames.cpp
         testCustomDagNodeTranslation.cpp
+        testArnoldCustomNodes.cpp
         testCameraPrimvars.cpp
         testMeshPrimvars.cpp
         testMeshGeomSubsets.cpp

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testArnoldCustomNodes.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testArnoldCustomNodes.cpp
@@ -1,0 +1,204 @@
+// Copyright 2026 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// C++ GTest suite for the HdArnoldMtoaSceneIndexPlugin (mtoaSIP).
+//
+// Tests must run with the Arnold renderer active so that mtoaSIP is inserted
+// into the scene index chain.  The Python driver (testArnoldCustomNodes.py) sets the
+// Arnold renderer and creates the required scene nodes.
+//
+// Custom node translation:
+//    aiPhotometricLight -> sphereLight   (verifyPrimType, attrs)
+//    aiStandIn          -> ArnoldProcedural  (verifyPrimType, dso -> arnold:filename)
+//    aiVolume           -> ArnoldVolume      (verifyPrimType, filename -> arnold:filename)
+//
+// NOTE: aiSkyDomeLight and aiAreaLight are NOT tested via the mayaCustomDagNode
+// path because they have existing maya-hydra adapters (aiSkydomeLightAdapter /
+// aiAreaLightAdapter) that produce domeLight / rectLight prims directly, so
+// mtoaSIP's custom node dispatch never sees them.
+//
+
+#include "testUtils.h"
+
+#include <mayaHydraLib/adapters/tokens.h>
+
+#include <pxr/base/gf/vec3f.h>
+#include <pxr/base/tf/token.h>
+#include <pxr/base/vt/value.h>
+#include <pxr/imaging/hd/dataSource.h>
+#include <pxr/imaging/hd/primvarsSchema.h>
+#include <pxr/imaging/hd/tokens.h>
+#include <pxr/usd/sdf/assetPath.h>
+#include <pxr/usd/usdLux/tokens.h>
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+using namespace MayaHydra;
+
+namespace {
+
+// Convenience: read a float from a sampled data source, accepting both float
+// and double storage (MtoA stores many attrs as double).
+float GetFloatValue(const HdSampledDataSourceHandle& ds, float fallback = 0.0f)
+{
+    if (!ds)
+        return fallback;
+    const VtValue v = ds->GetValue(0.0f);
+    if (v.IsHolding<float>())
+        return v.UncheckedGet<float>();
+    if (v.IsHolding<double>())
+        return static_cast<float>(v.UncheckedGet<double>());
+    return fallback;
+}
+
+} // namespace
+
+// What: mtoaSIP re-types aiPhotometricLight to sphereLight and maps attributes.
+// How:  Python creates aiPhotometricLight (intensity=2.5, aiExposure=3.0,
+//       aiFilename="/path/to/test.ies", aiSamples=5) with Arnold renderer active.
+// Expect: prim type = sphereLight; inputs:intensity, inputs:exposure,
+//         inputs:shaping:ies:file are set; arnold:samples primvar exists (catch-all).
+TEST(MtoaSIP, photometricLightTranslation)
+{
+    auto [argc, argv] = getTestingArgs();
+    ASSERT_GE(argc, 1);
+    const std::string shapeFull(argv[0]);
+    const std::string shapeNamePart = GetShapeNameFromFullPath(shapeFull);
+
+    const SceneIndicesVector& sceneIndices = GetTerminalSceneIndices();
+    ASSERT_GT(sceneIndices.size(), 0u);
+
+    HdSceneIndexBaseRefPtr si = FindTerminalSceneIndexWithPrim(
+        sceneIndices, shapeNamePart, HdPrimTypeTokens->sphereLight);
+    ASSERT_TRUE(si) << "sphereLight prim for '" << shapeNamePart
+                    << "' not found in any scene index";
+
+    SceneIndexInspector inspector(si);
+    PrimEntriesVector   found
+        = inspector.FindPrims(CreatePrimPredicate(shapeNamePart, HdPrimTypeTokens->sphereLight), 1);
+    ASSERT_GE(found.size(), 1u);
+
+    const HdSceneIndexPrim& prim = found.front().prim;
+    ASSERT_EQ(prim.primType, HdPrimTypeTokens->sphereLight);
+    ASSERT_NE(prim.dataSource, nullptr);
+
+    // Check inputs:intensity = 2.5
+    auto intensityDs = HdTypedSampledDataSource<float>::Cast(
+        prim.dataSource->Get(UsdLuxTokens->inputsIntensity));
+    ASSERT_TRUE(intensityDs) << "inputs:intensity not found on sphereLight";
+    EXPECT_NEAR(GetFloatValue(intensityDs), 2.5f, 1e-5f);
+
+    // aiExposure = 3.0 -> inputs:exposure
+    auto exposureDs
+        = HdTypedSampledDataSource<float>::Cast(prim.dataSource->Get(UsdLuxTokens->inputsExposure));
+    ASSERT_TRUE(exposureDs) << "inputs:exposure not found on sphereLight";
+    EXPECT_NEAR(GetFloatValue(exposureDs), 3.0f, 1e-5f);
+
+    // aiFilename -> inputs:shaping:ies:file
+    auto iesDs = HdTypedSampledDataSource<SdfAssetPath>::Cast(
+        prim.dataSource->Get(UsdLuxTokens->inputsShapingIesFile));
+    ASSERT_TRUE(iesDs) << "inputs:shaping:ies:file not found on sphereLight";
+    EXPECT_EQ(iesDs->GetTypedValue(0.0f).GetAssetPath(), "/path/to/test.ies");
+
+    // aiSamples = 5 -> arnold:samples primvar (catch-all ai* pass-through).
+    HdPrimvarsSchema primvarsSchema = HdPrimvarsSchema::GetFromParent(prim.dataSource);
+    HdPrimvarSchema  samplesSchema = primvarsSchema.GetPrimvar(TfToken("arnold:samples"));
+    EXPECT_TRUE(samplesSchema)
+        << "arnold:samples primvar not found; aiSamples not forwarded by mtoaSIP";
+}
+
+// What: mtoaSIP re-types aiStandIn to ArnoldProcedural and maps dso -> arnold:filename.
+// How:  Python creates aiStandIn (dso="/path/to/test.ass") with Arnold renderer.
+// Expect: prim type = ArnoldProcedural; arnold:filename = "/path/to/test.ass".
+TEST(MtoaSIP, standInTranslation)
+{
+    auto [argc, argv] = getTestingArgs();
+    ASSERT_GE(argc, 1);
+    const std::string shapeFull(argv[0]);
+    const std::string shapeNamePart = GetShapeNameFromFullPath(shapeFull);
+
+    const SceneIndicesVector& sceneIndices = GetTerminalSceneIndices();
+    ASSERT_GT(sceneIndices.size(), 0u);
+
+    static const TfToken kArnoldProcedural("ArnoldProcedural");
+    static const TfToken kArnoldFilename("arnold:filename");
+
+    HdSceneIndexBaseRefPtr si
+        = FindTerminalSceneIndexWithPrim(sceneIndices, shapeNamePart, kArnoldProcedural);
+    ASSERT_TRUE(si) << "ArnoldProcedural prim for '" << shapeNamePart
+                    << "' not found in any scene index";
+
+    SceneIndexInspector inspector(si);
+    PrimEntriesVector   found
+        = inspector.FindPrims(CreatePrimPredicate(shapeNamePart, kArnoldProcedural), 1);
+    ASSERT_GE(found.size(), 1u);
+
+    const HdSceneIndexPrim& prim = found.front().prim;
+    ASSERT_EQ(prim.primType, kArnoldProcedural);
+    ASSERT_NE(prim.dataSource, nullptr);
+
+    // dso -> arnold:filename
+    auto filenameDs
+        = HdTypedSampledDataSource<std::string>::Cast(prim.dataSource->Get(kArnoldFilename));
+    ASSERT_TRUE(filenameDs) << "arnold:filename not found on ArnoldProcedural";
+    EXPECT_EQ(filenameDs->GetTypedValue(0.0f), "/path/to/test.ass");
+}
+
+// What: mtoaSIP re-types aiVolume to ArnoldVolume and maps filename -> arnold:filename.
+// How:  Python creates aiVolume (filename="/path/to/test.vdb") with Arnold renderer.
+// Expect: prim type = ArnoldVolume; arnold:filename = "/path/to/test.vdb".
+TEST(MtoaSIP, volumeTranslation)
+{
+    auto [argc, argv] = getTestingArgs();
+    ASSERT_GE(argc, 1);
+    const std::string shapeFull(argv[0]);
+    const std::string shapeNamePart = GetShapeNameFromFullPath(shapeFull);
+
+    const SceneIndicesVector& sceneIndices = GetTerminalSceneIndices();
+    ASSERT_GT(sceneIndices.size(), 0u);
+
+    static const TfToken kArnoldVolume("ArnoldVolume");
+    static const TfToken kArnoldFilename("arnold:filename");
+
+    HdSceneIndexBaseRefPtr si
+        = FindTerminalSceneIndexWithPrim(sceneIndices, shapeNamePart, kArnoldVolume);
+    ASSERT_TRUE(si) << "ArnoldVolume prim for '" << shapeNamePart
+                    << "' not found in any scene index";
+
+    SceneIndexInspector inspector(si);
+    PrimEntriesVector   found
+        = inspector.FindPrims(CreatePrimPredicate(shapeNamePart, kArnoldVolume), 1);
+    ASSERT_GE(found.size(), 1u);
+
+    const HdSceneIndexPrim& prim = found.front().prim;
+    ASSERT_EQ(prim.primType, kArnoldVolume);
+    ASSERT_NE(prim.dataSource, nullptr);
+
+    // filename (aiVolume Maya attr) -> arnold:filename
+    // _TranslateVolume prefixes ALL mayaAttributes keys with "arnold:".
+    // The value is stored via _VtValueDataSource, so use the base HdSampledDataSource.
+    auto filenameBase = prim.dataSource->Get(kArnoldFilename);
+    ASSERT_TRUE(filenameBase) << "arnold:filename not found on ArnoldVolume — "
+                                 "all-attrs-as-arnold:* pattern not applied by mtoaSIP";
+
+    // The value is stored via _VtValueDataSource, so use the base HdSampledDataSource.
+    auto filenameDs = HdSampledDataSource::Cast(filenameBase);
+    ASSERT_TRUE(filenameDs) << "arnold:filename is not a sampled data source";
+    const VtValue filenameVal = filenameDs->GetValue(0.0f);
+    ASSERT_TRUE(filenameVal.IsHolding<std::string>()) << "arnold:filename value is not a string";
+    EXPECT_EQ(filenameVal.UncheckedGet<std::string>(), "/path/to/test.vdb");
+}

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testArnoldCustomNodes.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testArnoldCustomNodes.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// C++ GTest suite for the HdArnoldMtoaSceneIndexPlugin (mtoaSIP).
+// C++ GTest suite for mtoaSIP (Hydra Arnold Scene Index Plugin).
 //
 // Tests must run with the Arnold renderer active so that mtoaSIP is inserted
 // into the scene index chain.  The Python driver (testArnoldCustomNodes.py) sets the
@@ -97,14 +97,13 @@ TEST(MtoaSIP, photometricLightTranslation)
     ASSERT_NE(prim.dataSource, nullptr);
 
     // Check inputs:intensity = 2.5
-    auto intensityDs = HdTypedSampledDataSource<float>::Cast(
-        prim.dataSource->Get(UsdLuxTokens->inputsIntensity));
+    auto intensityDs
+        = HdSampledDataSource::Cast(prim.dataSource->Get(UsdLuxTokens->inputsIntensity));
     ASSERT_TRUE(intensityDs) << "inputs:intensity not found on sphereLight";
     EXPECT_NEAR(GetFloatValue(intensityDs), 2.5f, 1e-5f);
 
     // aiExposure = 3.0 -> inputs:exposure
-    auto exposureDs
-        = HdTypedSampledDataSource<float>::Cast(prim.dataSource->Get(UsdLuxTokens->inputsExposure));
+    auto exposureDs = HdSampledDataSource::Cast(prim.dataSource->Get(UsdLuxTokens->inputsExposure));
     ASSERT_TRUE(exposureDs) << "inputs:exposure not found on sphereLight";
     EXPECT_NEAR(GetFloatValue(exposureDs), 3.0f, 1e-5f);
 

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testArnoldCustomNodes.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testArnoldCustomNodes.py
@@ -38,9 +38,9 @@ class TestArnoldCustomNodes(mtohUtils.MayaHydraBaseTestCase):
     _requiredPlugins = ['mtoa']
     _setHdStormRenderer = False     # Need to use Arnold renderer for the tests
 
-    def tearDown(self):
-        """Test will hang if Arnold renderer is not reset before Maya exits."""
-        self.setViewport2Renderer()
+    # def tearDown(self):
+    #     """Test will hang if Arnold renderer is not reset before Maya exits."""
+    #     self.setViewport2Renderer()
 
     def _setArnoldRenderer(self):
         """Activate the Arnold Hydra renderer so mtoaSIP is in the scene index chain."""

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testArnoldCustomNodes.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testArnoldCustomNodes.py
@@ -1,0 +1,128 @@
+# Copyright 2026 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Python test for the custom node translation functionality of the
+# HdArnoldMtoaSceneIndexPlugin (mtoaSIP).
+#
+# Custom node translation: mayaCustomDagNode prims emitted by maya-hydra for
+#    Arnold plugin nodes are re-typed and have their attributes mapped to
+#    renderer-specific Hydra schemas.
+#    Tested: aiPhotometricLight -> sphereLight
+#            aiStandIn          -> ArnoldProcedural
+#            aiVolume           -> ArnoldVolume
+#    NOT tested here (have existing maya-hydra adapters that bypass mayaCustomDagNode):
+#            aiSkyDomeLight, aiAreaLight
+#
+import maya.cmds as cmds
+import fixturesUtils
+import mtohUtils
+from testUtils import PluginLoaded
+
+HD_ARNOLD = "HdArnoldRendererPlugin"
+HD_ARNOLD_OVERRIDE = "mayaHydraRenderOverride_" + HD_ARNOLD
+
+
+class TestArnoldCustomNodes(mtohUtils.MayaHydraBaseTestCase):
+    _file = __file__
+    _requiredPlugins = ['mtoa']
+    _setHdStormRenderer = False     # Need to use Arnold renderer for the tests
+
+    def tearDown(self):
+        """Test will hang if Arnold renderer is not reset before Maya exits."""
+        self.setViewport2Renderer()
+
+    def _setArnoldRenderer(self):
+        """Activate the Arnold Hydra renderer so mtoaSIP is in the scene index chain."""
+        self.activeEditor = cmds.playblast(activeEditor=1)
+        cmds.modelEditor(
+            self.activeEditor, e=1,
+            rendererOverrideName=HD_ARNOLD_OVERRIDE)
+        cmds.refresh(f=1)
+        activeOverride = cmds.modelEditor(
+            self.activeEditor, q=1, rendererOverrideName=True)
+        self.assertEqual(
+            activeOverride,
+            HD_ARNOLD_OVERRIDE,
+            "Arnold Hydra renderer override not available. "
+            "Ensure HdArnoldRendererPlugin is on PXR_PLUGINPATH_NAME.")
+
+    def _setupPhotometricLight(self):
+        with PluginLoaded('mtoa'):
+            xform = cmds.createNode('transform', name='photometric1')
+            shape = cmds.createNode(
+                'aiPhotometricLight',
+                name='photometricShape1',
+                parent=xform,
+            )
+            self._photometricShape = cmds.ls(shape, long=True)[0]
+            cmds.setAttr(self._photometricShape + ".intensity", 2.5)
+            cmds.setAttr(self._photometricShape + ".aiExposure", 3.0)
+            cmds.setAttr(self._photometricShape + ".aiFilename",
+                         "/path/to/test.ies", type="string")
+            cmds.setAttr(self._photometricShape + ".aiSamples", 5)
+        cmds.refresh()
+
+    def _setupStandIn(self):
+        with PluginLoaded('mtoa'):
+            xform = cmds.createNode('transform', name='standIn1')
+            shape = cmds.createNode(
+                'aiStandIn',
+                name='standInShape1',
+                parent=xform,
+            )
+            self._standInShape = cmds.ls(shape, long=True)[0]
+            cmds.setAttr(self._standInShape + ".dso",
+                         "/path/to/test.ass", type="string")
+        cmds.refresh()
+
+    def _setupVolume(self):
+        with PluginLoaded('mtoa'):
+            xform = cmds.createNode('transform', name='volume1')
+            shape = cmds.createNode(
+                'aiVolume',
+                name='volumeShape1',
+                parent=xform,
+            )
+            self._volumeShape = cmds.ls(shape, long=True)[0]
+            cmds.setAttr(self._volumeShape + ".filename",
+                         "/path/to/test.vdb", type="string")
+        cmds.refresh()
+
+    def test_photometricLightTranslation(self):
+        self._setArnoldRenderer()
+        self._setupPhotometricLight()
+        with PluginLoaded('mayaHydraCppTests'):
+            cmds.mayaHydraCppTest(
+                self._photometricShape,
+                f="MtoaSIP.photometricLightTranslation")
+
+    def test_standInTranslation(self):
+        self._setArnoldRenderer()
+        self._setupStandIn()
+        with PluginLoaded('mayaHydraCppTests'):
+            cmds.mayaHydraCppTest(
+                self._standInShape,
+                f="MtoaSIP.standInTranslation")
+
+    def test_volumeTranslation(self):
+        self._setArnoldRenderer()
+        self._setupVolume()
+        with PluginLoaded('mayaHydraCppTests'):
+            cmds.mayaHydraCppTest(
+                self._volumeShape,
+                f="MtoaSIP.volumeTranslation")
+
+
+if __name__ == '__main__':
+    fixturesUtils.runTests(globals())

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testArnoldCustomNodes.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testArnoldCustomNodes.py
@@ -84,6 +84,9 @@ class TestArnoldCustomNodes(mtohUtils.MayaHydraBaseTestCase):
             self._standInShape = cmds.ls(shape, long=True)[0]
             cmds.setAttr(self._standInShape + ".dso",
                          "/path/to/test.ass", type="string")
+            # Prevent MtoA from loading the non-existent .ass file while
+            # HdArnold is active; the C++ test only verifies scene-index translation.
+            cmds.setAttr(self._standInShape + ".standInDrawOverride", 4)
         cmds.refresh()
 
     def _setupVolume(self):


### PR DESCRIPTION
Added unit test for HdArnold custom nodes implementation from https://github.com/Autodesk/arnold-usd/pull/2653/changes.

aiSkyDomeLight and aiAreaLight are not tested because they have existing maya-hydra adapters (aiSkydomeLightAdapter / aiAreaLightAdapter) that produce domeLight / rectLight prims directly, so they don't go through the mayaCustomDagNode / mtoaSIP paths.