### PR TITLE
HYDRA-2482 : Playback performance regression

### DIFF
--- a/doc/render_delegate_topology_vs_deformation.md
+++ b/doc/render_delegate_topology_vs_deformation.md
@@ -121,7 +121,9 @@ This applies to:
 
 Maya may set `MVS_changedTopo` alongside `MVS_changedGeometry` for operations that do not change connectivity (e.g. moving a vertex). The render item adapter suppresses topology locators when **both** vertex count and index connectivity are unchanged ([`RenderItemShouldEmitTopologyLocators`](../lib/mayaHydra/hydraExtensions/adapters/renderItemTopologyUtil.cpp)).
 
-When connectivity changes with the same vertex count (e.g. edge flip), topology locators **are** emitted. Render delegates should not treat `primvars/points` alone as topology-stable if `mesh/topology` is also in the same notice.
+When connectivity changes with the same vertex count (e.g. edge flip), topology locators **are** emitted — **provided Maya set `MVS_changedTopo`**. Detection is conditional on that flag: the index buffer is not read back on a geometry-only update, because mapping it, scanning it and copying it on every deformation frame was a playback regression (HYDRA-2417). Genuine connectivity edits (extrude, merge, edge flip, smooth-level crossing) do set the flag, so in practice this is not a gap — but a render item whose vertex count or connectivity changed while Maya reported only `MVS_changedGeometry` would keep its cached topology.
+
+Render delegates should not treat `primvars/points` alone as topology-stable if `mesh/topology` is also in the same notice.
 
 ---
 

--- a/lib/mayaHydra/hydraExtensions/adapters/renderItemAdapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/renderItemAdapter.cpp
@@ -333,7 +333,7 @@ void MayaHydraRenderItemAdapter::UpdateFromDelta(const UpdateFromDeltaData& data
 
     // geomChanged means vertex buffers are re-read. Dirty one locator per primvar so the render
     // delegate only re-pulls what actually changed. Normals are skipped when Hydra generates them.
-    // Emitted after the vertex-count workaround above which may have promoted topoChanged -> geomChanged.
+    // Emitted after the vertex-count workaround above, which may have turned a topo-only update into also setting geomChanged.
     if (geomChanged) {
         notifier.dirtyPoints();
         notifier.dirtyUVs();

--- a/lib/mayaHydra/hydraExtensions/adapters/renderItemAdapter.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/renderItemAdapter.cpp
@@ -225,7 +225,9 @@ void MayaHydraRenderItemAdapter::UpdateFromDelta(const UpdateFromDeltaData& data
     //     Topology locators are suppressed when Maya sets MVS_changedTopo alongside
     //     MVS_changedGeometry but both vertex count and index connectivity are unchanged
     //     (deformation-only). When connectivity changes with the same vertex count, topology
-    //     locators are still emitted.
+    //     locators are still emitted — but only when Maya set MVS_changedTopo, because the index
+    //     buffer is not read on the geometry-only path (see the Indices block below). Detecting
+    //     connectivity edits therefore relies on that flag, which Maya sets for genuine ones.
     //   Extent: dirty only when the bounding box actually changes. Maya has no bbox-changed
     //     flag, so we diff the freshly-read bbox against the stored _bounds before overwriting.
     //     Checked in the geomChanged||topoChanged block (before the vertex-count workaround below),
@@ -331,7 +333,7 @@ void MayaHydraRenderItemAdapter::UpdateFromDelta(const UpdateFromDeltaData& data
 
     // geomChanged means vertex buffers are re-read. Dirty one locator per primvar so the render
     // delegate only re-pulls what actually changed. Normals are skipped when Hydra generates them.
-    // Emitted after the vertex-count workaround below which may have promoted topoChanged -> geomChanged.
+    // Emitted after the vertex-count workaround above which may have promoted topoChanged -> geomChanged.
     if (geomChanged) {
         notifier.dirtyPoints();
         notifier.dirtyUVs();
@@ -480,7 +482,11 @@ void MayaHydraRenderItemAdapter::UpdateFromDelta(const UpdateFromDeltaData& data
     // Indices
     // Line strips do not make use of the index buffer, so we can skip this block.
     // See "Line strips indices are implicitly defined" comment.
-    if ((topoChanged || geomChanged) && vertexBuffercount
+    // Gated on topoChanged, never on geomChanged alone: mapping the index buffer, scanning it for
+    // the highest referenced index and copying it into a VtIntArray on every deformation frame is
+    // the HYDRA-2417 playback regression. Deformation leaves connectivity untouched, so on those
+    // frames there is nothing here to recompute.
+    if (topoChanged && vertexBuffercount
         && GetPrimitive() != MHWRender::MGeometry::Primitive::kLineStrip) {
         // Assume first stream contains the positions.
         MIndexBuffer* indices = geom->indexBuffer(0);
@@ -583,10 +589,10 @@ void MayaHydraRenderItemAdapter::UpdateFromDelta(const UpdateFromDeltaData& data
         _EmitRenderItemTopologyDirtyLocators(notifier, GetPrimitive());
     }
 
-    // Keep cached topology in sync whenever index buffers were read, not only when Maya sets
-    // MVS_changedTopo. geomChanged-only connectivity edits (e.g. edge flip) may skip the topo flag
-    // while still changing the index buffer.
-    const bool indicesWereRead = (topoChanged || geomChanged) && vertexBuffercount > 0
+    // Mirrors the Indices block gate above: the cached _topology is rebuilt only when indices were
+    // actually read. On a deformation frame the cached _topology is retained and stays correct,
+    // because connectivity is unchanged.
+    const bool indicesWereRead = topoChanged && vertexBuffercount > 0
         && GetPrimitive() != MHWRender::MGeometry::Primitive::kLineStrip;
     if (indicesWereRead && !vertexCounts.empty()) {
         switch (GetPrimitive()) {

--- a/lib/mayaHydra/hydraExtensions/adapters/renderItemTopologyUtil.cpp
+++ b/lib/mayaHydra/hydraExtensions/adapters/renderItemTopologyUtil.cpp
@@ -30,7 +30,8 @@ namespace MAYAHYDRA_NS_DEF {
 // index/count arrays, so it is not free on a dense mesh. It is reached only through the narrow
 // branch in RenderItemShouldEmitTopologyLocators below where Maya sets BOTH MVS_changedTopo and
 // MVS_changedGeometry on the same update with an unchanged vertex count and a valid stored
-// baseline (every other case short-circuits before this call). That combination is the
+// baseline (every other case short-circuits before this call — the geometry-only path is what the
+// !topoChanged early return enforces, since indices are not read there). That combination is the
 // MAYA-134200 corner case: MVS_changedTopo can be set on edits that do not actually change
 // connectivity (e.g. a vertex move sets it alongside MVS_changedGeometry — see "Render item
 // topology suppression" in doc/render_delegate_topology_vs_deformation.md), and Maya exposes no
@@ -90,14 +91,22 @@ bool RenderItemShouldEmitTopologyLocators(
     const VtIntArray&    newIndices,
     const VtIntArray&    newCounts)
 {
-    if (!topoChanged && !geomChanged) {
+    // Nothing changed, or geometry only. On the geometry-only path UpdateFromDelta does not read
+    // the index buffer (that per-frame read-back was the HYDRA-2417 playback regression), so
+    // newIndices/newCounts are empty and the connectivity comparison below would report a spurious
+    // change on every deformation frame. Detecting a connectivity change here therefore relies on
+    // Maya setting MVS_changedTopo, which it does for genuine connectivity edits (extrude, merge,
+    // edge flip, smooth-level crossing).
+    if (!topoChanged) {
         return false;
     }
-    if (topoChanged && !geomChanged) {
+    // topoChanged is true from here on: emit unless the topo + geom combination can be shown below
+    // to be deformation-only.
+    if (!geomChanged) {
         return true;
     }
     if (!hasGeomAndBuffers || positionsEmpty) {
-        return topoChanged;
+        return true;
     }
     if (storedPositionCount != currentVertexCount) {
         return true;

--- a/lib/mayaHydra/hydraExtensions/adapters/renderItemTopologyUtil.h
+++ b/lib/mayaHydra/hydraExtensions/adapters/renderItemTopologyUtil.h
@@ -45,6 +45,8 @@ bool RenderItemTopologyConnectivityChanged(
     size_t                      lineStripVertexCount);
 
 /// Policy for whether UpdateFromDelta should emit mesh/topology locators on the render item path.
+/// \p newIndices / \p newCounts are only populated when \p topoChanged is true, which is why the
+/// geometry-only path returns early instead of comparing connectivity.
 MAYAHYDRALIB_API
 bool RenderItemShouldEmitTopologyLocators(
     bool                        topoChanged,

--- a/test/lib/mayaUsd/render/mayaToHydra/cpp/testRenderItemTopologyUtil.cpp
+++ b/test/lib/mayaUsd/render/mayaToHydra/cpp/testRenderItemTopologyUtil.cpp
@@ -132,14 +132,18 @@ TEST(RenderItemTopologyUtil, ShouldEmitWhenSameCountButConnectivityChanges)
         counts));
 }
 
-TEST(RenderItemTopologyUtil, ShouldEmitWhenGeomOnlyAndConnectivityChanges)
+// Accepted limitation, not a deformation case: the inputs describe a real connectivity change that
+// Maya reported without MVS_changedTopo. UpdateFromDelta no longer reads the index buffer on the
+// geometry-only path (that read-back was the HYDRA-2417 playback regression), so this change is
+// deliberately not detected. Genuine connectivity edits do set MVS_changedTopo.
+TEST(RenderItemTopologyUtil, ShouldSuppressGeomOnlyConnectivityChange)
 {
     const VtIntArray counts { 3, 3 };
     const VtIntArray storedIndices { 0, 1, 2, 2, 1, 3 };
     const VtIntArray newIndices { 0, 1, 2, 0, 2, 3 };
     const HdMeshTopology stored = MakeTriangleMeshTopology(counts, storedIndices);
 
-    EXPECT_TRUE(RenderItemShouldEmitTopologyLocators(
+    EXPECT_FALSE(RenderItemShouldEmitTopologyLocators(
         false,
         true,
         true,


### PR DESCRIPTION
Simplify RenderItemShouldEmitTopologyLocators by removing the redundant !topoChanged && !geomChanged guard and collapsing the topo-only branch into a clearer !topoChanged / !geomChanged early-return sequence. Replace the unreachable return topoChanged with an explicit return true once topoChanged is known, and clarify comments for the geometry-only (HYDRA-2417) and MAYA-134200 disambiguation paths.