### PR TITLE
HYDRA-2429 : Pass OCIO configuration file path to Hydra render delegate

### DIFF
--- a/lib/mayaHydra/mayaPlugin/batchRendering/batchRenderer.cpp
+++ b/lib/mayaHydra/mayaPlugin/batchRendering/batchRenderer.cpp
@@ -517,10 +517,10 @@ void BatchRenderer::_InitHydraResources()
     if (!ocioConfigFilePath.empty()) {
         TF_DEBUG_MSG(
             MAYAHYDRAPLUGIN_BATCHRENDER_RENDER_SETTINGS,
-            "Render setting " + BatchRenderTokens->adsk_ocioPath.GetString() + " set to "
+            "Render setting " + BatchRenderTokens->ocioConfigPath.GetString() + " set to "
                 + ocioConfigFilePath + "\n");
 
-        _renderDelegate->SetRenderSetting(BatchRenderTokens->adsk_ocioPath, VtValue(ocioConfigFilePath));
+        _renderDelegate->SetRenderSetting(BatchRenderTokens->ocioConfigPath, VtValue(ocioConfigFilePath));
     }
 
     // Tell render delegate to read render settings from the Hydra

--- a/lib/mayaHydra/mayaPlugin/batchRendering/batchRenderer.cpp
+++ b/lib/mayaHydra/mayaPlugin/batchRendering/batchRenderer.cpp
@@ -51,6 +51,9 @@
 #include <pxr/imaging/hgi/hgi.h>
 #include <pxr/imaging/hgi/tokens.h>
 
+#include <ufeExtensions/Global.h>
+#include <ufe/colorManagementHandler.h>
+
 #include <maya/MMessage.h>
 #include <maya/MSceneMessage.h>
 #include <maya/MStatus.h>
@@ -109,6 +112,17 @@ void dumpHydraScene(const HdRenderIndex* renderIndex)
             TF_STATUS("Hydra scene from scene index %s written to %s", sceneIndexName.c_str(), dumpPath.asChar());
         }
     }
+}
+
+std::string getOCIOConfigFilePath()
+{
+    const auto colorManagement
+        = Ufe::ColorManagementHandler::colorManagementHandler(UfeExtensions::getMayaRunTimeId());
+    if (!colorManagement || !colorManagement->isColorManagementEnabled()) {
+        return {};
+    }
+
+    return colorManagement->getConfigFilePath();
 }
 
 // Fvp::RenderViewDataManager::AddRenderViewData connects a custom data
@@ -497,6 +511,17 @@ void BatchRenderer::_InitHydraResources()
     _taskController->SetEnablePresentation(false);
     _renderDelegate->SetRenderSetting(
         HdRenderSettingsTokens->enableInteractive, VtValue(false));
+
+    const std::string ocioConfigFilePath = getOCIOConfigFilePath();
+
+    if (!ocioConfigFilePath.empty()) {
+        TF_DEBUG_MSG(
+            MAYAHYDRAPLUGIN_BATCHRENDER_RENDER_SETTINGS,
+            "Render setting " + BatchRenderTokens->adsk_ocioPath.GetString() + " set to "
+                + ocioConfigFilePath + "\n");
+
+        _renderDelegate->SetRenderSetting(BatchRenderTokens->adsk_ocioPath, VtValue(ocioConfigFilePath));
+    }
 
     // Tell render delegate to read render settings from the Hydra
     // scene (Hydra v2 render settings), rather than from the render

--- a/lib/mayaHydra/mayaPlugin/batchRendering/tokens.h
+++ b/lib/mayaHydra/mayaPlugin/batchRendering/tokens.h
@@ -47,7 +47,8 @@ PXR_NAMESPACE_OPEN_SCOPE
 #define BATCH_RENDER_TOKENS \
     (renderSettingsSrc) \
     (settingsMapRenderSettingsSrc) \
-    (hydraSceneRenderSettingsSrc)
+    (hydraSceneRenderSettingsSrc) \
+    (adsk_ocioPath)  // Autodesk-specific OCIO config path (no standard Hydra token).
 // clang-format on
 
 TF_DECLARE_PUBLIC_TOKENS(BatchRenderTokens, , BATCH_RENDER_TOKENS);

--- a/lib/mayaHydra/mayaPlugin/batchRendering/tokens.h
+++ b/lib/mayaHydra/mayaPlugin/batchRendering/tokens.h
@@ -48,7 +48,7 @@ PXR_NAMESPACE_OPEN_SCOPE
     (renderSettingsSrc) \
     (settingsMapRenderSettingsSrc) \
     (hydraSceneRenderSettingsSrc) \
-    (adsk_ocioPath)  // Autodesk-specific OCIO config path (no standard Hydra token).
+    (ocioConfigPath)
 // clang-format on
 
 TF_DECLARE_PUBLIC_TOKENS(BatchRenderTokens, , BATCH_RENDER_TOKENS);


### PR DESCRIPTION
To allow proper interpretation of color management color space names and other color management information, both the Hydra renderer and the application must refer to the same OCIO configuration file. Pass this information to render delegate's settingsMap via SetRenderSetting(). No unit test will be added as per the discussion with Pierre.