### PR TITLE
HYDRA-2488 - Selection highlight state for USD cameras only changes when changing viewport - #490

### DIFF
--- a/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
+++ b/lib/mayaHydra/hydraExtensions/sceneIndex/mayaHydraSceneIndex.cpp
@@ -491,6 +491,7 @@ void MayaHydraSceneIndex::UpdateRenderItems(const MDataServerOperation::MViewpor
     // This loop could, in theory, be parallelized.  Unclear how large the gains would be, but maybe
     // nothing to lose unless there is some internal contention in USD.
     for (size_t i = 0; i < scene.mCount; i++) {
+        using MVS = MDataServerOperation::MViewportScene;
         auto flags = scene.mFlags[i];
         if (flags == 0) {
             continue;
@@ -566,8 +567,10 @@ void MayaHydraSceneIndex::UpdateRenderItems(const MDataServerOperation::MViewpor
         }
 
 #ifdef MAYA_HAS_MVS_CHANGED_WIREFRAME_COLOR_API
+        // Some custom render items (Ufe cameras) don't send the dirty wireframe color notification
+        // but they change wireframe color by resetting their effect so we catch it this way.
         bool wireframeColorDirty = isNewRenderitem ||
-            (flags & MDataServerOperation::MViewportScene::MVS_changedWireframeColor);
+            (flags & (MVS::MVS_changedWireframeColor | MVS::MVS_changedEffect));
 #else
         bool wireframeColorDirty = true;
 #endif


### PR DESCRIPTION
Custom render items (Ufe cameras) don't send the dirty wireframe color notification but they change wireframe color by resetting their effect so we catch it this way.