### PR TITLE
HYDRA-2483 - Move dg_access_mutex down to where it's actually needed

### DIFF
--- a/lib/mayaHydra/hydraExtensions/CMakeLists.txt
+++ b/lib/mayaHydra/hydraExtensions/CMakeLists.txt
@@ -12,6 +12,7 @@ target_sources(${TARGET_NAME}
         mayaHydraLibInterfaceImp.cpp
         mayaUtils.cpp
         mhBuildInfo.cpp
+        mhDgAccessLock.cpp
         mixedUtils.cpp
         mhWireframeColorInterfaceImp.cpp
         mhLeadObjectPathTracker.cpp
@@ -27,6 +28,7 @@ set(HEADERS
     mayaHydraLibInterface.h
     mayaHydraLibInterfaceImp.h
     mayaUtils.h
+    mhDgAccessLock.h
     mixedUtils.h
     mhWireframeColorInterfaceImp.h
     mhLeadObjectPathTracker.h

--- a/lib/mayaHydra/hydraExtensions/adapters/adapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/adapter.cpp
@@ -47,9 +47,6 @@ TF_REGISTRY_FUNCTION(TfType) { TfType::Define<MayaHydraAdapter>(); }
 
 namespace {
 
-using LockType = std::recursive_mutex;
-LockType dg_access_mutex;
-
 // When an extension/dynamic attribute set changes on an rprim, also dirty extComputationPrimvars
 // because the attribute may back a computation input. This is NOT emitted on topology changes
 // (see doc/render_delegate_topology_vs_deformation.md).
@@ -207,8 +204,7 @@ HdPrimvarDescriptorVector MayaHydraAdapter::GetPrimvarDescriptors(HdInterpolatio
     // All extension/dynamic attributes as custom primvars.
     if (interpolation == HdInterpolationConstant) {
         if (_extAttrMapNeedUpdate) {
-            // Apply a global lock to avoid race condition while doing parallel DG node evaluation.
-            std::lock_guard<LockType> lock(dg_access_mutex);
+            MayaHydra::DgAccessLock dgLock;
             MAYAHYDRA_NS::GetExtensionAndDynamicAttributesFromNode(
                 GetNode(),
                 _extAttrNameToValueMap);

--- a/lib/mayaHydra/hydraExtensions/adapters/adapter.h
+++ b/lib/mayaHydra/hydraExtensions/adapters/adapter.h
@@ -21,6 +21,7 @@
 #include <mayaHydraLib/api.h>
 
 #include <mayaHydraLib/adapters/mhDirtyNotifier.h>
+#include <mayaHydraLib/mhDgAccessLock.h>
 
 #include <pxr/imaging/hd/sceneDelegate.h>
 #include <pxr/pxr.h>

--- a/lib/mayaHydra/hydraExtensions/adapters/aiAreaLightAdapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/aiAreaLightAdapter.cpp
@@ -45,6 +45,8 @@ public:
     {
         const TfToken& defaultLightType = HdPrimTypeTokens->rectLight;
 
+        MayaHydra::DgAccessLock dgLock;
+
         // Get the light type
         MStatus           status;
         MFnDependencyNode depNode(GetNode(), &status);
@@ -79,6 +81,8 @@ public:
                 "Called MayaHydraAiAreaLightAdapter::GetLightParamValue(%s) - %s\n",
                 paramName.GetText(),
                 GetDagPath().partialPathName().asChar());
+
+        MayaHydra::DgAccessLock dgLock;
 
         MStatus           status;
         MFnDependencyNode depNode(GetNode(), &status);

--- a/lib/mayaHydra/hydraExtensions/adapters/aiSkydomeLightAdapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/aiSkydomeLightAdapter.cpp
@@ -99,6 +99,8 @@ public:
 
     VtValue GetLightParamValue(const TfToken& paramName) override
     {
+        MayaHydra::DgAccessLock dgLock;
+
         MStatus           status;
         MFnDependencyNode light(GetNode(), &status);
         if (ARCH_UNLIKELY(!status)) {

--- a/lib/mayaHydra/hydraExtensions/adapters/areaLightAdapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/areaLightAdapter.cpp
@@ -48,6 +48,8 @@ public:
                 paramName.GetText(),
                 GetDagPath().partialPathName().asChar());
 
+        MayaHydra::DgAccessLock dgLock;
+
         auto sizeScaled = [=](int index) {
             constexpr float             defaultSizeForAreaLights[2] { 2.0f, 2.0f };
             double                      scale[3] = { 1.0, 1.0, 1.0 };

--- a/lib/mayaHydra/hydraExtensions/adapters/cameraAdapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/cameraAdapter.cpp
@@ -194,6 +194,8 @@ VtValue MayaHydraCameraAdapter::Get(const TfToken& key) { return MayaHydraShapeA
 
 VtValue MayaHydraCameraAdapter::GetCameraParamValue(const TfToken& paramName)
 {
+    MayaHydra::DgAccessLock dgLock;
+
     constexpr double inchToMM = 25.4;
 
     MStatus status;

--- a/lib/mayaHydra/hydraExtensions/adapters/customDagAdapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/customDagAdapter.cpp
@@ -250,6 +250,8 @@ bool MayaHydraCustomDagAdapter::GetVisible()
 
 VtDictionary MayaHydraCustomDagAdapter::GetNonDefaultMayaAttributes() const
 {
+    MayaHydra::DgAccessLock dgLock;
+
     VtDictionary attrs;
     GetNonDefaultMayaAttributesFromNode(GetNode(), attrs);
     return attrs;

--- a/lib/mayaHydra/hydraExtensions/adapters/dagAdapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/dagAdapter.cpp
@@ -195,6 +195,7 @@ GfMatrix4d MayaHydraDagAdapter::GetTransform()
             _dagPath.partialPathName().asChar());
 
     if (_invalidTransform) {
+        MayaHydra::DgAccessLock dgLock;
         if (IsInstanced()) {
             _transform.SetIdentity();
         } else {
@@ -210,12 +211,15 @@ size_t
 MayaHydraDagAdapter::SampleTransform(size_t maxSampleCount, float* times, GfMatrix4d* samples)
 {
     return GetMayaHydraSceneIndex()->SampleValues(maxSampleCount, times, samples, [&]() -> GfMatrix4d {
+        MayaHydra::DgAccessLock dgLock;
         return GetGfMatrixFromMaya(_dagPath.inclusiveMatrix());
     });
 }
 
 void MayaHydraDagAdapter::RefreshInstancingState()
 {
+    MayaHydra::DgAccessLock dgLock;
+
     MDagPathArray dags;
     if (MDagPath::getAllPathsTo(GetDagPath().node(), dags)) {
         _isInstanced = dags.length() > 1;
@@ -278,6 +282,8 @@ void MayaHydraDagAdapter::RemovePrim()
 
 bool MayaHydraDagAdapter::UpdateVisibility()
 {
+    MayaHydra::DgAccessLock dgLock;
+
     if (ARCH_UNLIKELY(!GetDagPath().isValid())) {
         return false;
     }
@@ -303,6 +309,9 @@ VtIntArray MayaHydraDagAdapter::GetInstanceIndices(const SdfPath& prototypeId)
     if (!IsInstanced()) {
         return {};
     }
+
+    MayaHydra::DgAccessLock dgLock;
+
     MDagPathArray dags;
     if (!MDagPath::getAllPathsTo(GetDagPath().node(), dags)) {
         return {};
@@ -344,6 +353,8 @@ void MayaHydraDagAdapter::_AddHierarchyChangedCallbacks(MDagPath& dag)
 
 SdfPath MayaHydraDagAdapter::GetInstancerID() const
 {
+    MayaHydra::DgAccessLock dgLock;
+
     MDagPathArray dags;
     if (!MDagPath::getAllPathsTo(GetDagPath().node(), dags) || dags.length() <= 1) {
         return {};
@@ -367,6 +378,8 @@ bool MayaHydraDagAdapter::_GetVisibility() const { return GetDagPath().isVisible
 VtValue MayaHydraDagAdapter::GetInstancePrimvar(const TfToken& key)
 {
     if (key == _tokens->instanceTransform) {
+        MayaHydra::DgAccessLock dgLock;
+
         MDagPathArray dags;
         if (!MDagPath::getAllPathsTo(GetDagPath().node(), dags)) {
             return {};

--- a/lib/mayaHydra/hydraExtensions/adapters/directionalLightAdapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/directionalLightAdapter.cpp
@@ -77,6 +77,8 @@ public:
                 GetDagPath().partialPathName().asChar());
 
         if (key == HdLightTokens->shadowParams) {
+            MayaHydra::DgAccessLock dgLock;
+
             HdxShadowParams     shadowParams;
             MFnDirectionalLight mayaLight(GetDagPath());
             if (!GetShadowsEnabled(mayaLight)) {
@@ -96,6 +98,8 @@ public:
     VtValue GetLightParamValue(const TfToken& paramName) override
     {
         if ((paramName == HdLightTokens->angle) || (paramName == UsdLuxTokens->inputsAngle)) {
+            MayaHydra::DgAccessLock dgLock;
+
             MStatus           status;
             MFnDependencyNode lightNode(GetNode(), &status);
             if (ARCH_UNLIKELY(!status)) {

--- a/lib/mayaHydra/hydraExtensions/adapters/imagePlaneMaterialAdapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/imagePlaneMaterialAdapter.cpp
@@ -166,7 +166,11 @@ void MayaHydraImagePlaneMaterialAdapter::CreateCallbacks()
 
 VtValue MayaHydraImagePlaneMaterialAdapter::GetMaterialResource()
 {
-    std::string imagePath = GetImagePlaneTexturePath(GetNode());
+    std::string imagePath;
+    {
+        MayaHydra::DgAccessLock dgLock;
+        imagePath = GetImagePlaneTexturePath(GetNode());
+    }
     if (imagePath.empty()) {
         return GetPreviewMaterialResource(GetID());
     }

--- a/lib/mayaHydra/hydraExtensions/adapters/lightAdapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/lightAdapter.cpp
@@ -340,6 +340,8 @@ VtValue MayaHydraLightAdapter::Get(const TfToken& key)
             GetDagPath().partialPathName().asChar());
 
     if (key == HdLightTokens->params) {
+        MayaHydra::DgAccessLock dgLock;
+
         MFnLight       mayaLight(GetDagPath());
         GlfSimpleLight light;
         const auto     color = mayaLight.color();
@@ -397,6 +399,8 @@ VtValue MayaHydraLightAdapter::Get(const TfToken& key)
         coll.SetRootPaths(lightedPaths);
         return VtValue(coll);
     } else if (key == HdLightTokens->shadowParams) {
+        MayaHydra::DgAccessLock dgLock;
+
         HdxShadowParams shadowParams;
         MFnLight        mayaLight(GetDagPath());
         if (!GetShadowsEnabled(mayaLight)) {
@@ -412,6 +416,8 @@ VtValue MayaHydraLightAdapter::Get(const TfToken& key)
 
 MayaHydraLightAdapter::MayaLightParams MayaHydraLightAdapter::GetMayaLightParams() const
 {
+    MayaHydra::DgAccessLock dgLock;
+
     MayaLightParams   params;
     MStatus           status;
     MFnDependencyNode lightDepNode(GetNode(), &status);
@@ -493,6 +499,8 @@ VtValue MayaHydraLightAdapter::GetLightParamValue(const TfToken& paramName)
             paramName.GetText(),
             GetDagPath().partialPathName().asChar());
 
+    MayaHydra::DgAccessLock dgLock;
+
     MFnLight light(GetDagPath());
 
     // Get Maya parameters (including Arnold attributes with "ai" prefix)
@@ -550,6 +558,8 @@ VtValue MayaHydraLightAdapter::GetLightMaterialNetwork() const
         .Msg(
             "Called MayaHydraLightAdapter::GetLightMaterialNetwork() - %s\n",
             GetDagPath().partialPathName().asChar());
+
+    MayaHydra::DgAccessLock dgLock;
 
     // Additional debugging for dome lights
     const bool isSkyDomeLight = IsDagPathAnArnoldSkyDomeLight(GetDagPath());

--- a/lib/mayaHydra/hydraExtensions/adapters/materialAdapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/materialAdapter.cpp
@@ -266,6 +266,8 @@ private:
 
     void _CacheNodeAndTypes()
     {
+        MayaHydra::DgAccessLock dgLock;
+
         _surfaceShader = MObject::kNullObj;
         _surfaceShaderType = _emptyToken;
         MStatus           status;
@@ -507,6 +509,8 @@ private:
         TF_DEBUG(MAYAHYDRALIB_ADAPTER_MATERIALS)
             .Msg("MayaHydraShadingEngineAdapter::GetMaterialResource(): %s\n", GetID().GetText());
         
+        MayaHydra::DgAccessLock dgLock;
+
         HdMaterialNetworkMap materialXNetworkMap;
         if (PopulateMaterialXNetworkMap(materialXNetworkMap)) {
             return VtValue(materialXNetworkMap);

--- a/lib/mayaHydra/hydraExtensions/adapters/meshAdapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/meshAdapter.cpp
@@ -203,6 +203,8 @@ public:
     /// Return face-varying UVs as a primvar value.
     VtValue GetUVs()
     {
+        MayaHydra::DgAccessLock dgLock;
+
         MStatus status;
         MFnMesh mesh(GetDagPath(), &status);
         if (ARCH_UNLIKELY(!status)) {
@@ -234,6 +236,8 @@ public:
     /// Return face-varying tangents as a primvar value.
     VtValue GetTangents()
     {
+        MayaHydra::DgAccessLock dgLock;
+
         MStatus status;
         MFnMesh mesh(GetDagPath(), &status);
         if (ARCH_UNLIKELY(!status)) {
@@ -268,6 +272,8 @@ public:
     /// Return vertex positions as a primvar value.
     VtValue GetPoints()
     {
+        MayaHydra::DgAccessLock dgLock;
+
         MStatus status;
         MFnMesh mesh(GetDagPath(), &status);
         if (ARCH_UNLIKELY(!status)) {
@@ -286,6 +292,8 @@ public:
     /// Return face-varying normals as a primvar value.
     VtValue GetNormals()
     {
+        MayaHydra::DgAccessLock dgLock;
+
         MStatus status;
         MFnMesh mesh(GetDagPath(), &status);
         if (ARCH_UNLIKELY(!status)) {
@@ -379,6 +387,8 @@ public:
     /// Build the mesh topology from the Maya mesh.
     HdMeshTopology GetMeshTopology() override
     {
+        MayaHydra::DgAccessLock dgLock;
+
         MFnMesh    mesh(GetDagPath());
         const auto numPolygons = mesh.numPolygons();
         VtIntArray faceVertexCounts;
@@ -406,6 +416,8 @@ public:
     /// Return display style based on smooth mesh settings.
     HdDisplayStyle GetDisplayStyle() override
     {
+        MayaHydra::DgAccessLock dgLock;
+
         MStatus           status;
         MFnDependencyNode node(GetNode(), &status);
         if (ARCH_UNLIKELY(!status)) {
@@ -424,6 +436,8 @@ public:
     /// Return subdivision tags (creases/corners) for smooth meshes.
     PxOsdSubdivTags GetSubdivTags() override
     {
+        MayaHydra::DgAccessLock dgLock;
+
         PxOsdSubdivTags tags;
         if (GetDisplayStyle().refineLevel < 1) {
             return tags;
@@ -488,6 +502,8 @@ public:
     /// Return primvar descriptors for the requested interpolation.
     HdPrimvarDescriptorVector GetPrimvarDescriptors(HdInterpolation interpolation) override
     {
+        MayaHydra::DgAccessLock dgLock;
+
         // Base descriptors
         HdPrimvarDescriptorVector descs
             = MayaHydraShapeAdapter::GetPrimvarDescriptors(interpolation);
@@ -525,6 +541,8 @@ public:
     /// Return whether the mesh is double-sided.
     bool GetDoubleSided() const override
     {
+        MayaHydra::DgAccessLock dgLock;
+
         MFnMesh mesh(GetDagPath());
         auto    p = mesh.findPlug(MayaAttrs::mesh::doubleSided, true);
         if (ARCH_UNLIKELY(p.isNull())) {

--- a/lib/mayaHydra/hydraExtensions/adapters/nurbsCurveAdapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/nurbsCurveAdapter.cpp
@@ -125,6 +125,8 @@ public:
                 GetDagPath().partialPathName().asChar());
 
         if (key == HdTokens->points) {
+            MayaHydra::DgAccessLock dgLock;
+
             MFnNurbsCurve curve(GetDagPath());
             MStatus       status;
             MPointArray   pointArray;
@@ -147,6 +149,8 @@ public:
 
     HdBasisCurvesTopology GetBasisCurvesTopology() override
     {
+        MayaHydra::DgAccessLock dgLock;
+
         MFnNurbsCurve curve(GetDagPath());
         const auto    pointCount = curve.numCVs();
 

--- a/lib/mayaHydra/hydraExtensions/adapters/pointLightAdapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/pointLightAdapter.cpp
@@ -23,8 +23,6 @@
 #include <pxr/pxr.h>
 #include <pxr/usd/usdLux/tokens.h>
 
-#include <maya/MFnPointLight.h>
-
 #include <memory>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -58,7 +56,6 @@ public:
                 paramName.GetText(),
                 GetDagPath().partialPathName().asChar());
 
-        MFnPointLight light(GetDagPath());
         if ((paramName == HdLightTokens->radius) || (paramName == UsdLuxTokens->inputsRadius)) {
             // For point lights, use a default radius if the render delegate asks for it
             constexpr float radius = 0.01f; // Default radius for point lights

--- a/lib/mayaHydra/hydraExtensions/adapters/shapeAdapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/shapeAdapter.cpp
@@ -72,11 +72,14 @@ MObject MayaHydraShapeAdapter::GetMaterial(const MObject& shadingComp)
             "Called MayaHydraShapeAdapter::GetMaterial() - %s\n",
             GetDagPath().partialPathName().asChar());
 
+    MayaHydra::DgAccessLock dgLock;
     return MayaHydra::FindShadingEngine(GetDagPath(), shadingComp);
 }
 
 GfBBox3d MayaHydraShapeAdapter::GetBoundingBox()
 {
+    MayaHydra::DgAccessLock dgLock;
+
     MFnDagNode   node(GetDagPath());
     MBoundingBox objBB = node.boundingBox();
     MPoint       minPt = objBB.min();

--- a/lib/mayaHydra/hydraExtensions/adapters/spotLightAdapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/spotLightAdapter.cpp
@@ -87,6 +87,8 @@ public:
 protected:
     void _CalculateLightParams(GlfSimpleLight& light) override
     {
+        MayaHydra::DgAccessLock dgLock;
+
         MStatus      status;
         MFnSpotLight mayaLight(GetDagPath(), &status);
         if (TF_VERIFY(status)) {
@@ -104,6 +106,8 @@ protected:
                 GetDagPath().partialPathName().asChar());
 
         if (key == HdLightTokens->shadowParams) {
+            MayaHydra::DgAccessLock dgLock;
+
             HdxShadowParams shadowParams;
             MFnSpotLight    mayaLight(GetDagPath());
             if (!GetShadowsEnabled(mayaLight)
@@ -129,6 +133,8 @@ protected:
                 "Called MayaHydraSpotLightAdapter::GetLightParamValue(%s) - %s\n",
                 paramName.GetText(),
                 GetDagPath().partialPathName().asChar());
+
+        MayaHydra::DgAccessLock dgLock;
 
         MStatus      status;
         MFnSpotLight light(GetDagPath(), &status);

--- a/lib/mayaHydra/hydraExtensions/mhDgAccessLock.cpp
+++ b/lib/mayaHydra/hydraExtensions/mhDgAccessLock.cpp
@@ -1,0 +1,27 @@
+//
+// Copyright 2026 Autodesk, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "mhDgAccessLock.h"
+
+namespace MAYAHYDRA_NS_DEF {
+
+DgAccessMutexType& GetDgAccessMutex()
+{
+    static DgAccessMutexType mutex;
+    return mutex;
+}
+
+} // namespace MAYAHYDRA_NS_DEF

--- a/lib/mayaHydra/hydraExtensions/mhDgAccessLock.h
+++ b/lib/mayaHydra/hydraExtensions/mhDgAccessLock.h
@@ -1,0 +1,56 @@
+//
+// Copyright 2026 Autodesk, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef MAYAHYDRALIB_MH_DG_ACCESS_LOCK_H
+#define MAYAHYDRALIB_MH_DG_ACCESS_LOCK_H
+
+#include <mayaHydraLib/api.h>
+
+#include <mutex>
+
+namespace MAYAHYDRA_NS_DEF {
+
+using DgAccessMutexType = std::recursive_mutex;
+
+/// The single mutex serializing Maya Dependency Graph reads performed on behalf of Hydra.
+///
+/// Hydra pulls prim data from multiple threads while Maya may be evaluating the DG in
+/// parallel, and the Maya API tolerates neither concurrent reads of the same node nor reads
+/// racing against evaluation. There must be exactly one such mutex for the whole library:
+/// per-translation-unit mutexes would let two call sites believe they are mutually exclusive
+/// when they are not.
+///
+/// The mutex is recursive because locked methods legitimately call one another, for example
+/// MayaHydraMeshAdapter::GetMeshTopology() calls GetDisplayStyle(), and
+/// MayaHydraShapeAdapter::GetBoundingBox() calls GetTransform().
+MAYAHYDRALIB_API
+DgAccessMutexType& GetDgAccessMutex();
+
+class DgAccessLock
+{
+public:
+    DgAccessLock() : _lock(GetDgAccessMutex()) { }
+
+    DgAccessLock(const DgAccessLock&) = delete;
+    DgAccessLock& operator=(const DgAccessLock&) = delete;
+
+private:
+    std::lock_guard<DgAccessMutexType> _lock;
+};
+
+} // namespace MAYAHYDRA_NS_DEF
+
+#endif // MAYAHYDRALIB_MH_DG_ACCESS_LOCK_H

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraDataSource.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraDataSource.cpp
@@ -52,11 +52,6 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-namespace {
-    using LockType = std::recursive_mutex;
-    LockType dg_access_mutex;
-}
-
 MayaHydraDataSource::MayaHydraDataSource(
     const SdfPath& id,
     TfToken type,
@@ -127,9 +122,6 @@ MayaHydraDataSource::GetNames()
 HdDataSourceBaseHandle
 MayaHydraDataSource::Get(const TfToken& name)
 {
-    // Apply a global lock to avoid race condition while doing parallel DG node evaluation.
-    std::lock_guard<LockType> lock(dg_access_mutex);
-
     if (name == HdMeshSchemaTokens->mesh) {
         if (_type == HdPrimTypeTokens->mesh) {
             auto topology = _adapter->GetMeshTopology();

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
@@ -337,6 +337,8 @@ void _connectionChanged(MPlug& srcPlug, MPlug& destPlug, bool made, void* client
 
 SdfPath _GetMaterialPath(const SdfPath& base, const MObject& obj)
 {
+    MayaHydra::DgAccessLock dgLock;
+
     MStatus           status;
     MFnDependencyNode node(obj, &status);
     if (!status) {

--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.h
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.h
@@ -235,6 +235,9 @@ public:
         // For sample size of 1 tStep is unused and we match USD and to provide t=shutterOpen
         // sample.
         const double tStep = maxSampleCount > 1 ? (shutter.GetSize() / (maxSampleCount - 1)) : 0;
+
+        MayaHydra::DgAccessLock dgLock;
+
         const MTime  mayaTime = MAnimControl::currentTime();
         size_t       nSamples = 0;
         double       relTime = shutter.GetMin();


### PR DESCRIPTION
The current placement of dg_access_mutex is too high in the stack. In case where many rprims updated, this prevents full multithreading of  Hydra's SyncAll. This change moves the mutex down to the methods that actually access Maya DG.