### PR TITLE
harden the download macro and report error at configure stage

### DIFF
--- a/lib/adskHydraSceneBrowser/lib/CMakeLists.txt
+++ b/lib/adskHydraSceneBrowser/lib/CMakeLists.txt
@@ -78,8 +78,8 @@ macro(download file)
             "  Error : ${_download_code} - ${_download_message}")
     endif()
 
-    # A zero status only means the transfer completed; guard against an empty or
-    # truncated body (e.g. a proxy/CDN returning a 0-byte 200) as well.
+    # A zero status only means the transfer completed; guard against an empty body
+    # (e.g. a proxy/CDN returning a 0-byte 200) as well.
     file(SIZE "${_download_dest}" _download_size)
     if(_download_size EQUAL 0)
         file(REMOVE "${_download_dest}")

--- a/lib/adskHydraSceneBrowser/lib/CMakeLists.txt
+++ b/lib/adskHydraSceneBrowser/lib/CMakeLists.txt
@@ -52,10 +52,41 @@ string(REGEX REPLACE "(\\.|^)([1-9])(\\.|$)" "\\10\\2\\3" USD_minor_patch_versio
 set(DOWNLOAD_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/src/download")
 set(PATCH_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/src/patch")
 
+# Download a single hdui source/header file from OpenUSD, failing the configure
+# stage loudly if the transfer does not succeed. The upstream file(DOWNLOAD) call
+# used to run without any error handling, so a transient network failure or a
+# truncated response silently produced an empty file. That empty translation unit
+# then compiled cleanly but dropped every symbol it should have defined, surfacing
+# much later as a confusing link error (undefined vtable/symbols) instead of a
+# clear configure-time failure.
 macro(download file)
-    file(DOWNLOAD 
-    "https://raw.githubusercontent.com/PixarAnimationStudios/OpenUSD/v${USD_minor_patch_version}/extras/imaging/examples/hdui/${file}" 
-    "${DOWNLOAD_LOCATION}/${file}")
+    set(_download_url "https://raw.githubusercontent.com/PixarAnimationStudios/OpenUSD/v${USD_minor_patch_version}/extras/imaging/examples/hdui/${file}")
+    set(_download_dest "${DOWNLOAD_LOCATION}/${file}")
+    file(DOWNLOAD
+        "${_download_url}"
+        "${_download_dest}"
+        STATUS _download_status
+        TLS_VERIFY ON)
+
+    list(GET _download_status 0 _download_code)
+    list(GET _download_status 1 _download_message)
+    if(NOT _download_code EQUAL 0)
+        file(REMOVE "${_download_dest}")
+        message(FATAL_ERROR
+            "Failed to download '${file}' for ${TARGET_NAME}.\n"
+            "  URL   : ${_download_url}\n"
+            "  Error : ${_download_code} - ${_download_message}")
+    endif()
+
+    # A zero status only means the transfer completed; guard against an empty or
+    # truncated body (e.g. a proxy/CDN returning a 0-byte 200) as well.
+    file(SIZE "${_download_dest}" _download_size)
+    if(_download_size EQUAL 0)
+        file(REMOVE "${_download_dest}")
+        message(FATAL_ERROR
+            "Downloaded '${file}' for ${TARGET_NAME} is empty.\n"
+            "  URL : ${_download_url}")
+    endif()
 endmacro()
 
 # Insert an include directive at the top a file.


### PR DESCRIPTION
Key changes:

STATUS capture + FATAL_ERROR — any non-zero libcurl result (network failure, DNS, 4xx/5xx, TLS) now stops configure immediately with the URL and error message, instead of writing a bad file and marching on.
TLS_VERIFY ON — enforces certificate validation on the HTTPS fetch.
Empty-file guard — a STATUS 0 only means the transfer finished; a 0-byte body (the exact failure mode you hit) is now caught explicitly via file(SIZE ...).
file(REMOVE ...) on failure — deletes the partial/empty artifact so a stale cached copy can't survive into the next configure and mask the problem.

Notes:

I only hardened download; the header/source patch-and-write logic is unchanged, so behavior on success is identical.
file(SIZE) requires CMake ≥ 3.14, which this repo already exceeds, so no floor bump needed.
This turns your intermittent link failure into a clear, actionable configure-stage error like Failed to download 'sceneIndexTreeWidget.cpp' for adskHydraSceneBrowser.