### PR TITLE
HYDRA-2484 : Register Hydra-based renderers with -cap/cpv flags

### DIFF
--- a/lib/mayaHydra/mayaPlugin/pluginUtils.cpp
+++ b/lib/mayaHydra/mayaPlugin/pluginUtils.cpp
@@ -207,6 +207,9 @@ bool registerRenderer(const MtohRendererDescription& desc)
            << " -showBatchRenderProcedure " << dq << "batchRender -showImage true" << dq
            << " -renderSequenceProcedure mayaRenderSequence"
            << " -supportColorManagement true"
+           // Need these to list Hydra-based renderers in USD Render Setup.
+           << " -capability isHydra"
+           << " -capabilityValue true"
            // To avoid breaking the render settings UI we add the Common tab,
            // even though we don't use it.
            << " -addGlobalsTab Common createMayaSoftwareCommonGlobalsTab updateMayaSoftwareCommonGlobalsTab"

--- a/lib/mayaHydra/mayaPlugin/pluginUtils.cpp
+++ b/lib/mayaHydra/mayaPlugin/pluginUtils.cpp
@@ -207,9 +207,8 @@ bool registerRenderer(const MtohRendererDescription& desc)
            << " -showBatchRenderProcedure " << dq << "batchRender -showImage true" << dq
            << " -renderSequenceProcedure mayaRenderSequence"
            << " -supportColorManagement true"
-           // Need these to list Hydra-based renderers in USD Render Setup.
-           << " -capability isHydra"
-           << " -capabilityValue true"
+           // Need these to list Hydra-based renderers.
+           << " -capability isHydra -capabilityValue true"
            // To avoid breaking the render settings UI we add the Common tab,
            // even though we don't use it.
            << " -addGlobalsTab Common createMayaSoftwareCommonGlobalsTab updateMayaSoftwareCommonGlobalsTab"

--- a/test/lib/cmdLineRender/registeredMayaRenderers.py
+++ b/test/lib/cmdLineRender/registeredMayaRenderers.py
@@ -35,6 +35,20 @@ class RegisteredMayaRenderers(mtohUtils.MayaHydraBaseTestCase):
         for r in expected:
             self.assertIn(r, registeredRenderers)
 
+    def test_hydraBasedRenderers(self):
+        """
+        Test that registered renderers are Hydra-based.
+        """
+        hydraBasedRenderers = ['HdStormRendererPlugin', 'HdArnoldRendererPlugin']
+
+        for r in hydraBasedRenderers:
+            if not cmds.renderer(r, exists=True):
+                continue
+            val = cmds.renderer(r, query=True, capability="isHydra")
+            # capability query returns a string value; "false" is also truthy.
+            # Compare with the string "true".
+            self.assertEqual(val, "true", msg=f"{r} is not Hydra-based (got {val!r})")
+
 if __name__ == '__main__':
     fixturesUtils.runTests(globals())
 


### PR DESCRIPTION
We need to describe that a renderer registered with the renderer command is Hydra-based. This will allow clients to filter on Hydra-based renderers only, as this is a requirement for USD Render Setup.

This is done with the -capability / -capabilityValue flags (e.g. `renderer -capability isHydra -capabilityValue true HdArnoldRendererPlugin`) and USD render setup can query renderers with `renderer -q -capability isHydra HdArnoldRendererPlugin`.