### PR TITLE
HYDRA-2347 : Add Arnold custom attributes on Maya node unit test

### DIFF
--- a/test/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
+++ b/test/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
@@ -141,6 +141,7 @@ endif()
 if(MAYA_APP_VERSION VERSION_GREATER 2026)
     list(APPEND INTERACTIVE_TEST_SCRIPT_FILES
         cpp/testArnoldCustomNodes.py|depOnPlugins:mtoa
+        cpp/testArnoldCustomAttributesMayaNodes.py|depOnPlugins:mtoa
     )
 endif()
 

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/CMakeLists.txt
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/CMakeLists.txt
@@ -38,6 +38,7 @@ target_sources(${TARGET_NAME}
         testDataSourceNames.cpp
         testCustomDagNodeTranslation.cpp
         testArnoldCustomNodes.cpp
+        testArnoldCustomAttributesMayaNodes.cpp
         testCameraPrimvars.cpp
         testMeshPrimvars.cpp
         testMeshGeomSubsets.cpp

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testArnoldCustomAttributesMayaNodes.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testArnoldCustomAttributesMayaNodes.cpp
@@ -1,0 +1,273 @@
+// Copyright 2026 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// C++ GTest suite for Arnold custom attribute translation on native Maya nodes.
+//
+// Tests must run with the Arnold renderer active so that mtoaSIP is inserted
+// into the scene index chain.  The Python driver (testArnoldCustomAttributesMayaNodes.py) sets the
+// Arnold renderer and creates the required scene nodes.
+//
+// Mesh/Camera ai* attrs -> arnold:* primvars (mtoaSIP _RemapMtoaAiName).
+// Light param attrs (aiExposure, aiColorTemperature) -> HdLight schema (light.exposure,
+// light.colorTemperature) via MayaHydraLightAdapter.
+// Light non-param ai* attrs (aiAngle, aiResolution, aiSpread, aiRoundness) ->
+// arnold:* primvars.
+//
+
+#include "testUtils.h"
+
+#include <mayaHydraLib/mayaUtils.h>
+
+#include <pxr/base/tf/token.h>
+#include <pxr/base/vt/value.h>
+#include <pxr/imaging/hd/dataSource.h>
+#include <pxr/imaging/hd/light.h>
+#include <pxr/imaging/hd/lightSchema.h>
+#include <pxr/imaging/hd/primvarsSchema.h>
+#include <pxr/imaging/hd/tokens.h>
+
+#include <maya/MFnDependencyNode.h>
+#include <maya/MPlug.h>
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+using namespace MayaHydra;
+
+namespace {
+
+// Convenience: read a float from a sampled data source, accepting both float
+// and double storage (MtoA stores many attrs as double).
+float GetFloatValue(const HdSampledDataSourceHandle& ds, float fallback = 0.0f)
+{
+    if (!ds)
+        return fallback;
+    const VtValue v = ds->GetValue(0.0f);
+    if (v.IsHolding<float>())
+        return v.UncheckedGet<float>();
+    if (v.IsHolding<double>())
+        return static_cast<float>(v.UncheckedGet<double>());
+    return fallback;
+}
+
+} // namespace
+
+// What: mtoaSIP remaps mesh ai* attrs to arnold:* primvars.
+// How:  Python creates mesh with non-default aiSubdivType, aiDispHeight, aiOpaque,
+//       aiMatte, aiSelfShadows.
+// Expect: arnold:subdiv_type, disp_height, opaque, matte, self_shadows primvars match.
+TEST(ArnoldCustomAttributesMayaNodes, meshArnoldPrimvars)
+{
+    auto [argc, argv] = getTestingArgs();
+    ASSERT_GE(argc, 1);
+    const std::string shapeFull(argv[0]);
+    const std::string shapeNamePart = GetShapeNameFromFullPath(shapeFull);
+
+    const SceneIndicesVector& sceneIndices = GetTerminalSceneIndices();
+    ASSERT_GT(sceneIndices.size(), 0u);
+
+    HdSceneIndexBaseRefPtr si
+        = FindTerminalSceneIndexWithPrim(sceneIndices, shapeNamePart, HdPrimTypeTokens->mesh);
+    ASSERT_TRUE(si) << "mesh prim for '" << shapeNamePart << "' not found in any scene index";
+
+    SceneIndexInspector inspector(si);
+    PrimEntriesVector   found
+        = inspector.FindPrims(CreatePrimPredicate(shapeNamePart, HdPrimTypeTokens->mesh), 1);
+    ASSERT_GE(found.size(), 1u);
+
+    const HdSceneIndexPrim& prim = found.front().prim;
+    ASSERT_NE(prim.dataSource, nullptr);
+
+    HdPrimvarsSchema primvarsSchema = HdPrimvarsSchema::GetFromParent(prim.dataSource);
+
+    EXPECT_EQ(
+        primvarsSchema.GetPrimvar(TfToken("arnold:subdiv_type"))
+            .GetPrimvarValue()
+            ->GetValue(0.0f)
+            .UncheckedGet<int>(),
+        1)
+        << "aiSubdivType should map to arnold:subdiv_type";
+    EXPECT_NEAR(
+        GetFloatValue(primvarsSchema.GetPrimvar(TfToken("arnold:disp_height")).GetPrimvarValue()),
+        0.25f,
+        1e-5f)
+        << "aiDispHeight should map to arnold:disp_height";
+    EXPECT_FALSE(primvarsSchema.GetPrimvar(TfToken("arnold:opaque"))
+                     .GetPrimvarValue()
+                     ->GetValue(0.0f)
+                     .UncheckedGet<bool>())
+        << "aiOpaque=0 should map to arnold:opaque";
+    EXPECT_TRUE(primvarsSchema.GetPrimvar(TfToken("arnold:matte"))
+                    .GetPrimvarValue()
+                    ->GetValue(0.0f)
+                    .UncheckedGet<bool>())
+        << "aiMatte=1 should map to arnold:matte";
+    EXPECT_FALSE(primvarsSchema.GetPrimvar(TfToken("arnold:self_shadows"))
+                     .GetPrimvarValue()
+                     ->GetValue(0.0f)
+                     .UncheckedGet<bool>())
+        << "aiSelfShadows=0 should map to arnold:self_shadows";
+}
+
+// What: mtoaSIP remaps camera ai* attrs to arnold:* primvars.
+// How:  Python creates camera with aiExposure=1.0, aiFocusDistance=12.5.
+// Expect: arnold:exposure and arnold:focus_distance primvars match.
+TEST(ArnoldCustomAttributesMayaNodes, cameraArnoldPrimvars)
+{
+    auto [argc, argv] = getTestingArgs();
+    ASSERT_GE(argc, 1);
+    const std::string shapeFull(argv[0]);
+    const std::string shapeNamePart = GetShapeNameFromFullPath(shapeFull);
+
+    const SceneIndicesVector& sceneIndices = GetTerminalSceneIndices();
+    ASSERT_GT(sceneIndices.size(), 0u);
+
+    HdSceneIndexBaseRefPtr si
+        = FindTerminalSceneIndexWithPrim(sceneIndices, shapeNamePart, HdPrimTypeTokens->camera);
+    ASSERT_TRUE(si) << "camera prim for '" << shapeNamePart << "' not found in any scene index";
+
+    SceneIndexInspector inspector(si);
+    PrimEntriesVector   found
+        = inspector.FindPrims(CreatePrimPredicate(shapeNamePart, HdPrimTypeTokens->camera), 1);
+    ASSERT_GE(found.size(), 1u);
+
+    const HdSceneIndexPrim& prim = found.front().prim;
+    ASSERT_NE(prim.dataSource, nullptr);
+
+    HdPrimvarsSchema primvarsSchema = HdPrimvarsSchema::GetFromParent(prim.dataSource);
+
+    EXPECT_NEAR(
+        GetFloatValue(primvarsSchema.GetPrimvar(TfToken("arnold:exposure")).GetPrimvarValue()),
+        1.0f,
+        1e-5f)
+        << "aiExposure should map to arnold:exposure";
+    EXPECT_NEAR(
+        GetFloatValue(
+            primvarsSchema.GetPrimvar(TfToken("arnold:focus_distance")).GetPrimvarValue()),
+        12.5f,
+        1e-5f)
+        << "aiFocusDistance should map to arnold:focus_distance";
+}
+
+// What: directionalLight ai* attrs map to light schema inputs and arnold:* primvars.
+// How:  Python creates directionalLight with aiAngle=2.5, aiExposure=1.5,
+//       aiCastVolumetricShadows=0, aiColorTemperature=3200 (temperature enabled).
+// Expect: arnold:angle and arnold:cast_volumetric_shadows primvars;
+//         light.exposure and light.colorTemperature on distantLight.
+TEST(ArnoldCustomAttributesMayaNodes, directionalLightAttributes)
+{
+    auto [argc, argv] = getTestingArgs();
+    ASSERT_GE(argc, 1);
+    const std::string shapeFull(argv[0]);
+    const std::string shapeNamePart = GetShapeNameFromFullPath(shapeFull);
+
+    const SceneIndicesVector& sceneIndices = GetTerminalSceneIndices();
+    ASSERT_GT(sceneIndices.size(), 0u);
+
+    HdSceneIndexBaseRefPtr si = FindTerminalSceneIndexWithPrim(
+        sceneIndices, shapeNamePart, HdPrimTypeTokens->distantLight);
+    ASSERT_TRUE(si) << "distantLight prim for '" << shapeNamePart
+                    << "' not found in any scene index";
+
+    SceneIndexInspector inspector(si);
+    PrimEntriesVector   found = inspector.FindPrims(
+        CreatePrimPredicate(shapeNamePart, HdPrimTypeTokens->distantLight), 1);
+    ASSERT_GE(found.size(), 1u);
+
+    const HdSceneIndexPrim& prim = found.front().prim;
+    ASSERT_NE(prim.dataSource, nullptr);
+    ASSERT_EQ(prim.primType, HdPrimTypeTokens->distantLight);
+
+    HdPrimvarsSchema primvarsSchema = HdPrimvarsSchema::GetFromParent(prim.dataSource);
+
+    EXPECT_NEAR(
+        GetFloatValue(primvarsSchema.GetPrimvar(TfToken("arnold:angle")).GetPrimvarValue()),
+        2.5f,
+        1e-5f)
+        << "aiAngle should map to arnold:angle";
+
+    MObject lightNode;
+    ASSERT_TRUE(GetDependNodeFromNodeName(shapeNamePart.c_str(), lightNode));
+    MFnDependencyNode lightDepNode(lightNode);
+    const MPlug       castVolShadowsPlug = lightDepNode.findPlug("aiCastVolumetricShadows", true);
+    ASSERT_FALSE(castVolShadowsPlug.isNull());
+    const bool expectedCastVolShadows = castVolShadowsPlug.asBool();
+    EXPECT_EQ(
+        primvarsSchema.GetPrimvar(TfToken("arnold:cast_volumetric_shadows"))
+            .GetPrimvarValue()
+            ->GetValue(0.0f)
+            .UncheckedGet<bool>(),
+        expectedCastVolShadows)
+        << "aiCastVolumetricShadows should map to arnold:cast_volumetric_shadows";
+
+    HdLightSchema lightSchema = HdLightSchema::GetFromParent(prim.dataSource);
+    ASSERT_TRUE(lightSchema);
+    auto container = lightSchema.GetContainer();
+    ASSERT_TRUE(container);
+    auto exposureDs = HdSampledDataSource::Cast(container->Get(HdLightTokens->exposure));
+    EXPECT_NEAR(GetFloatValue(exposureDs), 1.5f, 1e-5f)
+        << "aiExposure should map to light.exposure";
+    auto colorTempDs = HdSampledDataSource::Cast(container->Get(HdLightTokens->colorTemperature));
+    EXPECT_NEAR(GetFloatValue(colorTempDs), 3200.0f, 1e-3f)
+        << "aiColorTemperature should map to light.colorTemperature";
+}
+
+// What: mtoaSIP remaps areaLight ai* attrs to arnold:* primvars.
+// How:  Python creates areaLight with aiResolution=256, aiSpread=0.5, aiRoundness=0.25.
+// Expect: arnold:resolution, arnold:spread, arnold:roundness primvars match.
+TEST(ArnoldCustomAttributesMayaNodes, areaLightArnoldPrimvars)
+{
+    auto [argc, argv] = getTestingArgs();
+    ASSERT_GE(argc, 1);
+    const std::string shapeFull(argv[0]);
+    const std::string shapeNamePart = GetShapeNameFromFullPath(shapeFull);
+
+    const SceneIndicesVector& sceneIndices = GetTerminalSceneIndices();
+    ASSERT_GT(sceneIndices.size(), 0u);
+
+    HdSceneIndexBaseRefPtr si
+        = FindTerminalSceneIndexWithPrim(sceneIndices, shapeNamePart, HdPrimTypeTokens->rectLight);
+    ASSERT_TRUE(si) << "rectLight prim for '" << shapeNamePart << "' not found in any scene index";
+
+    SceneIndexInspector inspector(si);
+    PrimEntriesVector   found
+        = inspector.FindPrims(CreatePrimPredicate(shapeNamePart, HdPrimTypeTokens->rectLight), 1);
+    ASSERT_GE(found.size(), 1u);
+
+    const HdSceneIndexPrim& prim = found.front().prim;
+    ASSERT_NE(prim.dataSource, nullptr);
+    ASSERT_EQ(prim.primType, HdPrimTypeTokens->rectLight);
+
+    HdPrimvarsSchema primvarsSchema = HdPrimvarsSchema::GetFromParent(prim.dataSource);
+
+    EXPECT_EQ(
+        primvarsSchema.GetPrimvar(TfToken("arnold:resolution"))
+            .GetPrimvarValue()
+            ->GetValue(0.0f)
+            .UncheckedGet<int>(),
+        256)
+        << "aiResolution should map to arnold:resolution";
+    EXPECT_NEAR(
+        GetFloatValue(primvarsSchema.GetPrimvar(TfToken("arnold:spread")).GetPrimvarValue()),
+        0.5f,
+        1e-5f)
+        << "aiSpread should map to arnold:spread";
+    EXPECT_NEAR(
+        GetFloatValue(primvarsSchema.GetPrimvar(TfToken("arnold:roundness")).GetPrimvarValue()),
+        0.25f,
+        1e-5f)
+        << "aiRoundness should map to arnold:roundness";
+}

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testArnoldCustomAttributesMayaNodes.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testArnoldCustomAttributesMayaNodes.cpp
@@ -93,32 +93,36 @@ TEST(ArnoldCustomAttributesMayaNodes, meshArnoldPrimvars)
 
     HdPrimvarsSchema primvarsSchema = HdPrimvarsSchema::GetFromParent(prim.dataSource);
 
-    EXPECT_EQ(
-        primvarsSchema.GetPrimvar(TfToken("arnold:subdiv_type"))
-            .GetPrimvarValue()
-            ->GetValue(0.0f)
-            .UncheckedGet<int>(),
-        1)
+    auto subdivTypeDs = primvarsSchema.GetPrimvar(TfToken("arnold:subdiv_type")).GetPrimvarValue();
+    ASSERT_TRUE(subdivTypeDs);
+    const VtValue subdivTypeVal = subdivTypeDs->GetValue(0.0f);
+    ASSERT_TRUE(subdivTypeVal.IsHolding<short>());
+    EXPECT_EQ(subdivTypeVal.UncheckedGet<short>(), 1)
         << "aiSubdivType should map to arnold:subdiv_type";
-    EXPECT_NEAR(
-        GetFloatValue(primvarsSchema.GetPrimvar(TfToken("arnold:disp_height")).GetPrimvarValue()),
-        0.25f,
-        1e-5f)
+
+    auto dispHeightDs = primvarsSchema.GetPrimvar(TfToken("arnold:disp_height")).GetPrimvarValue();
+    ASSERT_TRUE(dispHeightDs);
+    EXPECT_NEAR(GetFloatValue(dispHeightDs), 0.25f, 1e-5f)
         << "aiDispHeight should map to arnold:disp_height";
-    EXPECT_FALSE(primvarsSchema.GetPrimvar(TfToken("arnold:opaque"))
-                     .GetPrimvarValue()
-                     ->GetValue(0.0f)
-                     .UncheckedGet<bool>())
-        << "aiOpaque=0 should map to arnold:opaque";
-    EXPECT_TRUE(primvarsSchema.GetPrimvar(TfToken("arnold:matte"))
-                    .GetPrimvarValue()
-                    ->GetValue(0.0f)
-                    .UncheckedGet<bool>())
-        << "aiMatte=1 should map to arnold:matte";
-    EXPECT_FALSE(primvarsSchema.GetPrimvar(TfToken("arnold:self_shadows"))
-                     .GetPrimvarValue()
-                     ->GetValue(0.0f)
-                     .UncheckedGet<bool>())
+
+    auto opaqueDs = primvarsSchema.GetPrimvar(TfToken("arnold:opaque")).GetPrimvarValue();
+    ASSERT_TRUE(opaqueDs);
+    const VtValue opaqueVal = opaqueDs->GetValue(0.0f);
+    ASSERT_TRUE(opaqueVal.IsHolding<bool>());
+    EXPECT_FALSE(opaqueVal.UncheckedGet<bool>()) << "aiOpaque=0 should map to arnold:opaque";
+
+    auto matteDs = primvarsSchema.GetPrimvar(TfToken("arnold:matte")).GetPrimvarValue();
+    ASSERT_TRUE(matteDs);
+    const VtValue matteVal = matteDs->GetValue(0.0f);
+    ASSERT_TRUE(matteVal.IsHolding<bool>());
+    EXPECT_TRUE(matteVal.UncheckedGet<bool>()) << "aiMatte=1 should map to arnold:matte";
+
+    auto selfShadowsDs
+        = primvarsSchema.GetPrimvar(TfToken("arnold:self_shadows")).GetPrimvarValue();
+    ASSERT_TRUE(selfShadowsDs);
+    const VtValue selfShadowsVal = selfShadowsDs->GetValue(0.0f);
+    ASSERT_TRUE(selfShadowsVal.IsHolding<bool>());
+    EXPECT_FALSE(selfShadowsVal.UncheckedGet<bool>())
         << "aiSelfShadows=0 should map to arnold:self_shadows";
 }
 
@@ -149,16 +153,15 @@ TEST(ArnoldCustomAttributesMayaNodes, cameraArnoldPrimvars)
 
     HdPrimvarsSchema primvarsSchema = HdPrimvarsSchema::GetFromParent(prim.dataSource);
 
-    EXPECT_NEAR(
-        GetFloatValue(primvarsSchema.GetPrimvar(TfToken("arnold:exposure")).GetPrimvarValue()),
-        1.0f,
-        1e-5f)
+    auto exposureDs = primvarsSchema.GetPrimvar(TfToken("arnold:exposure")).GetPrimvarValue();
+    ASSERT_TRUE(exposureDs);
+    EXPECT_NEAR(GetFloatValue(exposureDs), 1.0f, 1e-5f)
         << "aiExposure should map to arnold:exposure";
-    EXPECT_NEAR(
-        GetFloatValue(
-            primvarsSchema.GetPrimvar(TfToken("arnold:focus_distance")).GetPrimvarValue()),
-        12.5f,
-        1e-5f)
+
+    auto focusDistanceDs
+        = primvarsSchema.GetPrimvar(TfToken("arnold:focus_distance")).GetPrimvarValue();
+    ASSERT_TRUE(focusDistanceDs);
+    EXPECT_NEAR(GetFloatValue(focusDistanceDs), 12.5f, 1e-5f)
         << "aiFocusDistance should map to arnold:focus_distance";
 }
 
@@ -193,11 +196,9 @@ TEST(ArnoldCustomAttributesMayaNodes, directionalLightAttributes)
 
     HdPrimvarsSchema primvarsSchema = HdPrimvarsSchema::GetFromParent(prim.dataSource);
 
-    EXPECT_NEAR(
-        GetFloatValue(primvarsSchema.GetPrimvar(TfToken("arnold:angle")).GetPrimvarValue()),
-        2.5f,
-        1e-5f)
-        << "aiAngle should map to arnold:angle";
+    auto angleDs = primvarsSchema.GetPrimvar(TfToken("arnold:angle")).GetPrimvarValue();
+    ASSERT_TRUE(angleDs);
+    EXPECT_NEAR(GetFloatValue(angleDs), 2.5f, 1e-5f) << "aiAngle should map to arnold:angle";
 
     MObject lightNode;
     ASSERT_TRUE(GetDependNodeFromNodeName(shapeNamePart.c_str(), lightNode));
@@ -205,22 +206,25 @@ TEST(ArnoldCustomAttributesMayaNodes, directionalLightAttributes)
     const MPlug       castVolShadowsPlug = lightDepNode.findPlug("aiCastVolumetricShadows", true);
     ASSERT_FALSE(castVolShadowsPlug.isNull());
     const bool expectedCastVolShadows = castVolShadowsPlug.asBool();
-    EXPECT_EQ(
-        primvarsSchema.GetPrimvar(TfToken("arnold:cast_volumetric_shadows"))
-            .GetPrimvarValue()
-            ->GetValue(0.0f)
-            .UncheckedGet<bool>(),
-        expectedCastVolShadows)
+
+    auto castVolShadowsDs
+        = primvarsSchema.GetPrimvar(TfToken("arnold:cast_volumetric_shadows")).GetPrimvarValue();
+    ASSERT_TRUE(castVolShadowsDs);
+    const VtValue castVolShadowsVal = castVolShadowsDs->GetValue(0.0f);
+    ASSERT_TRUE(castVolShadowsVal.IsHolding<bool>());
+    EXPECT_EQ(castVolShadowsVal.UncheckedGet<bool>(), expectedCastVolShadows)
         << "aiCastVolumetricShadows should map to arnold:cast_volumetric_shadows";
 
     HdLightSchema lightSchema = HdLightSchema::GetFromParent(prim.dataSource);
     ASSERT_TRUE(lightSchema);
     auto container = lightSchema.GetContainer();
     ASSERT_TRUE(container);
-    auto exposureDs = HdSampledDataSource::Cast(container->Get(HdLightTokens->exposure));
-    EXPECT_NEAR(GetFloatValue(exposureDs), 1.5f, 1e-5f)
+    auto lightExposureDs = HdSampledDataSource::Cast(container->Get(HdLightTokens->exposure));
+    ASSERT_TRUE(lightExposureDs);
+    EXPECT_NEAR(GetFloatValue(lightExposureDs), 1.5f, 1e-5f)
         << "aiExposure should map to light.exposure";
     auto colorTempDs = HdSampledDataSource::Cast(container->Get(HdLightTokens->colorTemperature));
+    ASSERT_TRUE(colorTempDs);
     EXPECT_NEAR(GetFloatValue(colorTempDs), 3200.0f, 1e-3f)
         << "aiColorTemperature should map to light.colorTemperature";
 }
@@ -253,21 +257,19 @@ TEST(ArnoldCustomAttributesMayaNodes, areaLightArnoldPrimvars)
 
     HdPrimvarsSchema primvarsSchema = HdPrimvarsSchema::GetFromParent(prim.dataSource);
 
-    EXPECT_EQ(
-        primvarsSchema.GetPrimvar(TfToken("arnold:resolution"))
-            .GetPrimvarValue()
-            ->GetValue(0.0f)
-            .UncheckedGet<int>(),
-        256)
+    auto resolutionDs = primvarsSchema.GetPrimvar(TfToken("arnold:resolution")).GetPrimvarValue();
+    ASSERT_TRUE(resolutionDs);
+    const VtValue resolutionVal = resolutionDs->GetValue(0.0f);
+    ASSERT_TRUE(resolutionVal.IsHolding<int>());
+    EXPECT_EQ(resolutionVal.UncheckedGet<int>(), 256)
         << "aiResolution should map to arnold:resolution";
-    EXPECT_NEAR(
-        GetFloatValue(primvarsSchema.GetPrimvar(TfToken("arnold:spread")).GetPrimvarValue()),
-        0.5f,
-        1e-5f)
-        << "aiSpread should map to arnold:spread";
-    EXPECT_NEAR(
-        GetFloatValue(primvarsSchema.GetPrimvar(TfToken("arnold:roundness")).GetPrimvarValue()),
-        0.25f,
-        1e-5f)
+
+    auto spreadDs = primvarsSchema.GetPrimvar(TfToken("arnold:spread")).GetPrimvarValue();
+    ASSERT_TRUE(spreadDs);
+    EXPECT_NEAR(GetFloatValue(spreadDs), 0.5f, 1e-5f) << "aiSpread should map to arnold:spread";
+
+    auto roundnessDs = primvarsSchema.GetPrimvar(TfToken("arnold:roundness")).GetPrimvarValue();
+    ASSERT_TRUE(roundnessDs);
+    EXPECT_NEAR(GetFloatValue(roundnessDs), 0.25f, 1e-5f)
         << "aiRoundness should map to arnold:roundness";
 }

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testArnoldCustomAttributesMayaNodes.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testArnoldCustomAttributesMayaNodes.py
@@ -1,0 +1,124 @@
+# Copyright 2026 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Python test for Arnold custom attribute translation on native Maya nodes
+# (mesh, camera, directionalLight, areaLight) via mtoaSIP primvar remapping and
+# maya-hydra light schema mapping.
+#
+import maya.cmds as cmds
+import fixturesUtils
+import mtohUtils
+from testUtils import PluginLoaded
+
+HD_ARNOLD = "HdArnoldRendererPlugin"
+HD_ARNOLD_OVERRIDE = "mayaHydraRenderOverride_" + HD_ARNOLD
+
+
+class TestArnoldCustomAttributesMayaNodes(mtohUtils.MayaHydraBaseTestCase):
+    _file = __file__
+    _requiredPlugins = ['mtoa']
+    _setHdStormRenderer = False
+
+    def _setArnoldRenderer(self):
+        """Activate the Arnold Hydra renderer so mtoaSIP is in the scene index chain."""
+        self.activeEditor = cmds.playblast(activeEditor=1)
+        cmds.modelEditor(
+            self.activeEditor, e=1,
+            rendererOverrideName=HD_ARNOLD_OVERRIDE)
+        cmds.refresh(f=1)
+        activeOverride = cmds.modelEditor(
+            self.activeEditor, q=1, rendererOverrideName=True)
+        self.assertEqual(
+            activeOverride,
+            HD_ARNOLD_OVERRIDE,
+            "Arnold Hydra renderer override not available. "
+            "Ensure HdArnoldRendererPlugin is on PXR_PLUGINPATH_NAME.")
+
+    def _setupMesh(self):
+        with PluginLoaded('mtoa'):
+            mesh_xform = cmds.polyCube(name='arnoldAttrMesh', width=2, height=2, depth=2)[0]
+            mesh_shape = cmds.listRelatives(mesh_xform, shapes=True)[0]
+            self._meshShape = cmds.ls(mesh_shape, long=True)[0]
+            cmds.setAttr(self._meshShape + ".aiSubdivType", 1)
+            cmds.setAttr(self._meshShape + ".aiDispHeight", 0.25)
+            cmds.setAttr(self._meshShape + ".aiOpaque", 0)
+            cmds.setAttr(self._meshShape + ".aiMatte", 1)
+            cmds.setAttr(self._meshShape + ".aiSelfShadows", 0)
+        cmds.refresh()
+
+    def _setupCamera(self):
+        with PluginLoaded('mtoa'):
+            _, cam_shape = cmds.camera(name='arnoldAttrCam')
+            self._cameraShape = cmds.ls(cam_shape, long=True)[0]
+            cmds.setAttr(self._cameraShape + ".aiExposure", 1.0)
+            cmds.setAttr(self._cameraShape + ".aiFocusDistance", 12.5)
+        cmds.refresh()
+
+    def _setupDirectionalLight(self):
+        with PluginLoaded('mtoa'):
+            dir_shape = cmds.directionalLight(name='arnoldAttrDirLight', intensity=1.0)
+            self._dirLightShape = cmds.ls(dir_shape, long=True)[0]
+            cmds.setAttr(self._dirLightShape + ".aiAngle", 2.5)
+            cmds.setAttr(self._dirLightShape + ".aiExposure", 1.5)
+            cmds.setAttr(self._dirLightShape + ".aiCastVolumetricShadows", 0)
+            cmds.setAttr(self._dirLightShape + ".aiUseColorTemperature", 1)
+            cmds.setAttr(self._dirLightShape + ".aiColorTemperature", 3200.0)
+        cmds.refresh()
+
+    def _setupAreaLight(self):
+        with PluginLoaded('mtoa'):
+            shape = cmds.shadingNode(
+                "areaLight", asLight=True, name="arnoldAttrAreaLightShape")
+            cmds.setAttr(shape + ".intensity", 1.0)
+            self._areaLightShape = cmds.ls(shape, long=True)[0]
+            cmds.setAttr(self._areaLightShape + ".aiResolution", 256)
+            cmds.setAttr(self._areaLightShape + ".aiSpread", 0.5)
+            cmds.setAttr(self._areaLightShape + ".aiRoundness", 0.25)
+        cmds.refresh()
+
+    def test_meshArnoldPrimvars(self):
+        self._setArnoldRenderer()
+        self._setupMesh()
+        with PluginLoaded('mayaHydraCppTests'):
+            cmds.mayaHydraCppTest(
+                self._meshShape,
+                f="ArnoldCustomAttributesMayaNodes.meshArnoldPrimvars")
+
+    def test_cameraArnoldPrimvars(self):
+        self._setArnoldRenderer()
+        self._setupCamera()
+        with PluginLoaded('mayaHydraCppTests'):
+            cmds.mayaHydraCppTest(
+                self._cameraShape,
+                f="ArnoldCustomAttributesMayaNodes.cameraArnoldPrimvars")
+
+    def test_directionalLightAttributes(self):
+        self._setArnoldRenderer()
+        self._setupDirectionalLight()
+        with PluginLoaded('mayaHydraCppTests'):
+            cmds.mayaHydraCppTest(
+                self._dirLightShape,
+                f="ArnoldCustomAttributesMayaNodes.directionalLightAttributes")
+
+    def test_areaLightArnoldPrimvars(self):
+        self._setArnoldRenderer()
+        self._setupAreaLight()
+        with PluginLoaded('mayaHydraCppTests'):
+            cmds.mayaHydraCppTest(
+                self._areaLightShape,
+                f="ArnoldCustomAttributesMayaNodes.areaLightArnoldPrimvars")
+
+
+if __name__ == '__main__':
+    fixturesUtils.runTests(globals())

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testArnoldCustomNodes.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testArnoldCustomNodes.cpp
@@ -72,7 +72,7 @@ float GetFloatValue(const HdSampledDataSourceHandle& ds, float fallback = 0.0f)
 //       aiFilename="/path/to/test.ies", aiSamples=5) with Arnold renderer active.
 // Expect: prim type = sphereLight; inputs:intensity, inputs:exposure,
 //         inputs:shaping:ies:file are set; arnold:samples primvar exists (catch-all).
-TEST(MtoaSIP, photometricLightTranslation)
+TEST(ArnoldCustomNodes, photometricLightTranslation)
 {
     auto [argc, argv] = getTestingArgs();
     ASSERT_GE(argc, 1);
@@ -123,7 +123,7 @@ TEST(MtoaSIP, photometricLightTranslation)
 // What: mtoaSIP re-types aiStandIn to ArnoldProcedural and maps dso -> arnold:filename.
 // How:  Python creates aiStandIn (dso="/path/to/test.ass") with Arnold renderer.
 // Expect: prim type = ArnoldProcedural; arnold:filename = "/path/to/test.ass".
-TEST(MtoaSIP, standInTranslation)
+TEST(ArnoldCustomNodes, standInTranslation)
 {
     auto [argc, argv] = getTestingArgs();
     ASSERT_GE(argc, 1);
@@ -160,7 +160,7 @@ TEST(MtoaSIP, standInTranslation)
 // What: mtoaSIP re-types aiVolume to ArnoldVolume and maps filename -> arnold:filename.
 // How:  Python creates aiVolume (filename="/path/to/test.vdb") with Arnold renderer.
 // Expect: prim type = ArnoldVolume; arnold:filename = "/path/to/test.vdb".
-TEST(MtoaSIP, volumeTranslation)
+TEST(ArnoldCustomNodes, volumeTranslation)
 {
     auto [argc, argv] = getTestingArgs();
     ASSERT_GE(argc, 1);

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testArnoldCustomNodes.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testArnoldCustomNodes.py
@@ -38,10 +38,6 @@ class TestArnoldCustomNodes(mtohUtils.MayaHydraBaseTestCase):
     _requiredPlugins = ['mtoa']
     _setHdStormRenderer = False     # Need to use Arnold renderer for the tests
 
-    # def tearDown(self):
-    #     """Test will hang if Arnold renderer is not reset before Maya exits."""
-    #     self.setViewport2Renderer()
-
     def _setArnoldRenderer(self):
         """Activate the Arnold Hydra renderer so mtoaSIP is in the scene index chain."""
         self.activeEditor = cmds.playblast(activeEditor=1)

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testArnoldCustomNodes.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testArnoldCustomNodes.py
@@ -104,7 +104,7 @@ class TestArnoldCustomNodes(mtohUtils.MayaHydraBaseTestCase):
         with PluginLoaded('mayaHydraCppTests'):
             cmds.mayaHydraCppTest(
                 self._photometricShape,
-                f="MtoaSIP.photometricLightTranslation")
+                f="ArnoldCustomNodes.photometricLightTranslation")
 
     def test_standInTranslation(self):
         self._setArnoldRenderer()
@@ -112,7 +112,7 @@ class TestArnoldCustomNodes(mtohUtils.MayaHydraBaseTestCase):
         with PluginLoaded('mayaHydraCppTests'):
             cmds.mayaHydraCppTest(
                 self._standInShape,
-                f="MtoaSIP.standInTranslation")
+                f="ArnoldCustomNodes.standInTranslation")
 
     def test_volumeTranslation(self):
         self._setArnoldRenderer()
@@ -120,7 +120,7 @@ class TestArnoldCustomNodes(mtohUtils.MayaHydraBaseTestCase):
         with PluginLoaded('mayaHydraCppTests'):
             cmds.mayaHydraCppTest(
                 self._volumeShape,
-                f="MtoaSIP.volumeTranslation")
+                f="ArnoldCustomNodes.volumeTranslation")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
List of tested Arnold custom attributes on Maya nodes:
- Mesh
  - aiSubdivType, aiDispHeight, aiOpaque, aiMatte, aiSelfShadows
- Camera
  - aiExposure, aiFocusDistance
- Lights
  - directionalLight
    - aiAngle, aiCastVolumetricShadows, aiColorTemperature, aiExposure
  - areaLight
    - aiResolution, aiSpread, aiRoundness